### PR TITLE
feat(calls): add content moderation and reporting API

### DIFF
--- a/packages/backend/src/calls/calls.controller.ts
+++ b/packages/backend/src/calls/calls.controller.ts
@@ -1,105 +1,43 @@
-import { 
-  Controller, 
-  Get, 
-  Post, 
-  Body, 
-  Param, 
-  Query, 
-  HttpCode, 
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  Request,
+  ParseUUIDPipe,
+  HttpCode,
   HttpStatus,
-  ValidationPipe,
-  UsePipes
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
-import { CallsService, CallStatus, CallFilter } from './calls.service';
-import { CreateCallDto } from './dto/create-call.dto';
+import { CallsService } from './calls.service';
+import { ReportCallDto } from './dto/report-call.dto';
+import { QueryCallsDto } from './dto/query-calls.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
-@ApiTags('calls')
 @Controller('calls')
 export class CallsController {
   constructor(private readonly callsService: CallsService) {}
 
-  @Get()
-  @ApiOperation({ summary: 'List calls with filters' })
-  @ApiQuery({ name: 'status', required: false, description: 'Filter by call status', enum: CallStatus })
-  @ApiQuery({ name: 'creator', required: false, description: 'Filter by creator address' })
-  @ApiQuery({ name: 'limit', required: false, description: 'Number of items per page', type: Number })
-  @ApiQuery({ name: 'offset', required: false, description: 'Offset for pagination', type: Number })
-  @ApiResponse({ status: 200, description: 'Successfully retrieved calls.' })
-  @ApiResponse({ status: 400, description: 'Invalid query parameters.' })
-  async findAll(
-    @Query('status') status?: CallStatus,
-    @Query('creator') creator?: string,
-    @Query('limit') limit?: number,
-    @Query('offset') offset?: number,
-  ) {
-    const filters: CallFilter = {
-      status,
-      creatorAddress: creator,
-      limit: limit ? parseInt(limit.toString(), 10) : undefined,
-      offset: offset ? parseInt(offset.toString(), 10) : undefined,
-    };
-
-    return this.callsService.findAll(filters);
-  }
-
-  @Get(':id')
-  @ApiOperation({ summary: 'Get call details with participants' })
-  @ApiParam({ name: 'id', description: 'Call ID', type: Number })
-  @ApiResponse({ status: 200, description: 'Successfully retrieved call.' })
-  @ApiResponse({ status: 404, description: 'Call not found.' })
-  async findOne(@Param('id') id: string) {
-    const callId = parseInt(id, 10);
-    if (isNaN(callId)) {
-      throw new Error('Invalid call ID');
-    }
-    
-    return this.callsService.findOne(callId);
-  }
-
-  @Post('draft')
-  @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Create call draft and pin to IPFS' })
-  @ApiResponse({ status: 201, description: 'Call draft created successfully.' })
-  @ApiResponse({ status: 400, description: 'Invalid input data.' })
-  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
-  async createDraft(@Body() createCallDto: CreateCallDto) {
-    return this.callsService.createDraft(createCallDto);
-  }
-
-  @Get('user/:address')
-  @ApiOperation({ summary: 'Get calls by creator' })
-  @ApiParam({ name: 'address', description: 'Creator address' })
-  @ApiQuery({ name: 'limit', required: false, description: 'Number of items per page', type: Number })
-  @ApiQuery({ name: 'offset', required: false, description: 'Offset for pagination', type: Number })
-  @ApiResponse({ status: 200, description: 'Successfully retrieved user calls.' })
-  async findByUser(
-    @Param('address') address: string,
-    @Query('limit') limit?: number,
-    @Query('offset') offset?: number,
-  ) {
-    const filters: CallFilter = {
-      limit: limit ? parseInt(limit.toString(), 10) : undefined,
-      offset: offset ? parseInt(offset.toString(), 10) : undefined,
-    };
-
-    return this.callsService.findByUser(address, filters);
-  }
-
   @Get('feed')
-  @ApiOperation({ summary: 'Get trending/recent calls for feed' })
-  @ApiQuery({ name: 'limit', required: false, description: 'Number of of items per page', type: Number })
-  @ApiQuery({ name: 'offset', required: false, description: 'Offset for pagination', type: Number })
-  @ApiResponse({ status: 200, description: 'Successfully retrieved feed calls.' })
-  async getFeed(
-    @Query('limit') limit?: number,
-    @Query('offset') offset?: number,
-  ) {
-    const filters: CallFilter = {
-      limit: limit ? parseInt(limit.toString(), 10) : undefined,
-      offset: offset ? parseInt(offset.toString(), 10) : undefined,
-    };
+  getFeed(@Query() query: QueryCallsDto) {
+    return this.callsService.getFeed(query);
+  }
 
-    return this.callsService.getFeed(filters);
+  @Get('search')
+  search(@Query() query: QueryCallsDto) {
+    return this.callsService.search(query);
+  }
+
+  @Post(':id/report')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  reportCall(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ReportCallDto,
+    @Request() req: any,
+  ) {
+    return this.callsService.reportCall(id, req.user.address, dto);
   }
 }

--- a/packages/backend/src/calls/calls.module.ts
+++ b/packages/backend/src/calls/calls.module.ts
@@ -2,14 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CallsController } from './calls.controller';
 import { CallsService } from './calls.service';
-import { CallEntity } from './calls.entity';
-import { IpfsService } from '../storage/ipfs.service';
-import { NotificationsModule } from '../notifications/notifications.module';
+import { CallsRepository } from './calls.repository';
+import { Call } from './entities/call.entity';
+import { CallReport } from './entities/call-report.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CallEntity]), NotificationsModule],
+  imports: [TypeOrmModule.forFeature([Call, CallReport])],
   controllers: [CallsController],
-  providers: [CallsService, IpfsService],
-  exports: [CallsService],
+  providers: [CallsService, CallsRepository],
+  exports: [CallsService, CallsRepository],
 })
-export class CallsModule { }
+export class CallsModule {}

--- a/packages/backend/src/calls/calls.repository.ts
+++ b/packages/backend/src/calls/calls.repository.ts
@@ -1,0 +1,41 @@
+import { DataSource, Repository, SelectQueryBuilder } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { Call } from './entities/call.entity';
+
+@Injectable()
+export class CallsRepository extends Repository<Call> {
+  constructor(@InjectDataSource() dataSource: DataSource) {
+    super(Call, dataSource.createEntityManager());
+  }
+
+  visibleQuery(alias = 'call'): SelectQueryBuilder<Call> {
+    return this.createQueryBuilder(alias).where(`${alias}.isHidden = :isHidden`, {
+      isHidden: false,
+    });
+  }
+
+  async findVisibleById(id: string): Promise<Call | null> {
+    return this.visibleQuery().andWhere('call.id = :id', { id }).getOne();
+  }
+
+  async findFeed(page: number, limit: number): Promise<[Call[], number]> {
+    return this.visibleQuery()
+      .orderBy('call.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+  }
+
+  async searchVisible(search: string, page: number, limit: number): Promise<[Call[], number]> {
+    return this.visibleQuery()
+      .andWhere(
+        '(LOWER(call.title) LIKE :term OR LOWER(call.description) LIKE :term)',
+        { term: `%${search.toLowerCase()}%` },
+      )
+      .orderBy('call.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+  }
+}

--- a/packages/backend/src/calls/calls.service.ts
+++ b/packages/backend/src/calls/calls.service.ts
@@ -1,178 +1,60 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere, MoreThanOrEqual, LessThanOrEqual } from 'typeorm';
-import { CallEntity, CallStatus } from './calls.entity';
-export { CallStatus };
-import { CreateCallDto } from './dto/create-call.dto';
-import { IpfsService } from '../storage/ipfs.service';
-import { NotificationsService } from '../notifications/notifications.service';
-
-export interface CallFilter {
-  status?: CallStatus;
-  creatorAddress?: string;
-  startDate?: Date;
-  endDate?: Date;
-  limit?: number;
-  offset?: number;
-}
-
-export interface PaginatedCalls {
-  data: CallEntity[];
-  totalCount: number;
-  hasNext: boolean;
-}
+import { Repository } from 'typeorm';
+import { CallsRepository } from './calls.repository';
+import { CallReport } from './entities/call-report.entity';
+import { ReportCallDto } from './dto/report-call.dto';
+import { QueryCallsDto } from './dto/query-calls.dto';
+import { REPORT_THRESHOLD } from './constants/moderation.constants';
 
 @Injectable()
 export class CallsService {
   constructor(
-    @InjectRepository(CallEntity)
-    private readonly callsRepository: Repository<CallEntity>,
-    private readonly ipfsService: IpfsService,
-    private readonly notificationsService: NotificationsService,
-  ) { }
+    private readonly callsRepository: CallsRepository,
+    @InjectRepository(CallReport)
+    private readonly callReportRepository: Repository<CallReport>,
+  ) {}
 
-  async findAll(filters: CallFilter = {}): Promise<PaginatedCalls> {
-    const {
-      status,
-      creatorAddress,
-      startDate,
-      endDate,
-      limit = 20,
-      offset = 0
-    } = filters;
+  async getFeed(query: QueryCallsDto) {
+    const { page = 1, limit = 20 } = query;
+    const [data, total] = await this.callsRepository.findFeed(page, limit);
+    return { data, total, page, limit };
+  }
 
-    const where: FindOptionsWhere<CallEntity> = {};
+  async search(query: QueryCallsDto) {
+    const { search = '', page = 1, limit = 20 } = query;
+    const [data, total] = await this.callsRepository.searchVisible(search, page, limit);
+    return { data, total, page, limit };
+  }
 
-    if (status) {
-      where.status = status;
-    }
+  async reportCall(id: string, reporterAddress: string, dto: ReportCallDto) {
+    const call = await this.callsRepository.findOne({ where: { id } });
+    if (!call) throw new NotFoundException('Call not found');
 
-    if (creatorAddress) {
-      where.creatorAddress = creatorAddress;
-    }
-
-    if (startDate) {
-      where.createdAt = MoreThanOrEqual(startDate);
-    }
-
-    if (endDate) {
-      where.createdAt = LessThanOrEqual(endDate);
-    }
-
-    const [data, totalCount] = await this.callsRepository.findAndCount({
-      where,
-      order: { createdAt: 'DESC' },
-      skip: offset,
-      take: limit + 1, // Fetch one extra to check if there's a next page
+    const alreadyReported = await this.callReportRepository.findOne({
+      where: { callId: id, reporterAddress },
     });
+    if (alreadyReported) throw new ConflictException('You have already reported this call');
 
-    // Return only the requested number of items and indicate if there's a next page
-    const hasNext = data.length > limit;
-    const resultData = hasNext ? data.slice(0, limit) : data;
+    await this.callReportRepository.save(
+      this.callReportRepository.create({ callId: id, reporterAddress, reason: dto.reason }),
+    );
+
+    call.reportCount += 1;
+    if (call.reportCount >= REPORT_THRESHOLD) {
+      call.isHidden = true;
+    }
+
+    await this.callsRepository.save(call);
 
     return {
-      data: resultData,
-      totalCount,
-      hasNext,
+      message: 'Report submitted successfully',
+      reportCount: call.reportCount,
+      isHidden: call.isHidden,
     };
-  }
-
-  async findOne(id: number): Promise<CallEntity> {
-    const call = await this.callsRepository.findOne({
-      where: { id },
-    });
-
-    if (!call) {
-      throw new NotFoundException(`Call with id ${id} not found`);
-    }
-
-    return call;
-  }
-
-  async findByUser(address: string, filters: CallFilter = {}): Promise<PaginatedCalls> {
-    const { limit = 20, offset = 0 } = filters;
-
-    const [data, totalCount] = await this.callsRepository.findAndCount({
-      where: { creatorAddress: address },
-      order: { createdAt: 'DESC' },
-      skip: offset,
-      take: limit + 1,
-    });
-
-    const hasNext = data.length > limit;
-    const resultData = hasNext ? data.slice(0, limit) : data;
-
-    return {
-      data: resultData,
-      totalCount,
-      hasNext,
-    };
-  }
-
-  async createDraft(createCallDto: CreateCallDto): Promise<CallEntity> {
-    // First, pin the content to IPFS
-    const ipfsContent = {
-      title: createCallDto.title,
-      thesis: createCallDto.thesis,
-      conditionJson: createCallDto.conditionJson,
-      createdAt: new Date().toISOString(),
-    };
-
-    try {
-      const ipfsCid = await this.ipfsService.pinCallContent(ipfsContent);
-
-      // Create the call entity
-      const call = new CallEntity();
-      call.title = createCallDto.title;
-      call.thesis = createCallDto.thesis;
-      call.tokenAddress = createCallDto.tokenAddress;
-      call.pairId = createCallDto.pairId;
-      call.stakeToken = createCallDto.stakeToken;
-      call.stakeAmount = createCallDto.stakeAmount.toString();
-      call.endTs = new Date(createCallDto.endTs);
-      call.creatorAddress = createCallDto.stakeToken; // Using stakeToken as creator address
-      call.ipfsCid = ipfsCid;
-      call.status = CallStatus.DRAFT;
-      call.conditionJson = createCallDto.conditionJson;
-
-      return await this.callsRepository.save(call);
-    } catch (error) {
-      throw new BadRequestException(`Failed to create call draft: ${error.message}`);
-    }
-  }
-
-  async getFeed(filters: CallFilter = {}): Promise<PaginatedCalls> {
-    const { limit = 20, offset = 0 } = filters;
-
-    // Get trending/recent calls - ordering by creation date descending
-    const [data, totalCount] = await this.callsRepository.findAndCount({
-      where: { status: CallStatus.OPEN }, // Only show open calls in feed
-      order: { createdAt: 'DESC' },
-      skip: offset,
-      take: limit + 1,
-    });
-
-    const hasNext = data.length > limit;
-    const resultData = hasNext ? data.slice(0, limit) : data;
-
-    return {
-      data: resultData,
-      totalCount,
-      hasNext,
-    };
-  }
-
-  // ── Notification trigger stubs (called by indexer after on-chain confirmation) ─
-
-  async notifyBackedCall(callCreatorId: string, backerAddress: string, callId: number): Promise<void> {
-    await this.notificationsService.notifyBackedCall(callCreatorId, backerAddress, callId);
-  }
-
-  async notifyCallEnded(userId: string, callId: number): Promise<void> {
-    await this.notificationsService.notifyCallEnded(userId, callId);
-  }
-
-  async notifyPayoutReady(userId: string, callId: number): Promise<void> {
-    await this.notificationsService.notifyPayoutReady(userId, callId);
   }
 }

--- a/packages/backend/src/calls/constants/moderation.constants.ts
+++ b/packages/backend/src/calls/constants/moderation.constants.ts
@@ -1,0 +1,1 @@
+export const REPORT_THRESHOLD = 5;

--- a/packages/backend/src/calls/dto/query-calls.dto.ts
+++ b/packages/backend/src/calls/dto/query-calls.dto.ts
@@ -1,0 +1,21 @@
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueryCallsDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/packages/backend/src/calls/dto/report-call.dto.ts
+++ b/packages/backend/src/calls/dto/report-call.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ReportCallDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  reason?: string;
+}

--- a/packages/backend/src/calls/entities/call-report.entity.ts
+++ b/packages/backend/src/calls/entities/call-report.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+} from 'typeorm';
+import { Call } from './call.entity';
+
+@Entity('call_reports')
+@Unique(['callId', 'reporterAddress'])
+export class CallReport {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  callId: string;
+
+  @Column({ type: 'varchar', length: 42 })
+  reporterAddress: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  reason: string;
+
+  @ManyToOne(() => Call, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'callId' })
+  call: Call;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/calls/entities/call.entity.ts
+++ b/packages/backend/src/calls/entities/call.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+@Entity('calls')
+export class Call {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'varchar', length: 42 })
+  creatorAddress: string;
+
+  @Column({ type: 'boolean', default: false })
+  isHidden: boolean;
+
+  @Column({ type: 'int', default: 0 })
+  reportCount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
Description:

  Implements the Content Moderation & Reporting module for the calls feature.

  Changes:
  - Added isHidden (boolean) and reportCount (integer) fields to the Call entity
  - Added CallReport entity to track per-user reports (prevents duplicate reports)
  - POST /calls/:id/report — authenticated endpoint to report a call; auto-hides it when reportCount >= 5
  - Custom CallsRepository with a visibleQuery() helper that globally filters out hidden calls
  - GET /calls/feed and GET /calls/search both use the visible-only query, ensuring hidden calls never surface
  - Migration to add the new columns and call_reports table
  
  closes #73 