### PR TITLE
feat: update contract types with `#[contracttype]`, migrate to `sorob…

### DIFF
--- a/packages/contracts/Cargo.toml
+++ b/packages/contracts/Cargo.toml
@@ -1,11 +1,13 @@
 [workspace]
 resolver = "2"
 members = [
-  "contracts/*",
+  "call_registry",
+  "outcome_manager",
+  "contracts/hello-world",
 ]
 
 [workspace.dependencies]
-soroban-sdk = "23"
+soroban-sdk = "23.0.0"
 
 [profile.release]
 opt-level = "z"
@@ -17,12 +19,6 @@ panic = "abort"
 codegen-units = 1
 lto = true
 
-# For more information about this profile see https://soroban.stellar.org/docs/basic-tutorials/logging#cargotoml-profile
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
-    "call_registry",
-    "outcome_manager",
-    "shared",
-
-

--- a/packages/contracts/call_registry/Cargo.toml
+++ b/packages/contracts/call_registry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "call-registry"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, Symbol, Vec as SorobanVec};
-use soroban_token_sdk::TokenClient;
+use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, Vec, token};
 
 mod events;
 mod storage;
@@ -185,7 +184,7 @@ impl CallRegistry {
         };
 
         // Transfer tokens from staker to contract
-        let token_client = TokenClient::new(&env, &call.stake_token);
+        let token_client = token::Client::new(&env, &call.stake_token);
         token_client.transfer(&staker, &env.current_contract_address(), &amount);
 
         // Update stakes
@@ -234,8 +233,8 @@ impl CallRegistry {
     ///
     /// # Returns
     /// Vector of calls created by the address
-    pub fn get_calls_by_creator(env: Env, creator: Address) -> SorobanVec<Call> {
-        let mut calls = SorobanVec::new(&env);
+    pub fn get_calls_by_creator(env: Env, creator: Address) -> Vec<Call> {
+        let mut calls = Vec::new(&env);
         let total_calls = get_call_counter(&env);
 
         for i in 1..=total_calls {
@@ -278,9 +277,9 @@ impl CallRegistry {
     ///
     /// # Returns
     /// Vector of Call structs
-    pub fn get_staker_calls(env: Env, staker: Address) -> SorobanVec<Call> {
+    pub fn get_staker_calls(env: Env, staker: Address) -> Vec<Call> {
         let call_ids = get_staker_calls(&env, &staker);
-        let mut calls = SorobanVec::new(&env);
+        let mut calls = Vec::new(&env);
 
         for call_id in call_ids.iter() {
             if let Some(call) = get_call(&env, call_id) {

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -1,6 +1,7 @@
-use soroban_sdk::{Address, Bytes, Map};
+use soroban_sdk::{contracttype, Address, Bytes, Map};
 
 /// Represents a prediction call with all its metadata
+#[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Call {
     /// Unique identifier for the call
@@ -40,6 +41,7 @@ pub struct Call {
 }
 
 /// Enum representing stake positions on a call
+#[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub enum StakePosition {
     Up = 1,
@@ -66,6 +68,7 @@ impl StakePosition {
 }
 
 /// Configuration for the contract
+#[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ContractConfig {
     /// Admin address with privileged operations
@@ -75,11 +78,12 @@ pub struct ContractConfig {
 }
 
 /// Statistics for a call
+#[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct CallStats {
     pub total_up_stake: i128,
     pub total_down_stake: i128,
-    pub total_stakes: u64,
-    pub up_stake_count: u64,
-    pub down_stake_count: u64,
+    pub total_stakes: u32,
+    pub up_stake_count: u32,
+    pub down_stake_count: u32,
 }

--- a/packages/contracts/contracts/hello-world/test_snapshots/test/test.1.json
+++ b/packages/contracts/contracts/hello-world/test_snapshots/test/test.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/packages/contracts/outcome_manager/Cargo.toml
+++ b/packages/contracts/outcome_manager/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "outcome-manager"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -126,13 +126,13 @@ impl OutcomeManager {
         let votes: u32 = env
             .storage()
             .temporary()
-            .get(&TempKey::VoteCount(outcome_hash.clone(), signed.call_id))
+            .get(&TempKey::VoteCount(outcome_hash.clone().into(), signed.call_id))
             .unwrap_or(0);
 
         let votes = votes + 1;
 
         env.storage().temporary().set(
-            &TempKey::VoteCount(outcome_hash.clone(), signed.call_id),
+            &TempKey::VoteCount(outcome_hash.clone().into(), signed.call_id),
             &votes,
         );
 

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -1,5 +1,6 @@
-use soroban_sdk::{Env, BytesN};
+use soroban_sdk::{contracttype, BytesN};
 
+#[contracttype]
 #[derive(Clone)]
 pub struct Outcome {
     pub call_id: u64,
@@ -8,6 +9,7 @@ pub struct Outcome {
     pub timestamp: u64,
 }
 
+#[contracttype]
 #[derive(Clone)]
 pub struct SignedOutcome {
     pub call_id: u64,
@@ -18,6 +20,7 @@ pub struct SignedOutcome {
     pub signature: BytesN<64>,
 }
 
+#[contracttype]
 #[derive(Clone)]
 pub enum InstanceKey {
     Admin,
@@ -26,6 +29,7 @@ pub enum InstanceKey {
     FinalOutcome(u64),
 }
 
+#[contracttype]
 #[derive(Clone)]
 pub enum TempKey {
     Submission(BytesN<32>, u64),      // (oracle_pubkey, call_id)

--- a/packages/contracts/outcome_manager/src/verification.rs
+++ b/packages/contracts/outcome_manager/src/verification.rs
@@ -31,5 +31,6 @@ pub fn verify_signature(
     signature: &BytesN<64>,
     message: &Bytes,
 ) -> bool {
-    env.crypto().ed25519_verify(public_key, message, signature)
+    env.crypto().ed25519_verify(public_key, message, signature);
+    true
 }

--- a/packages/contracts/test_output_4.txt
+++ b/packages/contracts/test_output_4.txt
@@ -1,0 +1,90 @@
+   Compiling call-registry v0.0.0 (/Users/mustang/Desktop/BACKit-onStellar/packages/contracts/call_registry)
+   Compiling outcome-manager v0.0.0 (/Users/mustang/Desktop/BACKit-onStellar/packages/contracts/outcome_manager)
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+   --> outcome_manager/src/lib.rs:161:22
+    |
+161 |         env.events().publish(
+    |                      ^^^^^^^
+    |
+    = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+  --> call_registry/src/events.rs:15:18
+   |
+15 |     env.events().publish(
+   |                  ^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+  --> call_registry/src/events.rs:29:18
+   |
+29 |     env.events().publish(
+   |                  ^^^^^^^
+
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+  --> call_registry/src/events.rs:42:18
+   |
+42 |     env.events().publish(
+   |                  ^^^^^^^
+
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+  --> call_registry/src/events.rs:54:18
+   |
+54 |     env.events().publish(
+   |                  ^^^^^^^
+
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+  --> call_registry/src/events.rs:66:18
+   |
+66 |     env.events().publish(
+   |                  ^^^^^^^
+
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+  --> call_registry/src/events.rs:78:18
+   |
+78 |     env.events().publish(
+   |                  ^^^^^^^
+
+warning: use of deprecated method `soroban_sdk::events::Events::publish`: use the #[contractevent] macro on a contract event type
+  --> call_registry/src/lib.rs:46:22
+   |
+46 |         env.events().publish(
+   |                      ^^^^^^^
+
+warning: function `emit_call_settled` is never used
+  --> call_registry/src/events.rs:49:8
+   |
+49 | pub fn emit_call_settled(
+   |        ^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+
+warning: function `call_exists` is never used
+  --> call_registry/src/storage.rs:47:8
+   |
+47 | pub fn call_exists(env: &Env, call_id: u64) -> bool {
+   |        ^^^^^^^^^^^
+
+warning: `outcome-manager` (lib test) generated 1 warning
+warning: `call-registry` (lib test) generated 9 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.53s
+     Running unittests src/lib.rs (target/debug/deps/call_registry-52385d7ce0673d26)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/lib.rs (target/debug/deps/hello_world-78c3a71d998127ac)
+
+running 1 test
+test test::test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running unittests src/lib.rs (target/debug/deps/outcome_manager-a3cb85abdf376d77)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+


### PR DESCRIPTION
…an_sdk::token`, and temporarily bypass ED25519 verification.