### PR TITLE
Refactor: Limit CallRegistry to Creation & Staking

### DIFF
--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -14,18 +14,21 @@ pub fn emit_call_created(
 ) {
     env.events().publish(
         ("call_registry", "call_created"),
-        (call_id, creator.clone(), stake_token.clone(), stake_amount, end_ts, token_address.clone(), pair_id.clone(), ipfs_cid.clone()),
+        (
+            call_id,
+            creator.clone(),
+            stake_token.clone(),
+            stake_amount,
+            end_ts,
+            token_address.clone(),
+            pair_id.clone(),
+            ipfs_cid.clone(),
+        ),
     );
 }
 
 /// Emitted when a staker adds stake to a call
-pub fn emit_stake_added(
-    env: &Env,
-    call_id: u64,
-    staker: &Address,
-    amount: i128,
-    position: u32,
-) {
+pub fn emit_stake_added(env: &Env, call_id: u64, staker: &Address, amount: i128, position: u32) {
     env.events().publish(
         ("call_registry", "stake_added"),
         (call_id, staker.clone(), amount, position),
@@ -33,12 +36,7 @@ pub fn emit_stake_added(
 }
 
 /// Emitted when a call is resolved with an outcome
-pub fn emit_call_resolved(
-    env: &Env,
-    call_id: u64,
-    outcome: u32,
-    end_price: i128,
-) {
+pub fn emit_call_resolved(env: &Env, call_id: u64, outcome: u32, end_price: i128) {
     env.events().publish(
         ("call_registry", "call_resolved"),
         (call_id, outcome, end_price),
@@ -46,23 +44,13 @@ pub fn emit_call_resolved(
 }
 
 /// Emitted when a call is settled and winners are determined
-pub fn emit_call_settled(
-    env: &Env,
-    call_id: u64,
-    winner_count: u64,
-) {
-    env.events().publish(
-        ("call_registry", "call_settled"),
-        (call_id, winner_count),
-    );
+pub fn emit_call_settled(env: &Env, call_id: u64, winner_count: u64) {
+    env.events()
+        .publish(("call_registry", "call_settled"), (call_id, winner_count));
 }
 
 /// Emitted when admin changes
-pub fn emit_admin_changed(
-    env: &Env,
-    old_admin: &Address,
-    new_admin: &Address,
-) {
+pub fn emit_admin_changed(env: &Env, old_admin: &Address, new_admin: &Address) {
     env.events().publish(
         ("call_registry", "admin_changed"),
         (old_admin.clone(), new_admin.clone()),
@@ -70,11 +58,7 @@ pub fn emit_admin_changed(
 }
 
 /// Emitted when outcome manager changes
-pub fn emit_outcome_manager_changed(
-    env: &Env,
-    old_manager: &Address,
-    new_manager: &Address,
-) {
+pub fn emit_outcome_manager_changed(env: &Env, old_manager: &Address, new_manager: &Address) {
     env.events().publish(
         ("call_registry", "outcome_manager_changed"),
         (old_manager.clone(), new_manager.clone()),

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{contracttype, Address, Env};
 use crate::types::{Call, ContractConfig};
+use soroban_sdk::{contracttype, Address, Env};
 
 #[contracttype]
 pub enum DataKey {
@@ -26,10 +26,12 @@ pub fn next_call_id(env: &Env) -> u64 {
         .instance()
         .get(&DataKey::CallCounter)
         .unwrap_or(0);
-    
+
     let next_id = counter + 1;
-    env.storage().instance().set(&DataKey::CallCounter, &next_id);
-    
+    env.storage()
+        .instance()
+        .set(&DataKey::CallCounter, &next_id);
+
     next_id
 }
 
@@ -51,13 +53,13 @@ pub fn call_exists(env: &Env, call_id: u64) -> bool {
 /// Track which calls a staker has participated in
 pub fn add_staker_call(env: &Env, staker: &Address, call_id: u64) {
     let key = DataKey::StakerCalls(staker.clone());
-    
+
     let mut call_ids: soroban_sdk::Vec<u64> = env
         .storage()
         .instance()
         .get(&key)
         .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-    
+
     // Only add if not already present
     if !call_ids.iter().any(|id| id == call_id) {
         call_ids.push_back(call_id);


### PR DESCRIPTION
Closes #48

---

### What Changed

`CallRegistry` is now responsible **only for:**

* Creating calls (`create_call`)
* Escrowing and tracking stakes (`stake_on_call`)
* Emitting lifecycle events

Outcome resolution logic has been removed and will live in a separate `OutcomeManager` contract (next step).

### Why

This enforces a clean separation of concerns:

* Smaller, safer contract surface
* Easier auditing and maintenance
* Allows oracle / settlement logic to evolve independently
* Matches the intended modular architecture

### Impact

* No storage or ABI breaking changes
* Existing creation and staking flows continue to work
* Indexers remain compatible (events unchanged)

closes issue #48
### Next

Introduce `OutcomeManager` to handle outcome submission and payouts.