### PR TITLE
feat: implement leaderboard feature with prediction calls and snapshots

### DIFF
--- a/packages/backend/src/leaderboard/1700000000000-CreateLeaderboardTables.ts
+++ b/packages/backend/src/leaderboard/1700000000000-CreateLeaderboardTables.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, Table, Index } from 'typeorm';
+
+export class CreateLeaderboardTables1700000000000 implements MigrationInterface {
+  name = 'CreateLeaderboardTables1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'prediction_calls',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true, generationStrategy: 'uuid', default: 'uuid_generate_v4()' },
+          { name: 'userId', type: 'uuid', isNullable: false },
+          { name: 'status', type: 'enum', enum: ['pending', 'settled', 'cancelled'], default: "'pending'" },
+          { name: 'outcome', type: 'enum', enum: ['won', 'lost'], isNullable: true },
+          { name: 'profitUsdc', type: 'decimal', precision: 18, scale: 6, default: 0 },
+          { name: 'stakeUsdc', type: 'decimal', precision: 18, scale: 6, default: 0 },
+          { name: 'settledAt', type: 'timestamp', isNullable: true },
+          { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+          { name: 'updatedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'leaderboard_snapshots',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true, generationStrategy: 'uuid', default: 'uuid_generate_v4()' },
+          { name: 'userId', type: 'uuid', isNullable: false },
+          { name: 'username', type: 'varchar', isNullable: false },
+          { name: 'avatarUrl', type: 'varchar', isNullable: true },
+          { name: 'totalCalls', type: 'int', default: 0 },
+          { name: 'wonCalls', type: 'int', default: 0 },
+          { name: 'lostCalls', type: 'int', default: 0 },
+          { name: 'winRate', type: 'decimal', precision: 10, scale: 4, default: 0 },
+          { name: 'totalProfit', type: 'decimal', precision: 18, scale: 6, default: 0 },
+          { name: 'rank', type: 'int', default: 0 },
+          { name: 'period', type: 'varchar', default: "'all'" },
+          { name: 'snapshotDate', type: 'date', isNullable: false },
+          { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+      true,
+    );
+
+    // Composite indexes for efficient leaderboard queries
+    await queryRunner.createIndex('prediction_calls', new Index({ columnNames: ['userId', 'status'], name: 'IDX_calls_userId_status' }));
+    await queryRunner.createIndex('prediction_calls', new Index({ columnNames: ['status', 'settledAt'], name: 'IDX_calls_status_settledAt' }));
+    await queryRunner.createIndex('prediction_calls', new Index({ columnNames: ['status', 'outcome'], name: 'IDX_calls_status_outcome' }));
+    await queryRunner.createIndex('prediction_calls', new Index({ columnNames: ['userId'], name: 'IDX_calls_userId' }));
+    await queryRunner.createIndex('leaderboard_snapshots', new Index({ columnNames: ['period', 'snapshotDate'], name: 'IDX_snapshot_period_date' }));
+    await queryRunner.createIndex('leaderboard_snapshots', new Index({ columnNames: ['userId'], name: 'IDX_snapshot_userId' }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('leaderboard_snapshots', true);
+    await queryRunner.dropTable('prediction_calls', true);
+  }
+}

--- a/packages/backend/src/leaderboard/leaderboard.controller.spec.ts
+++ b/packages/backend/src/leaderboard/leaderboard.controller.spec.ts
@@ -1,0 +1,138 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeaderboardController } from './leaderboard.controller';
+import { LeaderboardService } from './leaderboard.service';
+import {
+  LeaderboardQueryDto,
+  LeaderboardResponseDto,
+  UserLeaderboardStatsDto,
+  LeaderboardSort,
+  LeaderboardTimeframe,
+} from './dto/leaderboard.dto';
+
+const mockLeaderboardResponse: LeaderboardResponseDto = {
+  data: [
+    {
+      rank: 1,
+      userId: 'user-1',
+      username: 'Alice',
+      avatarUrl: null,
+      totalCalls: 10,
+      wonCalls: 7,
+      lostCalls: 3,
+      winRate: 70,
+      totalProfit: 150.5,
+    },
+  ],
+  total: 1,
+  page: 1,
+  limit: 20,
+  pages: 1,
+  sort: LeaderboardSort.PROFIT,
+  timeframe: LeaderboardTimeframe.ALL,
+  generatedAt: new Date(),
+};
+
+const mockUserStats: UserLeaderboardStatsDto = {
+  userId: 'user-1',
+  rank: 1,
+  totalCalls: 10,
+  wonCalls: 7,
+  lostCalls: 3,
+  winRate: 70,
+  totalProfit: 150.5,
+  qualifiesForWinRate: true,
+};
+
+describe('LeaderboardController', () => {
+  let controller: LeaderboardController;
+  let service: jest.Mocked<LeaderboardService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LeaderboardController],
+      providers: [
+        {
+          provide: LeaderboardService,
+          useValue: {
+            getLeaderboard: jest.fn().mockResolvedValue(mockLeaderboardResponse),
+            getUserStats: jest.fn().mockResolvedValue(mockUserStats),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<LeaderboardController>(LeaderboardController);
+    service = module.get(LeaderboardService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('GET /leaderboard', () => {
+    it('delegates to service.getLeaderboard with query', async () => {
+      const query: LeaderboardQueryDto = {
+        sort: LeaderboardSort.PROFIT,
+        timeframe: LeaderboardTimeframe.ALL,
+        page: 1,
+        limit: 20,
+      };
+
+      const result = await controller.getLeaderboard(query);
+
+      expect(service.getLeaderboard).toHaveBeenCalledWith(query);
+      expect(result).toBe(mockLeaderboardResponse);
+    });
+
+    it('passes winrate sort query to service', async () => {
+      const query: LeaderboardQueryDto = {
+        sort: LeaderboardSort.WINRATE,
+        timeframe: LeaderboardTimeframe.MONTH,
+        page: 1,
+        limit: 10,
+      };
+
+      await controller.getLeaderboard(query);
+
+      expect(service.getLeaderboard).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: LeaderboardSort.WINRATE, timeframe: LeaderboardTimeframe.MONTH }),
+      );
+    });
+
+    it('returns empty response gracefully', async () => {
+      const empty: LeaderboardResponseDto = {
+        ...mockLeaderboardResponse,
+        data: [],
+        total: 0,
+        pages: 0,
+      };
+      service.getLeaderboard.mockResolvedValue(empty);
+
+      const result = await controller.getLeaderboard({
+        sort: LeaderboardSort.PROFIT,
+        timeframe: LeaderboardTimeframe.ALL,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.data).toHaveLength(0);
+    });
+  });
+
+  describe('GET /leaderboard/users/:userId', () => {
+    it('delegates to service.getUserStats with userId', async () => {
+      const userId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+      const result = await controller.getUserStats(userId);
+
+      expect(service.getUserStats).toHaveBeenCalledWith(userId);
+      expect(result).toBe(mockUserStats);
+    });
+
+    it('returns stats with qualifiesForWinRate flag', async () => {
+      service.getUserStats.mockResolvedValue({ ...mockUserStats, totalCalls: 3, qualifiesForWinRate: false });
+
+      const result = await controller.getUserStats('some-uuid');
+
+      expect(result.qualifiesForWinRate).toBe(false);
+    });
+  });
+});

--- a/packages/backend/src/leaderboard/leaderboard.controller.ts
+++ b/packages/backend/src/leaderboard/leaderboard.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  UseGuards,
+  ParseUUIDPipe,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { LeaderboardService } from './leaderboard.service';
+import {
+  LeaderboardQueryDto,
+  LeaderboardResponseDto,
+  UserLeaderboardStatsDto,
+} from './dto/leaderboard.dto';
+
+@ApiTags('Leaderboard')
+@Controller('leaderboard')
+export class LeaderboardController {
+  constructor(private readonly leaderboardService: LeaderboardService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get leaderboard',
+    description:
+      'Returns top traders sorted by profit or win rate. Win rate leaderboard requires minimum 5 settled calls.',
+  })
+  @ApiResponse({ status: HttpStatus.OK, type: LeaderboardResponseDto })
+  async getLeaderboard(
+    @Query() query: LeaderboardQueryDto,
+  ): Promise<LeaderboardResponseDto> {
+    return this.leaderboardService.getLeaderboard(query);
+  }
+
+  @Get('users/:userId')
+  @ApiOperation({
+    summary: "Get a specific user's leaderboard stats",
+    description: 'Returns win rate, total profit, rank, and call history for a user.',
+  })
+  @ApiResponse({ status: HttpStatus.OK, type: UserLeaderboardStatsDto })
+  async getUserStats(
+    @Param('userId', ParseUUIDPipe) userId: string,
+  ): Promise<UserLeaderboardStatsDto> {
+    return this.leaderboardService.getUserStats(userId);
+  }
+}

--- a/packages/backend/src/leaderboard/leaderboard.dto.ts
+++ b/packages/backend/src/leaderboard/leaderboard.dto.ts
@@ -1,0 +1,121 @@
+import { IsEnum, IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
+
+export enum LeaderboardSort {
+  PROFIT = 'profit',
+  WINRATE = 'winrate',
+}
+
+export enum LeaderboardTimeframe {
+  ALL = 'all',
+  MONTH = 'month',
+}
+
+export class LeaderboardQueryDto {
+  @ApiPropertyOptional({ enum: LeaderboardSort, default: LeaderboardSort.PROFIT })
+  @IsEnum(LeaderboardSort)
+  @IsOptional()
+  sort: LeaderboardSort = LeaderboardSort.PROFIT;
+
+  @ApiPropertyOptional({ enum: LeaderboardTimeframe, default: LeaderboardTimeframe.ALL })
+  @IsEnum(LeaderboardTimeframe)
+  @IsOptional()
+  timeframe: LeaderboardTimeframe = LeaderboardTimeframe.ALL;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  limit: number = 20;
+}
+
+export class LeaderboardEntryDto {
+  @ApiProperty()
+  rank: number;
+
+  @ApiProperty()
+  userId: string;
+
+  @ApiProperty()
+  username: string;
+
+  @ApiProperty({ nullable: true })
+  avatarUrl: string | null;
+
+  @ApiProperty()
+  totalCalls: number;
+
+  @ApiProperty()
+  wonCalls: number;
+
+  @ApiProperty()
+  lostCalls: number;
+
+  @ApiProperty({ description: 'Win rate as percentage (0-100)' })
+  winRate: number;
+
+  @ApiProperty({ description: 'Net USDC profit' })
+  totalProfit: number;
+}
+
+export class LeaderboardResponseDto {
+  @ApiProperty({ type: [LeaderboardEntryDto] })
+  data: LeaderboardEntryDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty()
+  pages: number;
+
+  @ApiProperty()
+  sort: LeaderboardSort;
+
+  @ApiProperty()
+  timeframe: LeaderboardTimeframe;
+
+  @ApiProperty()
+  generatedAt: Date;
+}
+
+export class UserLeaderboardStatsDto {
+  @ApiProperty()
+  userId: string;
+
+  @ApiProperty({ nullable: true })
+  rank: number | null;
+
+  @ApiProperty()
+  totalCalls: number;
+
+  @ApiProperty()
+  wonCalls: number;
+
+  @ApiProperty()
+  lostCalls: number;
+
+  @ApiProperty()
+  winRate: number;
+
+  @ApiProperty()
+  totalProfit: number;
+
+  @ApiProperty({ description: 'Whether user qualifies for win rate leaderboard (min 5 settled calls)' })
+  qualifiesForWinRate: boolean;
+}

--- a/packages/backend/src/leaderboard/leaderboard.e2e.spec.ts
+++ b/packages/backend/src/leaderboard/leaderboard.e2e.spec.ts
@@ -1,0 +1,267 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { LeaderboardModule } from './leaderboard.module';
+import {
+  PredictionCall,
+  LeaderboardSnapshot,
+  CallStatus,
+  CallOutcome,
+} from './entities/leaderboard.entity';
+
+// ── seed helpers ──────────────────────────────────────────────────────────────
+
+async function seedCalls(
+  ds: DataSource,
+  userId: string,
+  calls: Array<{ outcome: CallOutcome; profit: number; settledAt?: Date }>,
+) {
+  const repo = ds.getRepository(PredictionCall);
+  const entities = calls.map((c) =>
+    repo.create({
+      userId,
+      status: CallStatus.SETTLED,
+      outcome: c.outcome,
+      profitUsdc: c.profit,
+      stakeUsdc: 10,
+      settledAt: c.settledAt ?? new Date(),
+    }),
+  );
+  return repo.save(entities);
+}
+
+// ── suite ─────────────────────────────────────────────────────────────────────
+
+describe('Leaderboard (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+  const USER_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const USER_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+  const USER_C = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [PredictionCall, LeaderboardSnapshot],
+          synchronize: true,
+          logging: false,
+        }),
+        LeaderboardModule,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
+    await app.init();
+
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.getRepository(PredictionCall).clear();
+  });
+
+  // ── GET /leaderboard ────────────────────────────────────────────────────────
+
+  describe('GET /leaderboard', () => {
+    it('returns 200 with empty data when no settled calls', async () => {
+      const { body } = await request(app.getHttpServer())
+        .get('/leaderboard')
+        .expect(200);
+
+      expect(body.data).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    it('returns sorted leaderboard by profit (default)', async () => {
+      await seedCalls(dataSource, USER_A, [
+        { outcome: CallOutcome.WON, profit: 100 },
+        { outcome: CallOutcome.WON, profit: 50 },
+        { outcome: CallOutcome.LOST, profit: -20 },
+      ]);
+      await seedCalls(dataSource, USER_B, [
+        { outcome: CallOutcome.WON, profit: 300 },
+        { outcome: CallOutcome.LOST, profit: -10 },
+      ]);
+
+      const { body } = await request(app.getHttpServer())
+        .get('/leaderboard?sort=profit')
+        .expect(200);
+
+      expect(body.data[0].totalProfit).toBeGreaterThan(body.data[1].totalProfit);
+      expect(body.data[0].rank).toBe(1);
+    });
+
+    it('winrate leaderboard excludes users with < 5 settled calls', async () => {
+      // USER_A has 4 calls (should be excluded)
+      await seedCalls(dataSource, USER_A, [
+        { outcome: CallOutcome.WON, profit: 10 },
+        { outcome: CallOutcome.WON, profit: 10 },
+        { outcome: CallOutcome.WON, profit: 10 },
+        { outcome: CallOutcome.WON, profit: 10 },
+      ]);
+
+      // USER_B has 5 calls (should be included)
+      await seedCalls(dataSource, USER_B, [
+        { outcome: CallOutcome.WON, profit: 5 },
+        { outcome: CallOutcome.WON, profit: 5 },
+        { outcome: CallOutcome.WON, profit: 5 },
+        { outcome: CallOutcome.LOST, profit: -5 },
+        { outcome: CallOutcome.LOST, profit: -5 },
+      ]);
+
+      const { body } = await request(app.getHttpServer())
+        .get('/leaderboard?sort=winrate')
+        .expect(200);
+
+      const userIds = body.data.map((d: any) => d.userId);
+      expect(userIds).not.toContain(USER_A);
+      expect(userIds).toContain(USER_B);
+    });
+
+    it('timeframe=month filters out old calls', async () => {
+      const oldDate = new Date();
+      oldDate.setMonth(oldDate.getMonth() - 2);
+
+      // Old call — should be excluded
+      await seedCalls(dataSource, USER_A, [
+        { outcome: CallOutcome.WON, profit: 999, settledAt: oldDate },
+      ]);
+      // Recent call
+      await seedCalls(dataSource, USER_B, [
+        { outcome: CallOutcome.WON, profit: 10 },
+      ]);
+
+      const { body } = await request(app.getHttpServer())
+        .get('/leaderboard?sort=profit&timeframe=month')
+        .expect(200);
+
+      const userIds = body.data.map((d: any) => d.userId);
+      expect(userIds).not.toContain(USER_A);
+    });
+
+    it('returns 400 for invalid sort value', async () => {
+      await request(app.getHttpServer())
+        .get('/leaderboard?sort=invalid')
+        .expect(400);
+    });
+
+    it('returns 400 for invalid timeframe value', async () => {
+      await request(app.getHttpServer())
+        .get('/leaderboard?timeframe=week')
+        .expect(400);
+    });
+
+    it('paginates results correctly', async () => {
+      // Seed 3 users
+      for (let i = 0; i < 3; i++) {
+        const uid = `${i}${USER_A.slice(1)}`;
+        await seedCalls(dataSource, uid, [
+          { outcome: CallOutcome.WON, profit: (i + 1) * 10 },
+          { outcome: CallOutcome.LOST, profit: -1 },
+        ]);
+      }
+
+      const { body } = await request(app.getHttpServer())
+        .get('/leaderboard?page=1&limit=2')
+        .expect(200);
+
+      expect(body.data).toHaveLength(2);
+      expect(body.pages).toBe(2);
+    });
+
+    it('response includes meta fields', async () => {
+      const { body } = await request(app.getHttpServer())
+        .get('/leaderboard')
+        .expect(200);
+
+      expect(body).toMatchObject({
+        data: expect.any(Array),
+        total: expect.any(Number),
+        page: expect.any(Number),
+        limit: expect.any(Number),
+        pages: expect.any(Number),
+        sort: expect.any(String),
+        timeframe: expect.any(String),
+        generatedAt: expect.any(String),
+      });
+    });
+  });
+
+  // ── GET /leaderboard/users/:userId ──────────────────────────────────────────
+
+  describe('GET /leaderboard/users/:userId', () => {
+    it('returns 400 for non-UUID userId', async () => {
+      await request(app.getHttpServer())
+        .get('/leaderboard/users/not-a-uuid')
+        .expect(400);
+    });
+
+    it('returns stats with zeros for user with no calls', async () => {
+      const { body } = await request(app.getHttpServer())
+        .get(`/leaderboard/users/${USER_A}`)
+        .expect(200);
+
+      expect(body).toMatchObject({
+        userId: USER_A,
+        rank: null,
+        totalCalls: 0,
+        wonCalls: 0,
+        lostCalls: 0,
+        winRate: 0,
+        totalProfit: 0,
+        qualifiesForWinRate: false,
+      });
+    });
+
+    it('returns correct win rate and profit for user with settled calls', async () => {
+      await seedCalls(dataSource, USER_A, [
+        { outcome: CallOutcome.WON, profit: 100 },
+        { outcome: CallOutcome.WON, profit: 50 },
+        { outcome: CallOutcome.LOST, profit: -30 },
+        { outcome: CallOutcome.WON, profit: 20 },
+        { outcome: CallOutcome.LOST, profit: -10 },
+      ]);
+
+      const { body } = await request(app.getHttpServer())
+        .get(`/leaderboard/users/${USER_A}`)
+        .expect(200);
+
+      expect(body.totalCalls).toBe(5);
+      expect(body.wonCalls).toBe(3);
+      expect(body.lostCalls).toBe(2);
+      expect(body.winRate).toBeCloseTo(60, 0);
+      expect(body.totalProfit).toBeCloseTo(130, 0);
+      expect(body.qualifiesForWinRate).toBe(true);
+    });
+
+    it('does not count pending calls toward stats', async () => {
+      const repo = dataSource.getRepository(PredictionCall);
+      await repo.save(
+        repo.create({
+          userId: USER_A,
+          status: CallStatus.PENDING,
+          outcome: null,
+          profitUsdc: 0,
+          stakeUsdc: 10,
+        }),
+      );
+
+      const { body } = await request(app.getHttpServer())
+        .get(`/leaderboard/users/${USER_A}`)
+        .expect(200);
+
+      expect(body.totalCalls).toBe(0);
+    });
+  });
+});

--- a/packages/backend/src/leaderboard/leaderboard.entity.ts
+++ b/packages/backend/src/leaderboard/leaderboard.entity.ts
@@ -1,0 +1,100 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+export enum CallStatus {
+  PENDING = 'pending',
+  SETTLED = 'settled',
+  CANCELLED = 'cancelled',
+}
+
+export enum CallOutcome {
+  WON = 'won',
+  LOST = 'lost',
+}
+
+@Entity('prediction_calls')
+@Index(['userId', 'status'])
+@Index(['settledAt'])
+@Index(['status', 'outcome'])
+export class PredictionCall {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  @Index()
+  userId: string;
+
+  @Column({ type: 'enum', enum: CallStatus, default: CallStatus.PENDING })
+  status: CallStatus;
+
+  @Column({ type: 'enum', enum: CallOutcome, nullable: true })
+  outcome: CallOutcome | null;
+
+  @Column({ type: 'decimal', precision: 18, scale: 6, default: 0 })
+  profitUsdc: number;
+
+  @Column({ type: 'decimal', precision: 18, scale: 6, default: 0 })
+  stakeUsdc: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  settledAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('leaderboard_snapshots')
+@Index(['period', 'snapshotDate'])
+export class LeaderboardSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  @Index()
+  userId: string;
+
+  @Column()
+  username: string;
+
+  @Column({ nullable: true })
+  avatarUrl: string;
+
+  @Column({ type: 'int', default: 0 })
+  totalCalls: number;
+
+  @Column({ type: 'int', default: 0 })
+  wonCalls: number;
+
+  @Column({ type: 'int', default: 0 })
+  lostCalls: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 4, default: 0 })
+  winRate: number;
+
+  @Column({ type: 'decimal', precision: 18, scale: 6, default: 0 })
+  totalProfit: number;
+
+  @Column({ type: 'int', default: 0 })
+  rank: number;
+
+  @Column({ default: 'all' })
+  period: string; // 'all' | 'month'
+
+  @Column({ type: 'date' })
+  @Index()
+  snapshotDate: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/leaderboard/leaderboard.module.ts
+++ b/packages/backend/src/leaderboard/leaderboard.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PredictionCall, LeaderboardSnapshot } from './entities/leaderboard.entity';
+import { LeaderboardService } from './leaderboard.service';
+import { LeaderboardController } from './leaderboard.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PredictionCall, LeaderboardSnapshot])],
+  controllers: [LeaderboardController],
+  providers: [LeaderboardService],
+  exports: [LeaderboardService],
+})
+export class LeaderboardModule {}

--- a/packages/backend/src/leaderboard/leaderboard.service.spec.ts
+++ b/packages/backend/src/leaderboard/leaderboard.service.spec.ts
@@ -1,0 +1,303 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, SelectQueryBuilder } from 'typeorm';
+import { LeaderboardService } from './leaderboard.service';
+import {
+  PredictionCall,
+  LeaderboardSnapshot,
+  CallStatus,
+  CallOutcome,
+} from './entities/leaderboard.entity';
+import {
+  LeaderboardQueryDto,
+  LeaderboardSort,
+  LeaderboardTimeframe,
+} from './dto/leaderboard.dto';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeRawRow(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    userId: 'user-1',
+    username: 'Alice',
+    avatarUrl: null,
+    totalCalls: '10',
+    wonCalls: '7',
+    lostCalls: '3',
+    winRate: '70.00',
+    totalProfit: '150.50',
+    ...overrides,
+  };
+}
+
+function buildQbMock(rawRows: any[], count = rawRows.length) {
+  const qb: Partial<SelectQueryBuilder<any>> = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    having: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(rawRows),
+    getRawOne: jest.fn().mockResolvedValue({ count: String(count), rank: '2', ...rawRows[0] }),
+  };
+  return qb as jest.Mocked<SelectQueryBuilder<any>>;
+}
+
+// ── test suite ────────────────────────────────────────────────────────────────
+
+describe('LeaderboardService', () => {
+  let service: LeaderboardService;
+  let dataSourceMock: jest.Mocked<DataSource>;
+  let qbMock: jest.Mocked<SelectQueryBuilder<any>>;
+
+  beforeEach(async () => {
+    qbMock = buildQbMock([makeRawRow()]) as any;
+
+    dataSourceMock = {
+      createQueryBuilder: jest.fn().mockReturnValue(qbMock),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeaderboardService,
+        {
+          provide: getRepositoryToken(PredictionCall),
+          useValue: { createQueryBuilder: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(LeaderboardSnapshot),
+          useValue: {},
+        },
+        { provide: DataSource, useValue: dataSourceMock },
+      ],
+    }).compile();
+
+    service = module.get<LeaderboardService>(LeaderboardService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── getLeaderboard ──────────────────────────────────────────────────────────
+
+  describe('getLeaderboard()', () => {
+    const baseQuery: LeaderboardQueryDto = {
+      sort: LeaderboardSort.PROFIT,
+      timeframe: LeaderboardTimeframe.ALL,
+      page: 1,
+      limit: 20,
+    };
+
+    it('returns formatted leaderboard data', async () => {
+      const result = await service.getLeaderboard(baseQuery);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        rank: 1,
+        userId: 'user-1',
+        totalCalls: 10,
+        wonCalls: 7,
+        lostCalls: 3,
+        winRate: 70,
+        totalProfit: 150.5,
+      });
+    });
+
+    it('sets correct pagination meta', async () => {
+      // Simulate 45 total users across pages
+      qbMock.getRawMany.mockResolvedValue(
+        Array.from({ length: 20 }, (_, i) => makeRawRow({ userId: `user-${i}` })),
+      );
+      qbMock.getRawOne.mockResolvedValue({ count: '45' });
+
+      const result = await service.getLeaderboard({ ...baseQuery, page: 2 });
+
+      expect(result.page).toBe(2);
+      expect(result.total).toBe(45);
+      expect(result.pages).toBe(3);
+    });
+
+    it('returns empty response when no data', async () => {
+      qbMock.getRawMany.mockResolvedValue([]);
+      qbMock.getRawOne.mockResolvedValue({ count: '0' });
+
+      const result = await service.getLeaderboard(baseQuery);
+
+      expect(result.data).toHaveLength(0);
+      expect(result.total).toBe(0);
+      expect(result.pages).toBe(0);
+    });
+
+    it('applies WINRATE sort with having clause (min 5 calls)', async () => {
+      await service.getLeaderboard({ ...baseQuery, sort: LeaderboardSort.WINRATE });
+
+      expect(qbMock.having).toHaveBeenCalledWith(expect.stringContaining('COUNT(*)'), {
+        minCalls: 5,
+      });
+      expect(qbMock.orderBy).toHaveBeenCalledWith('winRate', 'DESC');
+    });
+
+    it('applies PROFIT sort without having clause', async () => {
+      await service.getLeaderboard({ ...baseQuery, sort: LeaderboardSort.PROFIT });
+
+      expect(qbMock.having).not.toHaveBeenCalled();
+      expect(qbMock.orderBy).toHaveBeenCalledWith('totalProfit', 'DESC');
+    });
+
+    it('applies month date filter when timeframe=month', async () => {
+      await service.getLeaderboard({ ...baseQuery, timeframe: LeaderboardTimeframe.MONTH });
+
+      expect(qbMock.andWhere).toHaveBeenCalledWith('pc.settledAt >= :since', {
+        since: expect.any(Date),
+      });
+    });
+
+    it('does not apply date filter when timeframe=all', async () => {
+      await service.getLeaderboard({ ...baseQuery, timeframe: LeaderboardTimeframe.ALL });
+
+      const andWhereCalls = (qbMock.andWhere as jest.Mock).mock.calls;
+      const hasDateFilter = andWhereCalls.some(([q]) => q.includes('settledAt'));
+      expect(hasDateFilter).toBe(false);
+    });
+
+    it('always filters by SETTLED status', async () => {
+      await service.getLeaderboard(baseQuery);
+
+      expect(qbMock.where).toHaveBeenCalledWith('pc.status = :status', {
+        status: CallStatus.SETTLED,
+      });
+    });
+
+    it('ranks start at (page-1)*limit + 1 for page 2', async () => {
+      qbMock.getRawMany.mockResolvedValue([
+        makeRawRow({ userId: 'user-21' }),
+        makeRawRow({ userId: 'user-22' }),
+      ]);
+      qbMock.getRawOne.mockResolvedValue({ count: '50' });
+
+      const result = await service.getLeaderboard({ ...baseQuery, page: 2, limit: 20 });
+
+      expect(result.data[0].rank).toBe(21);
+      expect(result.data[1].rank).toBe(22);
+    });
+
+    it('attaches generatedAt timestamp', async () => {
+      const before = new Date();
+      const result = await service.getLeaderboard(baseQuery);
+      const after = new Date();
+
+      expect(result.generatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(result.generatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('handles null username gracefully', async () => {
+      qbMock.getRawMany.mockResolvedValue([makeRawRow({ username: null, userId: 'abc-12345678' })]);
+
+      const result = await service.getLeaderboard(baseQuery);
+
+      expect(result.data[0].username).toContain('User');
+    });
+  });
+
+  // ── getUserStats ────────────────────────────────────────────────────────────
+
+  describe('getUserStats()', () => {
+    const userId = 'test-user-uuid';
+
+    it('returns stats with correct numeric conversions', async () => {
+      qbMock.getRawOne
+        .mockResolvedValueOnce({
+          totalCalls: '10',
+          wonCalls: '7',
+          lostCalls: '3',
+          winRate: '70.00',
+          totalProfit: '150.50',
+        })
+        .mockResolvedValueOnce({ rank: '2' });
+
+      const result = await service.getUserStats(userId);
+
+      expect(result).toMatchObject({
+        userId,
+        rank: 3, // rank = result.rank + 1
+        totalCalls: 10,
+        wonCalls: 7,
+        lostCalls: 3,
+        winRate: 70,
+        totalProfit: 150.5,
+        qualifiesForWinRate: true,
+      });
+    });
+
+    it('returns null rank when user has no calls', async () => {
+      qbMock.getRawOne
+        .mockResolvedValueOnce({
+          totalCalls: '0',
+          wonCalls: '0',
+          lostCalls: '0',
+          winRate: '0',
+          totalProfit: '0',
+        })
+        .mockResolvedValueOnce({ rank: '0' });
+
+      const result = await service.getUserStats(userId);
+
+      expect(result.rank).toBeNull();
+      expect(result.totalCalls).toBe(0);
+    });
+
+    it('sets qualifiesForWinRate=false when < 5 calls', async () => {
+      qbMock.getRawOne
+        .mockResolvedValueOnce({
+          totalCalls: '4',
+          wonCalls: '4',
+          lostCalls: '0',
+          winRate: '100.00',
+          totalProfit: '50.00',
+        })
+        .mockResolvedValueOnce({ rank: '0' });
+
+      const result = await service.getUserStats(userId);
+
+      expect(result.qualifiesForWinRate).toBe(false);
+    });
+
+    it('sets qualifiesForWinRate=true when exactly 5 calls', async () => {
+      qbMock.getRawOne
+        .mockResolvedValueOnce({
+          totalCalls: '5',
+          wonCalls: '3',
+          lostCalls: '2',
+          winRate: '60.00',
+          totalProfit: '20.00',
+        })
+        .mockResolvedValueOnce({ rank: '5' });
+
+      const result = await service.getUserStats(userId);
+
+      expect(result.qualifiesForWinRate).toBe(true);
+    });
+
+    it('handles null / missing profit gracefully (COALESCE)', async () => {
+      qbMock.getRawOne
+        .mockResolvedValueOnce({
+          totalCalls: '3',
+          wonCalls: '2',
+          lostCalls: '1',
+          winRate: null,
+          totalProfit: null,
+        })
+        .mockResolvedValueOnce({ rank: '0' });
+
+      const result = await service.getUserStats(userId);
+
+      expect(result.winRate).toBe(0);
+      expect(result.totalProfit).toBe(0);
+    });
+  });
+});

--- a/packages/backend/src/leaderboard/leaderboard.service.ts
+++ b/packages/backend/src/leaderboard/leaderboard.service.ts
@@ -1,0 +1,228 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import {
+  PredictionCall,
+  CallStatus,
+  CallOutcome,
+  LeaderboardSnapshot,
+} from '../entities/leaderboard.entity';
+import {
+  LeaderboardQueryDto,
+  LeaderboardSort,
+  LeaderboardTimeframe,
+  LeaderboardEntryDto,
+  LeaderboardResponseDto,
+  UserLeaderboardStatsDto,
+} from '../dto/leaderboard.dto';
+
+const MIN_CALLS_FOR_WINRATE = 5;
+
+@Injectable()
+export class LeaderboardService {
+  private readonly logger = new Logger(LeaderboardService.name);
+
+  constructor(
+    @InjectRepository(PredictionCall)
+    private readonly callRepo: Repository<PredictionCall>,
+    @InjectRepository(LeaderboardSnapshot)
+    private readonly snapshotRepo: Repository<LeaderboardSnapshot>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async getLeaderboard(query: LeaderboardQueryDto): Promise<LeaderboardResponseDto> {
+    const { sort, timeframe, page, limit } = query;
+    const offset = (page - 1) * limit;
+
+    const dateFilter = this.getDateFilter(timeframe);
+
+    // Build raw SQL for performance with indexed columns
+    let qb = this.dataSource
+      .createQueryBuilder()
+      .select('pc.userId', 'userId')
+      .addSelect('COUNT(*)', 'totalCalls')
+      .addSelect(
+        `SUM(CASE WHEN pc.outcome = '${CallOutcome.WON}' THEN 1 ELSE 0 END)`,
+        'wonCalls',
+      )
+      .addSelect(
+        `SUM(CASE WHEN pc.outcome = '${CallOutcome.LOST}' THEN 1 ELSE 0 END)`,
+        'lostCalls',
+      )
+      .addSelect(
+        `ROUND(
+          (SUM(CASE WHEN pc.outcome = '${CallOutcome.WON}' THEN 1 ELSE 0 END) * 100.0) / NULLIF(COUNT(*), 0),
+          2
+        )`,
+        'winRate',
+      )
+      .addSelect('COALESCE(SUM(pc.profitUsdc), 0)', 'totalProfit')
+      .from(PredictionCall, 'pc')
+      .where('pc.status = :status', { status: CallStatus.SETTLED });
+
+    if (dateFilter) {
+      qb = qb.andWhere('pc.settledAt >= :since', { since: dateFilter });
+    }
+
+    qb = qb.groupBy('pc.userId');
+
+    // Apply minimum calls filter for win rate leaderboard
+    if (sort === LeaderboardSort.WINRATE) {
+      qb = qb.having('COUNT(*) >= :minCalls', { minCalls: MIN_CALLS_FOR_WINRATE });
+      qb = qb.orderBy('winRate', 'DESC').addOrderBy('totalProfit', 'DESC');
+    } else {
+      qb = qb.orderBy('totalProfit', 'DESC').addOrderBy('winRate', 'DESC');
+    }
+
+    const [rawData, total] = await Promise.all([
+      qb.offset(offset).limit(limit).getRawMany(),
+      this.getTotalCount(sort, timeframe),
+    ]);
+
+    if (rawData.length === 0) {
+      return this.emptyResponse(query, 0);
+    }
+
+    // Enrich with user info (in production, join with users table)
+    const data: LeaderboardEntryDto[] = rawData.map((row, index) => ({
+      rank: offset + index + 1,
+      userId: row.userId,
+      username: row.username ?? `User ${row.userId.slice(0, 8)}`,
+      avatarUrl: row.avatarUrl ?? null,
+      totalCalls: Number(row.totalCalls),
+      wonCalls: Number(row.wonCalls),
+      lostCalls: Number(row.lostCalls),
+      winRate: Number(row.winRate ?? 0),
+      totalProfit: Number(row.totalProfit ?? 0),
+    }));
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      pages: Math.ceil(total / limit),
+      sort,
+      timeframe,
+      generatedAt: new Date(),
+    };
+  }
+
+  async getUserStats(userId: string): Promise<UserLeaderboardStatsDto> {
+    const result = await this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)', 'totalCalls')
+      .addSelect(
+        `SUM(CASE WHEN pc.outcome = '${CallOutcome.WON}' THEN 1 ELSE 0 END)`,
+        'wonCalls',
+      )
+      .addSelect(
+        `SUM(CASE WHEN pc.outcome = '${CallOutcome.LOST}' THEN 1 ELSE 0 END)`,
+        'lostCalls',
+      )
+      .addSelect(
+        `ROUND(
+          (SUM(CASE WHEN pc.outcome = '${CallOutcome.WON}' THEN 1 ELSE 0 END) * 100.0) / NULLIF(COUNT(*), 0),
+          2
+        )`,
+        'winRate',
+      )
+      .addSelect('COALESCE(SUM(pc.profitUsdc), 0)', 'totalProfit')
+      .from(PredictionCall, 'pc')
+      .where('pc.userId = :userId', { userId })
+      .andWhere('pc.status = :status', { status: CallStatus.SETTLED })
+      .getRawOne();
+
+    const totalCalls = Number(result?.totalCalls ?? 0);
+    const wonCalls = Number(result?.wonCalls ?? 0);
+    const lostCalls = Number(result?.lostCalls ?? 0);
+    const winRate = Number(result?.winRate ?? 0);
+    const totalProfit = Number(result?.totalProfit ?? 0);
+
+    // Get profit rank
+    const profitRankResult = await this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)', 'rank')
+      .from((subQuery) => {
+        return subQuery
+          .select('userId')
+          .addSelect('SUM(profitUsdc)', 'totalProfit')
+          .from(PredictionCall, 'pc')
+          .where('pc.status = :status', { status: CallStatus.SETTLED })
+          .groupBy('pc.userId')
+          .having('SUM(pc.profitUsdc) > :userProfit', { userProfit: totalProfit });
+      }, 'ranked')
+      .getRawOne();
+
+    const rank = totalCalls > 0 ? Number(profitRankResult?.rank ?? 0) + 1 : null;
+
+    return {
+      userId,
+      rank,
+      totalCalls,
+      wonCalls,
+      lostCalls,
+      winRate,
+      totalProfit,
+      qualifiesForWinRate: totalCalls >= MIN_CALLS_FOR_WINRATE,
+    };
+  }
+
+  private async getTotalCount(
+    sort: LeaderboardSort,
+    timeframe: LeaderboardTimeframe,
+  ): Promise<number> {
+    const dateFilter = this.getDateFilter(timeframe);
+
+    let qb = this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(DISTINCT sub.userId)', 'count')
+      .from((subQuery) => {
+        let inner = subQuery
+          .select('pc.userId', 'userId')
+          .addSelect('COUNT(*)', 'totalCalls')
+          .from(PredictionCall, 'pc')
+          .where('pc.status = :status', { status: CallStatus.SETTLED });
+
+        if (dateFilter) {
+          inner = inner.andWhere('pc.settledAt >= :since', { since: dateFilter });
+        }
+
+        inner = inner.groupBy('pc.userId');
+
+        if (sort === LeaderboardSort.WINRATE) {
+          inner = inner.having('COUNT(*) >= :minCalls', { minCalls: MIN_CALLS_FOR_WINRATE });
+        }
+
+        return inner;
+      }, 'sub');
+
+    const result = await qb.getRawOne();
+    return Number(result?.count ?? 0);
+  }
+
+  private getDateFilter(timeframe: LeaderboardTimeframe): Date | null {
+    if (timeframe === LeaderboardTimeframe.MONTH) {
+      const since = new Date();
+      since.setMonth(since.getMonth() - 1);
+      return since;
+    }
+    return null;
+  }
+
+  private emptyResponse(
+    query: LeaderboardQueryDto,
+    total: number,
+  ): LeaderboardResponseDto {
+    return {
+      data: [],
+      total,
+      page: query.page,
+      limit: query.limit,
+      pages: 0,
+      sort: query.sort,
+      timeframe: query.timeframe,
+      generatedAt: new Date(),
+    };
+  }
+}


### PR DESCRIPTION
- Create migration for leaderboard tables: prediction_calls and leaderboard_snapshots
- Add LeaderboardController with endpoints for fetching leaderboard and user stats
- Implement LeaderboardService to handle business logic for leaderboard queries
- Create DTOs for leaderboard queries and responses
- Add entity definitions for prediction calls and leaderboard snapshots
- Implement unit and e2e tests for leaderboard functionality

Closes #46 