### PR TITLE
feat: add WebSocket gateway, audit logging, and firewall middleware

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { CallsModule } from './calls/calls.module';
 import { HealthModule } from './health/health.module';
 import { OracleModule } from './oracle/oracle.module';
@@ -9,6 +10,10 @@ import { AnalyticsModule } from './analytics/analytics.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { SearchModule } from './search/search.module';
 import { UsersModule } from './user/users.module';
+import { GatewaysModule } from './gateways/gateways.module';
+import { AuditModule } from './audit/audit.module';
+import { FirewallModule } from './firewall/firewall.module';
+import { FirewallMiddleware } from './firewall/firewall.middleware';
 
 @Module({
   imports: [
@@ -19,12 +24,23 @@ import { UsersModule } from './user/users.module';
     TypeOrmModule.forRoot({
       type: 'postgres',
       host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'localhost',
-      port: parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
-      username: process.env.DB_USERNAME || process.env.POSTGRES_USER || 'postgres',
-      password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD || 'postgres',
+      port: parseInt(
+        process.env.DB_PORT || process.env.POSTGRES_PORT || '5432',
+        10,
+      ),
+      username:
+        process.env.DB_USERNAME || process.env.POSTGRES_USER || 'postgres',
+      password:
+        process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD || 'postgres',
       database: process.env.DB_NAME || process.env.POSTGRES_DB || 'backit',
       autoLoadEntities: true,
-      synchronize: process.env.NODE_ENV !== 'production', // Only sync in development
+      synchronize: process.env.NODE_ENV !== 'production',
+    }),
+    // Enables internal event-driven communication between modules.
+    // wildcard: true allows listeners like 'stake.*' to match 'stake.created' etc.
+    EventEmitterModule.forRoot({
+      wildcard: true,
+      delimiter: '.',
     }),
     CallsModule,
     HealthModule,
@@ -33,9 +49,21 @@ import { UsersModule } from './user/users.module';
     AnalyticsModule,
     NotificationsModule,
     SearchModule,
-    UsersModule
+    UsersModule,
+    GatewaysModule,
+    AuditModule,
+    FirewallModule,
   ],
   controllers: [],
   providers: [],
 })
-export class AppModule { }
+export class AppModule implements NestModule {
+  /**
+   * Apply FirewallMiddleware to all routes.
+   * The /health path is excluded so load-balancer probes are never blocked.
+   * Add more exclusions via .exclude() chaining if needed.
+   */
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(FirewallMiddleware).exclude('/health').forRoutes('*');
+  }
+}

--- a/packages/backend/src/audit/audit-log.entity.ts
+++ b/packages/backend/src/audit/audit-log.entity.ts
@@ -1,0 +1,85 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum AuditStatus {
+  SUCCESS = 'SUCCESS',
+  FAILURE = 'FAILURE',
+}
+
+export enum AuditActionType {
+  // Oracle parameter changes
+  ORACLE_PARAMS_UPDATED = 'ORACLE_PARAMS_UPDATED',
+  ORACLE_QUORUM_SET = 'ORACLE_QUORUM_SET',
+
+  // Market resolution
+  MARKET_MANUALLY_RESOLVED = 'MARKET_MANUALLY_RESOLVED',
+  MARKET_DISPUTED = 'MARKET_DISPUTED',
+  MARKET_PAUSED = 'MARKET_PAUSED',
+
+  // Generic admin actions (extend as needed)
+  ADMIN_ACTION = 'ADMIN_ACTION',
+}
+
+@Entity('audit_logs')
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /**
+   * When the action occurred. Set automatically by the DB; cannot be altered
+   * by application code — keeping the log immutable.
+   */
+  @CreateDateColumn({ type: 'timestamptz', update: false })
+  @Index()
+  timestamp: Date;
+
+  /**
+   * The authenticated user who triggered the action.
+   * Stored as an opaque string so it can hold a wallet address, UUID, or email.
+   */
+  @Column({ type: 'varchar', length: 256, update: false })
+  @Index()
+  actorId: string;
+
+  /** Human-readable label pulled from the enum above. */
+  @Column({ type: 'enum', enum: AuditActionType, update: false })
+  @Index()
+  actionType: AuditActionType;
+
+  /**
+   * The resource being acted upon, e.g. "market:abc123" or "oracle:feed:XLM/USD".
+   * Free-form so it stays flexible across feature areas.
+   */
+  @Column({ type: 'varchar', length: 512, update: false })
+  targetResource: string;
+
+  /**
+   * A JSON snapshot of the request body / relevant parameters at the time of
+   * the call. Stored as jsonb for efficient querying in Postgres.
+   */
+  @Column({ type: 'jsonb', nullable: true, update: false })
+  requestPayload: Record<string, unknown> | null;
+
+  /**
+   * A JSON snapshot of the response returned to the caller (or the error).
+   */
+  @Column({ type: 'jsonb', nullable: true, update: false })
+  responsePayload: Record<string, unknown> | null;
+
+  /** HTTP status code returned to the caller. */
+  @Column({ type: 'int', update: false })
+  httpStatus: number;
+
+  /** Whether the admin action ultimately succeeded or failed. */
+  @Column({ type: 'enum', enum: AuditStatus, update: false })
+  status: AuditStatus;
+
+  /** Optional free-text note, e.g. reason for manual resolution. */
+  @Column({ type: 'text', nullable: true, update: false })
+  note: string | null;
+}

--- a/packages/backend/src/audit/audit.controller.ts
+++ b/packages/backend/src/audit/audit.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  NotFoundException,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { AuditService } from './audit.service';
+import { AuditLog } from './audit-log.entity';
+import { QueryAuditLogsDto } from './dto/query-audit-logs.dto';
+
+/**
+ * NOTE: Swap `JwtAuthGuard` and `AdminGuard` for whatever guards your project
+ * already uses — e.g. an `@Roles('admin')` + `RolesGuard` combination.
+ * The important thing is that these routes are protected before they reach this
+ * controller. The imports below are placeholder names; adjust to your auth module.
+ */
+// import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+// import { AdminGuard } from '../auth/guards/admin.guard';
+
+@ApiTags('admin')
+@ApiBearerAuth('JWT-auth')
+// @UseGuards(JwtAuthGuard, AdminGuard)  ← uncomment when your guards are wired up
+@Controller('admin/audit-logs')
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  /**
+   * GET /admin/audit-logs
+   *
+   * Returns a paginated, filterable list of all audit log entries.
+   * Accessible only to authenticated administrators.
+   */
+  @Get()
+  @ApiOperation({
+    summary: 'List audit logs',
+    description:
+      'Returns a paginated list of admin audit log entries. ' +
+      'Supports filtering by actor, action type, status, resource, and date range.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated audit log results' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin access required' })
+  async findAll(
+    @Query() query: QueryAuditLogsDto,
+  ): Promise<{ data: AuditLog[]; total: number; page: number; limit: number }> {
+    const { data, total } = await this.auditService.findAll(query);
+    return { data, total, page: query.page ?? 1, limit: query.limit ?? 50 };
+  }
+
+  /**
+   * GET /admin/audit-logs/:id
+   *
+   * Returns a single audit log entry by its UUID.
+   */
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single audit log entry by ID' })
+  @ApiParam({ name: 'id', description: 'UUID of the audit log entry' })
+  @ApiResponse({ status: 200, description: 'The requested audit log entry' })
+  @ApiResponse({ status: 404, description: 'Entry not found' })
+  async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<AuditLog> {
+    const entry = await this.auditService.findOne(id);
+    if (!entry) throw new NotFoundException(`Audit log entry ${id} not found`);
+    return entry;
+  }
+}

--- a/packages/backend/src/audit/audit.module.ts
+++ b/packages/backend/src/audit/audit.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditLog } from './audit-log.entity';
+import { AuditService } from './audit.service';
+import { AuditController } from './audit.controller';
+import { AuditInterceptor } from './interceptors/audit.interceptor';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([AuditLog]), // registers the repo for injection
+  ],
+  providers: [
+    AuditService,
+    AuditInterceptor, // provided here so @Audited() can inject it via DI
+  ],
+  controllers: [AuditController],
+  exports: [AuditService, AuditInterceptor], // export so other modules can use @Audited()
+})
+export class AuditModule {}

--- a/packages/backend/src/audit/audit.service.ts
+++ b/packages/backend/src/audit/audit.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindManyOptions, Between, FindOptionsWhere } from 'typeorm';
+import { AuditLog, AuditActionType, AuditStatus } from './audit-log.entity';
+import { QueryAuditLogsDto } from './dto/query-audit-logs.dto';
+
+export interface WriteAuditLogParams {
+  actorId: string;
+  actionType: AuditActionType;
+  targetResource: string;
+  requestPayload?: Record<string, unknown> | null;
+  responsePayload?: Record<string, unknown> | null;
+  httpStatus: number;
+  status: AuditStatus;
+  note?: string | null;
+}
+
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly auditRepo: Repository<AuditLog>,
+  ) {}
+
+  /**
+   * Persist a single audit log entry.
+   * Called by the AuditInterceptor; should never throw — failures are swallowed
+   * and logged to stderr so they never break the admin request itself.
+   */
+  async write(params: WriteAuditLogParams): Promise<void> {
+    try {
+      const entry = this.auditRepo.create({
+        actorId: params.actorId,
+        actionType: params.actionType,
+        targetResource: params.targetResource,
+        requestPayload: params.requestPayload ?? null,
+        responsePayload: params.responsePayload ?? null,
+        httpStatus: params.httpStatus,
+        status: params.status,
+        note: params.note ?? null,
+      });
+      await this.auditRepo.save(entry);
+    } catch (err) {
+      // Log but never bubble — audit failures must not break admin operations
+      this.logger.error('Failed to persist audit log entry', (err as Error).stack);
+    }
+  }
+
+  /**
+   * Query audit logs with optional filters.
+   * Returns paginated results ordered newest-first.
+   */
+  async findAll(query: QueryAuditLogsDto): Promise<{ data: AuditLog[]; total: number }> {
+    const {
+      actorId,
+      actionType,
+      status,
+      targetResource,
+      from,
+      to,
+      page = 1,
+      limit = 50,
+    } = query;
+
+    const where: FindOptionsWhere<AuditLog> = {};
+
+    if (actorId) where.actorId = actorId;
+    if (actionType) where.actionType = actionType;
+    if (status) where.status = status;
+    if (targetResource) where.targetResource = targetResource;
+    if (from && to) where.timestamp = Between(new Date(from), new Date(to));
+
+    const [data, total] = await this.auditRepo.findAndCount({
+      where,
+      order: { timestamp: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { data, total };
+  }
+
+  /** Fetch a single log entry by ID. */
+  async findOne(id: string): Promise<AuditLog | null> {
+    return this.auditRepo.findOneBy({ id });
+  }
+}

--- a/packages/backend/src/audit/decorators/audited.decorator.ts
+++ b/packages/backend/src/audit/decorators/audited.decorator.ts
@@ -1,0 +1,35 @@
+import { SetMetadata, applyDecorators, UseInterceptors } from '@nestjs/common';
+import { AuditActionType } from '../audit-log.entity';
+import { AuditInterceptor } from '../interceptors/audit.interceptor';
+
+export const AUDIT_ACTION_KEY = 'audit:action';
+export const AUDIT_RESOURCE_KEY = 'audit:resource';
+
+/**
+ * @Audited(actionType, targetResourceFn)
+ *
+ * Attach this decorator to any admin controller method you want logged.
+ * The interceptor picks up the metadata and writes the log entry automatically.
+ *
+ * @param actionType    - One of the AuditActionType enum values
+ * @param getResource   - Optional function that receives the ExecutionContext
+ *                        and returns a resource string. Defaults to the route path.
+ *
+ * @example
+ * \@Audited(AuditActionType.MARKET_MANUALLY_RESOLVED, (ctx) => {
+ *   const req = ctx.switchToHttp().getRequest();
+ *   return `market:${req.params.marketId}`;
+ * })
+ * \@Post(':marketId/resolve')
+ * resolveMarket(...) { ... }
+ */
+export function Audited(
+  actionType: AuditActionType,
+  getResource?: (ctx: import('@nestjs/common').ExecutionContext) => string,
+) {
+  return applyDecorators(
+    SetMetadata(AUDIT_ACTION_KEY, actionType),
+    SetMetadata(AUDIT_RESOURCE_KEY, getResource),
+    UseInterceptors(AuditInterceptor),
+  );
+}

--- a/packages/backend/src/audit/dto/query-audit-logs.dto.ts
+++ b/packages/backend/src/audit/dto/query-audit-logs.dto.ts
@@ -1,0 +1,51 @@
+import { IsOptional, IsEnum, IsString, IsInt, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { AuditActionType, AuditStatus } from '../audit-log.entity';
+
+export class QueryAuditLogsDto {
+  @ApiPropertyOptional({ description: 'Filter by actor ID, wallet address, or user ID' })
+  @IsOptional()
+  @IsString()
+  actorId?: string;
+
+  @ApiPropertyOptional({ enum: AuditActionType, description: 'Filter by action type' })
+  @IsOptional()
+  @IsEnum(AuditActionType)
+  actionType?: AuditActionType;
+
+  @ApiPropertyOptional({ enum: AuditStatus, description: 'Filter by outcome status' })
+  @IsOptional()
+  @IsEnum(AuditStatus)
+  status?: AuditStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by target resource string (exact match)' })
+  @IsOptional()
+  @IsString()
+  targetResource?: string;
+
+  @ApiPropertyOptional({ description: 'Start of date range (ISO 8601)', example: '2024-01-01T00:00:00Z' })
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @ApiPropertyOptional({ description: 'End of date range (ISO 8601)', example: '2024-12-31T23:59:59Z' })
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Results per page', default: 50, minimum: 1, maximum: 200 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+}

--- a/packages/backend/src/audit/interceptors/audit.interceptor.ts
+++ b/packages/backend/src/audit/interceptors/audit.interceptor.ts
@@ -1,0 +1,165 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable, throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import { Request, Response } from 'express';
+import { AuditService } from '../audit.service';
+import { AuditActionType, AuditStatus } from '../audit-log.entity';
+import {
+  AUDIT_ACTION_KEY,
+  AUDIT_RESOURCE_KEY,
+} from '../decorators/audited.decorator';
+
+/**
+ * AuditInterceptor
+ *
+ * This interceptor is NOT registered globally. It is applied selectively via
+ * the @Audited() decorator on individual admin route handlers.
+ *
+ * Lifecycle:
+ *   1. Intercepts the inbound request → snapshots the body.
+ *   2. Lets the handler run normally.
+ *   3. On success: writes a SUCCESS log entry with the response payload.
+ *   4. On error:   writes a FAILURE log entry with the error details, then
+ *                  re-throws so the exception filter still handles the HTTP response.
+ *
+ * Actor resolution order:
+ *   req.user.id → req.user.sub → req.user.address → req.user.email → 'unknown'
+ */
+@Injectable()
+export class AuditInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(AuditInterceptor.name);
+
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  intercept(ctx: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const actionType = this.reflector.get<AuditActionType>(
+      AUDIT_ACTION_KEY,
+      ctx.getHandler(),
+    );
+
+    // If the decorator wasn't applied (defensive check), skip silently
+    if (!actionType) return next.handle();
+
+    const req: Request & { user?: Record<string, string> } = ctx
+      .switchToHttp()
+      .getRequest();
+
+    const res: Response = ctx.switchToHttp().getResponse();
+
+    // ── Actor ─────────────────────────────────────────────────────────────
+    const user = req.user ?? {};
+    const actorId =
+      user['id'] ??
+      user['sub'] ??
+      user['address'] ??
+      user['email'] ??
+      'unknown';
+
+    // ── Target Resource ───────────────────────────────────────────────────
+    const getResource = this.reflector.get<
+      ((c: ExecutionContext) => string) | undefined
+    >(AUDIT_RESOURCE_KEY, ctx.getHandler());
+
+    const targetResource = getResource
+      ? getResource(ctx)
+      : (req.path ?? ctx.getHandler().name);
+
+    // ── Request payload snapshot (strip sensitive fields) ─────────────────
+    const requestPayload = sanitize(req.body as Record<string, unknown>);
+
+    const startedAt = Date.now();
+
+    return next.handle().pipe(
+      // ── SUCCESS path ────────────────────────────────────────────────────
+      tap((responseBody: unknown) => {
+        void this.auditService.write({
+          actorId,
+          actionType,
+          targetResource,
+          requestPayload,
+          responsePayload: sanitize(responseBody as Record<string, unknown>),
+          httpStatus: res.statusCode,
+          status: AuditStatus.SUCCESS,
+        });
+
+        this.logger.debug(
+          `Audit [${actionType}] actor=${actorId} resource="${targetResource}" ` +
+            `status=SUCCESS http=${res.statusCode} duration=${Date.now() - startedAt}ms`,
+        );
+      }),
+
+      // ── FAILURE path ─────────────────────────────────────────────────────
+      catchError((err: Error & { status?: number; response?: unknown }) => {
+        const httpStatus = err.status ?? 500;
+
+        void this.auditService.write({
+          actorId,
+          actionType,
+          targetResource,
+          requestPayload,
+          responsePayload: {
+            error: err.message,
+            detail: sanitize(err.response as Record<string, unknown>),
+          },
+          httpStatus,
+          status: AuditStatus.FAILURE,
+          note: err.message,
+        });
+
+        this.logger.warn(
+          `Audit [${actionType}] actor=${actorId} resource="${targetResource}" ` +
+            `status=FAILURE http=${httpStatus} error="${err.message}"`,
+        );
+
+        return throwError(() => err); // re-throw so the exception filter handles HTTP response
+      }),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'secret',
+  'token',
+  'privateKey',
+  'mnemonic',
+  'seed',
+  'authorization',
+]);
+
+/**
+ * Recursively strips known sensitive keys from an object before storing it.
+ * Returns null for non-object values to avoid giant response blobs.
+ */
+function sanitize(
+  value: Record<string, unknown> | unknown,
+  depth = 0,
+): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || depth > 4) return null;
+
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_KEYS.has(k.toLowerCase())) {
+      result[k] = '[REDACTED]';
+    } else if (typeof v === 'object' && v !== null) {
+      result[k] = sanitize(v as Record<string, unknown>, depth + 1);
+    } else {
+      result[k] = v;
+    }
+  }
+  return result;
+}

--- a/packages/backend/src/audit/usage-example.admin.controller.ts
+++ b/packages/backend/src/audit/usage-example.admin.controller.ts
@@ -1,0 +1,92 @@
+/**
+ * usage-example.admin.controller.ts
+ *
+ * Shows how to apply @Audited() to sensitive admin routes in your existing
+ * Oracle, OutcomeManager, or any other admin controller.
+ *
+ * DO NOT copy this file as-is — apply the patterns to your real controllers.
+ */
+
+import { Controller, Post, Body, Param, Patch } from '@nestjs/common';
+import { Audited } from '../audit/decorators/audited.decorator';
+import { AuditActionType } from '../audit/audit-log.entity';
+
+// ─── Example: Oracle Admin Controller ─────────────────────────────────────
+
+@Controller('admin/oracle')
+export class OracleAdminController {
+  /**
+   * Updating oracle parameters → writes an ORACLE_PARAMS_UPDATED log entry.
+   * targetResource is derived from the route params via the second argument.
+   */
+  @Audited(
+    AuditActionType.ORACLE_PARAMS_UPDATED,
+    (ctx) => {
+      const req = ctx.switchToHttp().getRequest();
+      return `oracle:feed:${req.params.feedId}`;
+    },
+  )
+  @Patch('feeds/:feedId/params')
+  updateOracleParams(
+    @Param('feedId') feedId: string,
+    @Body() dto: { minResponses: number; heartbeatSeconds: number },
+  ) {
+    // ... your oracle service call
+  }
+
+  /**
+   * Setting a quorum → writes an ORACLE_QUORUM_SET log entry.
+   */
+  @Audited(
+    AuditActionType.ORACLE_QUORUM_SET,
+    (ctx) => {
+      const req = ctx.switchToHttp().getRequest();
+      return `oracle:quorum:${req.params.roundId}`;
+    },
+  )
+  @Patch('rounds/:roundId/quorum')
+  setQuorum(
+    @Param('roundId') roundId: string,
+    @Body() dto: { quorum: number },
+  ) {
+    // ... your oracle service call
+  }
+}
+
+// ─── Example: Market Resolution Admin Controller ───────────────────────────
+
+@Controller('admin/markets')
+export class MarketAdminController {
+  /**
+   * Manually resolving a market → writes a MARKET_MANUALLY_RESOLVED log entry.
+   */
+  @Audited(
+    AuditActionType.MARKET_MANUALLY_RESOLVED,
+    (ctx) => {
+      const req = ctx.switchToHttp().getRequest();
+      return `market:${req.params.marketId}`;
+    },
+  )
+  @Post(':marketId/resolve')
+  resolveMarket(
+    @Param('marketId') marketId: string,
+    @Body() dto: { outcome: string; note?: string },
+  ) {
+    // ... your OutcomeManager service call
+  }
+
+  /**
+   * Pausing a market → writes a MARKET_PAUSED log entry.
+   */
+  @Audited(
+    AuditActionType.MARKET_PAUSED,
+    (ctx) => {
+      const req = ctx.switchToHttp().getRequest();
+      return `market:${req.params.marketId}`;
+    },
+  )
+  @Post(':marketId/pause')
+  pauseMarket(@Param('marketId') marketId: string) {
+    // ... your service call
+  }
+}

--- a/packages/backend/src/firewall/dto/firewall.dto.ts
+++ b/packages/backend/src/firewall/dto/firewall.dto.ts
@@ -1,0 +1,65 @@
+import {
+  IsEnum,
+  IsString,
+  IsOptional,
+  Matches,
+  MaxLength,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IpRuleType } from '../entities/ip-rule.entity';
+import { BlockReason } from '../entities/blocked-request.entity';
+
+export class CreateIpRuleDto {
+  @ApiProperty({
+    description: 'IPv4/IPv6 address or CIDR range',
+    examples: ['192.168.1.42', '10.0.0.0/8', '2001:db8::/32'],
+  })
+  @IsString()
+  @MaxLength(64)
+  // Allows plain IPs and CIDR notation
+  @Matches(/^[\d.:/a-fA-F]+$/, {
+    message: 'cidr must be a valid IP address or CIDR range',
+  })
+  cidr: string;
+
+  @ApiProperty({ enum: IpRuleType, description: 'WHITELIST or BLACKLIST' })
+  @IsEnum(IpRuleType)
+  type: IpRuleType;
+
+  @ApiPropertyOptional({ description: 'Human-readable reason for this rule' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(512)
+  reason?: string;
+}
+
+export class QueryBlockedRequestsDto {
+  @ApiPropertyOptional({ description: 'Filter by client IP address' })
+  @IsOptional()
+  @IsString()
+  ip?: string;
+
+  @ApiPropertyOptional({ enum: BlockReason, description: 'Filter by block reason' })
+  @IsOptional()
+  @IsEnum(BlockReason)
+  reason?: BlockReason;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 50, minimum: 1, maximum: 200 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+}

--- a/packages/backend/src/firewall/entities/blocked-request.entity.ts
+++ b/packages/backend/src/firewall/entities/blocked-request.entity.ts
@@ -1,0 +1,65 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum BlockReason {
+  BLACKLISTED_IP = 'BLACKLISTED_IP',
+  BOT_FINGERPRINT = 'BOT_FINGERPRINT',
+  TURNSTILE_FAILED = 'TURNSTILE_FAILED',
+  RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
+  MALFORMED_REQUEST = 'MALFORMED_REQUEST',
+}
+
+/**
+ * Every dropped request produces one immutable BlockedRequest row.
+ * These feed the security audit trail and can be queried via
+ * GET /admin/firewall/blocked-requests.
+ *
+ * Error code format: BACKIT-FW-<YYYYMMDD>-<6-char hex>
+ * Example: BACKIT-FW-20240315-a3f9c1
+ */
+@Entity('blocked_requests')
+export class BlockedRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /**
+   * Unique, human-readable error code surfaced to the caller and stored here.
+   * Makes cross-referencing logs trivial for support/security teams.
+   */
+  @Column({ type: 'varchar', length: 64, unique: true, update: false })
+  @Index()
+  errorCode: string;
+
+  @Column({ type: 'varchar', length: 64, update: false })
+  @Index()
+  ip: string;
+
+  @Column({ type: 'enum', enum: BlockReason, update: false })
+  @Index()
+  reason: BlockReason;
+
+  /** HTTP method of the blocked request. */
+  @Column({ type: 'varchar', length: 16, update: false })
+  method: string;
+
+  /** Request path (without query string). */
+  @Column({ type: 'varchar', length: 1024, update: false })
+  path: string;
+
+  /** Captured User-Agent string for bot fingerprinting post-analysis. */
+  @Column({ type: 'text', nullable: true, update: false })
+  userAgent: string | null;
+
+  /** Subset of request headers useful for forensics (no auth headers). */
+  @Column({ type: 'jsonb', nullable: true, update: false })
+  headers: Record<string, string> | null;
+
+  @CreateDateColumn({ type: 'timestamptz', update: false })
+  @Index()
+  blockedAt: Date;
+}

--- a/packages/backend/src/firewall/entities/ip-rule.entity.ts
+++ b/packages/backend/src/firewall/entities/ip-rule.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum IpRuleType {
+  WHITELIST = 'WHITELIST',
+  BLACKLIST = 'BLACKLIST',
+}
+
+/**
+ * IpRule stores admin-managed IP address rules.
+ *
+ * Supports:
+ *  - Single IPv4 / IPv6 addresses  → cidr: "203.0.113.42"
+ *  - CIDR ranges                   → cidr: "203.0.113.0/24"
+ *  - Single-address CIDR notation  → cidr: "10.0.0.1/32"
+ *
+ * Evaluation order: WHITELIST beats BLACKLIST.
+ * If an IP matches a whitelist rule it is always allowed, even if it also
+ * matches a blacklist rule.
+ */
+@Entity('ip_rules')
+export class IpRule {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** IPv4/IPv6 address or CIDR range, e.g. "192.168.1.0/24" or "::1". */
+  @Column({ type: 'varchar', length: 64, unique: true })
+  @Index()
+  cidr: string;
+
+  @Column({ type: 'enum', enum: IpRuleType })
+  @Index()
+  type: IpRuleType;
+
+  /** Human-readable reason for adding this rule. */
+  @Column({ type: 'text', nullable: true })
+  reason: string | null;
+
+  /** The admin who created the rule. */
+  @Column({ type: 'varchar', length: 256, nullable: true })
+  createdBy: string | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/packages/backend/src/firewall/firewall.controller.ts
+++ b/packages/backend/src/firewall/firewall.controller.ts
@@ -1,0 +1,107 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  Query,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+  Request,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { FirewallService } from './firewall.service';
+import { IpRuleType } from './entities/ip-rule.entity';
+import { CreateIpRuleDto, QueryBlockedRequestsDto } from './dto/firewall.dto';
+import { Audited } from '../audit/decorators/audited.decorator';
+import { AuditActionType } from '../audit/audit-log.entity';
+
+/**
+ * NOTE: Uncomment your project's auth guards once wired up.
+ * import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+ * import { AdminGuard } from '../auth/guards/admin.guard';
+ */
+
+@ApiTags('admin')
+@ApiBearerAuth('JWT-auth')
+// @UseGuards(JwtAuthGuard, AdminGuard)
+@Controller('admin/firewall')
+export class FirewallController {
+  constructor(private readonly firewallService: FirewallService) {}
+
+  // ─── IP Rules ─────────────────────────────────────────────────────────────
+
+  @Get('rules')
+  @ApiOperation({ summary: 'List all IP whitelist/blacklist rules' })
+  @ApiResponse({ status: 200, description: 'Array of IpRule entries' })
+  getRules() {
+    return this.firewallService.getRules();
+  }
+
+  @Post('rules')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Add an IP whitelist or blacklist rule',
+    description:
+      'Accepts a plain IP address or CIDR range (e.g. "10.0.0.0/8"). ' +
+      'WHITELIST rules take precedence over BLACKLIST rules.',
+  })
+  @ApiResponse({ status: 201, description: 'Rule created and cache refreshed' })
+  @Audited(AuditActionType.ADMIN_ACTION, () => 'firewall:ip-rules')
+  addRule(
+    @Body() dto: CreateIpRuleDto,
+    @Request() req: { user?: Record<string, string> },
+  ) {
+    const actorId = req.user?.['id'] ?? req.user?.['sub'] ?? 'unknown';
+    return this.firewallService.addRule(
+      dto.cidr,
+      dto.type as IpRuleType,
+      dto.reason ?? null,
+      actorId,
+    );
+  }
+
+  @Delete('rules/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove an IP rule by UUID' })
+  @ApiParam({ name: 'id', description: 'UUID of the IpRule to remove' })
+  @ApiResponse({ status: 204, description: 'Rule removed and cache refreshed' })
+  @Audited(AuditActionType.ADMIN_ACTION, (ctx) => {
+    const id = ctx.switchToHttp().getRequest<{ params: { id: string } }>()
+      .params.id;
+    return `firewall:ip-rules:${id}`;
+  })
+  removeRule(@Param('id', ParseUUIDPipe) id: string) {
+    return this.firewallService.removeRule(id);
+  }
+
+  // ─── Blocked Request Logs ────────────────────────────────────────────────
+
+  @Get('blocked-requests')
+  @ApiOperation({
+    summary: 'List blocked request log entries',
+    description:
+      'Returns a paginated list of all requests that were dropped by the firewall middleware. ' +
+      'Use errorCode values to cross-reference with external WAF / SIEM logs.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated blocked-request results',
+  })
+  getBlockedRequests(@Query() query: QueryBlockedRequestsDto) {
+    return this.firewallService.getBlockedRequests(
+      query.page,
+      query.limit,
+      query.ip,
+      query.reason,
+    );
+  }
+}

--- a/packages/backend/src/firewall/firewall.middleware.ts
+++ b/packages/backend/src/firewall/firewall.middleware.ts
@@ -1,0 +1,59 @@
+import {
+  Injectable,
+  NestMiddleware,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { FirewallService } from './firewall.service';
+import { extractClientIp } from './utils/ip-matcher.util';
+
+/**
+ * FirewallMiddleware
+ *
+ * Runs on every inbound HTTP request before it reaches any controller.
+ * It is applied in AppModule.configure() so it wraps the entire app.
+ *
+ * Flow:
+ *  1. Extract the real client IP (respects CF-Connecting-IP, X-Real-IP, X-Forwarded-For)
+ *  2. Pass to FirewallService.evaluate() → checks whitelist → blacklist → bot UA
+ *  3. Allowed requests pass through with next()
+ *  4. Blocked requests receive a 403 JSON response with a unique error code
+ *     and the request is never forwarded to controllers
+ */
+@Injectable()
+export class FirewallMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(FirewallMiddleware.name);
+
+  constructor(private readonly firewallService: FirewallService) {}
+
+  async use(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const ip = extractClientIp({
+      ip: req.ip,
+      headers: req.headers as Record<string, string | string[] | undefined>,
+      socket: req.socket,
+    });
+
+    const verdict = await this.firewallService.evaluate({
+      ip,
+      method: req.method,
+      path: req.path,
+      userAgent: req.headers['user-agent'],
+      headers: req.headers as Record<string, string>,
+    });
+
+    if (verdict.allowed) {
+      // Attach the resolved IP to the request for downstream use
+      (req as Request & { clientIp: string }).clientIp = ip;
+      return next();
+    }
+
+    // Return a consistent, non-revealing 403 with the trackable error code
+    res.status(HttpStatus.FORBIDDEN).json({
+      statusCode: HttpStatus.FORBIDDEN,
+      error: 'Forbidden',
+      message: 'Access denied.',
+      errorCode: verdict.errorCode,
+    });
+  }
+}

--- a/packages/backend/src/firewall/firewall.module.ts
+++ b/packages/backend/src/firewall/firewall.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BlockedRequest } from './entities/blocked-request.entity';
+import { IpRule } from './entities/ip-rule.entity';
+import { AuditModule } from 'src/audit/audit.module';
+import { FirewallService } from './firewall.service';
+import { FirewallMiddleware } from './firewall.middleware';
+import { TurnstileGuard } from './guards/turnstile.guard';
+import { FirewallController } from './firewall.controller';
+
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([IpRule, BlockedRequest]),
+    AuditModule, // for @Audited() on the admin controller
+  ],
+  providers: [FirewallService, FirewallMiddleware, TurnstileGuard],
+  controllers: [FirewallController],
+  exports: [FirewallService, FirewallMiddleware, TurnstileGuard],
+})
+export class FirewallModule {}

--- a/packages/backend/src/firewall/firewall.service.ts
+++ b/packages/backend/src/firewall/firewall.service.ts
@@ -1,0 +1,196 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { IpRule, IpRuleType } from './entities/ip-rule.entity';
+import { BlockedRequest, BlockReason } from './entities/blocked-request.entity';
+import { ipMatchesCidr, isBotUserAgent, generateFirewallErrorCode } from './utils/ip-matcher.util';
+
+export interface FirewallVerdict {
+  allowed: boolean;
+  reason?: BlockReason;
+  errorCode?: string;
+}
+
+interface RequestSnapshot {
+  ip: string;
+  method: string;
+  path: string;
+  userAgent: string | undefined;
+  headers: Record<string, string>;
+}
+
+@Injectable()
+export class FirewallService implements OnModuleInit {
+  private readonly logger = new Logger(FirewallService.name);
+
+  /** In-memory rule cache — refreshed every CACHE_TTL_MS milliseconds. */
+  private ruleCache: IpRule[] = [];
+  private cacheLoadedAt = 0;
+  private readonly CACHE_TTL_MS = 60_000; // 1 minute
+
+  constructor(
+    @InjectRepository(IpRule)
+    private readonly ruleRepo: Repository<IpRule>,
+
+    @InjectRepository(BlockedRequest)
+    private readonly blockedRepo: Repository<BlockedRequest>,
+  ) {}
+
+  async onModuleInit() {
+    await this.refreshCache();
+    this.logger.log(`Firewall initialised — ${this.ruleCache.length} IP rules loaded`);
+  }
+
+  // ─── Public API ───────────────────────────────────────────────────────────
+
+  /**
+   * Main evaluation function called by the middleware.
+   * Returns { allowed: true } or { allowed: false, reason, errorCode }.
+   */
+  async evaluate(snapshot: RequestSnapshot): Promise<FirewallVerdict> {
+    await this.maybeRefreshCache();
+
+    const { ip, userAgent } = snapshot;
+
+    // 1. Whitelist check — always allow if explicitly whitelisted
+    const whitelisted = this.ruleCache
+      .filter((r) => r.type === IpRuleType.WHITELIST)
+      .some((r) => ipMatchesCidr(ip, r.cidr));
+
+    if (whitelisted) return { allowed: true };
+
+    // 2. Blacklist check
+    const blacklisted = this.ruleCache
+      .filter((r) => r.type === IpRuleType.BLACKLIST)
+      .some((r) => ipMatchesCidr(ip, r.cidr));
+
+    if (blacklisted) {
+      return this.block(snapshot, BlockReason.BLACKLISTED_IP);
+    }
+
+    // 3. Bot UA fingerprint check
+    if (isBotUserAgent(userAgent)) {
+      return this.block(snapshot, BlockReason.BOT_FINGERPRINT);
+    }
+
+    return { allowed: true };
+  }
+
+  /**
+   * Called from the Turnstile guard after a failed challenge verification.
+   * Writes a TURNSTILE_FAILED blocked-request record.
+   */
+  async recordTurnstileFailure(snapshot: RequestSnapshot): Promise<FirewallVerdict> {
+    return this.block(snapshot, BlockReason.TURNSTILE_FAILED);
+  }
+
+  // ─── IP Rule CRUD (used by the admin controller) ──────────────────────────
+
+  async getRules(): Promise<IpRule[]> {
+    return this.ruleRepo.find({ order: { createdAt: 'DESC' } });
+  }
+
+  async addRule(
+    cidr: string,
+    type: IpRuleType,
+    reason: string | null,
+    createdBy: string | null,
+  ): Promise<IpRule> {
+    const rule = this.ruleRepo.create({ cidr, type, reason, createdBy });
+    const saved = await this.ruleRepo.save(rule);
+    await this.refreshCache(); // immediate cache bust
+    this.logger.log(`Firewall rule added: [${type}] ${cidr} by ${createdBy ?? 'system'}`);
+    return saved;
+  }
+
+  async removeRule(id: string): Promise<void> {
+    await this.ruleRepo.delete(id);
+    await this.refreshCache();
+    this.logger.log(`Firewall rule removed: ${id}`);
+  }
+
+  // ─── Blocked-request log queries ──────────────────────────────────────────
+
+  async getBlockedRequests(
+    page = 1,
+    limit = 50,
+    ip?: string,
+    reason?: BlockReason,
+  ): Promise<{ data: BlockedRequest[]; total: number }> {
+    const qb = this.blockedRepo
+      .createQueryBuilder('br')
+      .orderBy('br.blockedAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (ip) qb.andWhere('br.ip = :ip', { ip });
+    if (reason) qb.andWhere('br.reason = :reason', { reason });
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total };
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  private async block(
+    snapshot: RequestSnapshot,
+    reason: BlockReason,
+  ): Promise<FirewallVerdict> {
+    const errorCode = generateFirewallErrorCode();
+
+    // Persist asynchronously — do not await in the hot path
+    this.persistBlockedRequest(snapshot, reason, errorCode).catch((err) =>
+      this.logger.error('Failed to persist blocked-request log', (err as Error).stack),
+    );
+
+    this.logger.warn(
+      `🚫 Blocked [${reason}] ip=${snapshot.ip} path=${snapshot.method} ${snapshot.path} code=${errorCode}`,
+    );
+
+    return { allowed: false, reason, errorCode };
+  }
+
+  private async persistBlockedRequest(
+    snapshot: RequestSnapshot,
+    reason: BlockReason,
+    errorCode: string,
+  ): Promise<void> {
+    const SAFE_HEADERS: (keyof RequestSnapshot['headers'])[] = [
+      'accept',
+      'accept-language',
+      'content-type',
+      'origin',
+      'referer',
+      'x-forwarded-for',
+      'cf-ipcountry',
+    ];
+
+    const safeHeaders: Record<string, string> = {};
+    for (const key of SAFE_HEADERS) {
+      if (snapshot.headers[key]) safeHeaders[key] = snapshot.headers[key];
+    }
+
+    const entry = this.blockedRepo.create({
+      errorCode,
+      ip: snapshot.ip,
+      reason,
+      method: snapshot.method,
+      path: snapshot.path,
+      userAgent: snapshot.userAgent ?? null,
+      headers: safeHeaders,
+    });
+
+    await this.blockedRepo.save(entry);
+  }
+
+  private async maybeRefreshCache(): Promise<void> {
+    if (Date.now() - this.cacheLoadedAt > this.CACHE_TTL_MS) {
+      await this.refreshCache();
+    }
+  }
+
+  private async refreshCache(): Promise<void> {
+    this.ruleCache = await this.ruleRepo.find();
+    this.cacheLoadedAt = Date.now();
+  }
+}

--- a/packages/backend/src/firewall/guards/turnstile.guard.ts
+++ b/packages/backend/src/firewall/guards/turnstile.guard.ts
@@ -1,0 +1,152 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { FirewallService } from './firewall.service';
+import { extractClientIp } from './utils/ip-matcher.util';
+
+export const SKIP_TURNSTILE_KEY = 'skipTurnstile';
+
+/**
+ * @SkipTurnstile()
+ * Apply to routes that should bypass the Turnstile check (e.g. mobile-only flows).
+ */
+export const SkipTurnstile = () =>
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@nestjs/common').SetMetadata(SKIP_TURNSTILE_KEY, true);
+
+/**
+ * TurnstileGuard
+ *
+ * Validates the Cloudflare Turnstile token sent in the request header
+ * `x-turnstile-token` against Cloudflare's siteverify API.
+ *
+ * Apply globally or per-controller:
+ *
+ * @example
+ * // Global — in main.ts after app creation:
+ * app.useGlobalGuards(app.get(TurnstileGuard));
+ *
+ * @example
+ * // Per-controller:
+ * @UseGuards(TurnstileGuard)
+ * @Controller('markets')
+ * export class MarketsController { ... }
+ *
+ * Required env vars:
+ *   TURNSTILE_SECRET_KEY  — Cloudflare Turnstile secret key
+ *   TURNSTILE_ENABLED     — set to "false" to disable in development
+ */
+@Injectable()
+export class TurnstileGuard implements CanActivate {
+  private readonly logger = new Logger(TurnstileGuard.name);
+  private readonly SITEVERIFY_URL =
+    'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly firewallService: FirewallService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(ctx: ExecutionContext): Promise<boolean> {
+    // Allow opt-out via @SkipTurnstile()
+    const skip = this.reflector.getAllAndOverride<boolean>(SKIP_TURNSTILE_KEY, [
+      ctx.getHandler(),
+      ctx.getClass(),
+    ]);
+    if (skip) return true;
+
+    // Allow disabling in development
+    const enabled = this.configService.get<string>('TURNSTILE_ENABLED') !== 'false';
+    if (!enabled) return true;
+
+    const secretKey = this.configService.get<string>('TURNSTILE_SECRET_KEY');
+    if (!secretKey) {
+      this.logger.warn('TURNSTILE_SECRET_KEY not set — skipping Turnstile verification');
+      return true;
+    }
+
+    const req = ctx.switchToHttp().getRequest<Request>();
+    const token =
+      (req.headers['x-turnstile-token'] as string | undefined) ??
+      (req.body as Record<string, string>)?.['cf-turnstile-response'];
+
+    const ip = extractClientIp({
+      ip: req.ip,
+      headers: req.headers as Record<string, string | string[] | undefined>,
+      socket: req.socket,
+    });
+
+    if (!token) {
+      await this.firewallService.recordTurnstileFailure({
+        ip,
+        method: req.method,
+        path: req.path,
+        userAgent: req.headers['user-agent'],
+        headers: req.headers as Record<string, string>,
+      });
+      throw new ForbiddenException({
+        message: 'Bot challenge token missing.',
+        hint: 'Include a valid Cloudflare Turnstile token in the x-turnstile-token header.',
+      });
+    }
+
+    const verified = await this.verifyToken(token, secretKey, ip);
+
+    if (!verified) {
+      const verdict = await this.firewallService.recordTurnstileFailure({
+        ip,
+        method: req.method,
+        path: req.path,
+        userAgent: req.headers['user-agent'],
+        headers: req.headers as Record<string, string>,
+      });
+
+      throw new ForbiddenException({
+        message: 'Bot challenge verification failed.',
+        errorCode: verdict.errorCode,
+      });
+    }
+
+    return true;
+  }
+
+  private async verifyToken(
+    token: string,
+    secretKey: string,
+    remoteIp: string,
+  ): Promise<boolean> {
+    try {
+      const body = new URLSearchParams({
+        secret: secretKey,
+        response: token,
+        remoteip: remoteIp,
+      });
+
+      const res = await fetch(this.SITEVERIFY_URL, {
+        method: 'POST',
+        body,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+
+      const data = (await res.json()) as { success: boolean; 'error-codes'?: string[] };
+
+      if (!data.success) {
+        this.logger.debug(`Turnstile rejected: ${data['error-codes']?.join(', ')}`);
+      }
+
+      return data.success;
+    } catch (err) {
+      this.logger.error('Turnstile siteverify request failed', (err as Error).message);
+      // Fail open on network error to avoid locking out legitimate users
+      return true;
+    }
+  }
+}

--- a/packages/backend/src/firewall/utils/ip-matcher.util.ts
+++ b/packages/backend/src/firewall/utils/ip-matcher.util.ts
@@ -1,0 +1,165 @@
+/**
+ * ip-matcher.util.ts
+ *
+ * Pure functions for matching IPv4/IPv6 addresses against CIDR ranges.
+ * Uses the built-in `net` module — zero external dependencies needed for
+ * basic IPv4 CIDR. For production-grade IPv6 CIDR support, install `ip-range-check`.
+ */
+
+import * as net from 'net';
+
+/**
+ * Returns true if `ip` falls within the `cidr` block.
+ *
+ * Handles:
+ *  - Plain addresses with no mask  → treated as /32 (IPv4) or /128 (IPv6)
+ *  - Standard CIDR notation        → "10.0.0.0/8", "2001:db8::/32"
+ *
+ * @param ip    The incoming request IP (may include ::ffff: IPv4-mapped prefix)
+ * @param cidr  A CIDR string or plain IP stored in the ip_rules table
+ */
+export function ipMatchesCidr(ip: string, cidr: string): boolean {
+  try {
+    // Strip IPv4-mapped IPv6 prefix (::ffff:1.2.3.4 → 1.2.3.4)
+    const cleanIp = ip.replace(/^::ffff:/i, '');
+
+    // Plain IP — no CIDR mask, do exact match
+    if (!cidr.includes('/')) {
+      return net.isIP(cleanIp) !== 0 && cleanIp === cidr;
+    }
+
+    const [range, bitsStr] = cidr.split('/');
+    const bits = parseInt(bitsStr, 10);
+
+    // IPv4 CIDR
+    if (net.isIPv4(cleanIp) && net.isIPv4(range)) {
+      return ipv4InCidr(cleanIp, range, bits);
+    }
+
+    // IPv6 CIDR (basic prefix comparison)
+    if (net.isIPv6(cleanIp) && net.isIPv6(range)) {
+      return ipv6InCidr(cleanIp, range, bits);
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// ─── IPv4 helpers ──────────────────────────────────────────────────────────
+
+function ipToUint32(ip: string): number {
+  return ip
+    .split('.')
+    .reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
+}
+
+function ipv4InCidr(ip: string, range: string, bits: number): boolean {
+  if (bits < 0 || bits > 32) return false;
+  const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+  return (ipToUint32(ip) & mask) === (ipToUint32(range) & mask);
+}
+
+// ─── IPv6 helpers (prefix comparison) ─────────────────────────────────────
+
+function ipv6ToBigInt(ip: string): bigint {
+  // expand :: shorthand
+  const full = expandIPv6(ip);
+  return full
+    .split(':')
+    .reduce((acc, group) => (acc << 16n) + BigInt(parseInt(group, 16)), 0n);
+}
+
+function expandIPv6(ip: string): string {
+  const halves = ip.split('::');
+  if (halves.length === 2) {
+    const left = halves[0] ? halves[0].split(':') : [];
+    const right = halves[1] ? halves[1].split(':') : [];
+    const missing = 8 - left.length - right.length;
+    const middle = Array(missing).fill('0');
+    return [...left, ...middle, ...right].map((g) => g.padStart(4, '0')).join(':');
+  }
+  return ip
+    .split(':')
+    .map((g) => g.padStart(4, '0'))
+    .join(':');
+}
+
+function ipv6InCidr(ip: string, range: string, bits: number): boolean {
+  if (bits < 0 || bits > 128) return false;
+  const mask = bits === 0 ? 0n : (~0n << BigInt(128 - bits)) & ((1n << 128n) - 1n);
+  return (ipv6ToBigInt(ip) & mask) === (ipv6ToBigInt(range) & mask);
+}
+
+// ─── Error code generator ──────────────────────────────────────────────────
+
+/**
+ * Generates a unique, human-readable firewall error code.
+ * Format: BACKIT-FW-<YYYYMMDD>-<6-char hex>
+ * Example: BACKIT-FW-20240315-a3f9c1
+ */
+export function generateFirewallErrorCode(): string {
+  const date = new Date();
+  const datePart = date.toISOString().slice(0, 10).replace(/-/g, '');
+  const randomPart = Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0');
+  return `BACKIT-FW-${datePart}-${randomPart}`;
+}
+
+/** Known bot / scraper User-Agent substrings. Case-insensitive matching. */
+export const BOT_UA_PATTERNS: RegExp[] = [
+  /bot/i,
+  /crawl/i,
+  /spider/i,
+  /scrape/i,
+  /curl\//i,
+  /wget\//i,
+  /python-requests/i,
+  /go-http-client/i,
+  /axios\//i,        // headless scripts often forget to change UA
+  /java\//i,
+  /libwww-perl/i,
+  /scrapy/i,
+  /semrush/i,
+  /ahrefs/i,
+  /mj12bot/i,
+  /dotbot/i,
+  /sistrix/i,
+  /petalbot/i,
+];
+
+/**
+ * Returns true if the User-Agent string matches a known bot pattern.
+ * Pass `allowedBots` (e.g. Googlebot) to exclude legitimate crawlers.
+ */
+export function isBotUserAgent(
+  userAgent: string | undefined,
+  allowedBots: RegExp[] = [],
+): boolean {
+  if (!userAgent) return true; // missing UA is suspicious
+  if (allowedBots.some((r) => r.test(userAgent))) return false;
+  return BOT_UA_PATTERNS.some((r) => r.test(userAgent));
+}
+
+/** Extract the real client IP, respecting common reverse-proxy headers. */
+export function extractClientIp(req: {
+  ip?: string;
+  headers: Record<string, string | string[] | undefined>;
+  socket?: { remoteAddress?: string };
+}): string {
+  const cfIp = req.headers['cf-connecting-ip'];
+  if (cfIp) return Array.isArray(cfIp) ? cfIp[0] : cfIp;
+
+  const xReal = req.headers['x-real-ip'];
+  if (xReal) return Array.isArray(xReal) ? xReal[0] : xReal;
+
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) {
+    const first = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+    return first.split(',')[0].trim();
+  }
+
+  return req.ip ?? req.socket?.remoteAddress ?? '0.0.0.0';
+}

--- a/packages/backend/src/gateways/events.gateway.ts
+++ b/packages/backend/src/gateways/events.gateway.ts
@@ -1,0 +1,278 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+  MessageBody,
+  ConnectedSocket,
+  WsException,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { Logger, UseGuards } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+// ---------------------------------------------------------------------------
+// Payload shapes
+// ---------------------------------------------------------------------------
+
+export interface StakeCreatedPayload {
+  marketId: string;
+  stakeId: string;
+  userId: string;
+  amount: number;
+  odds: number;
+  selection: string;
+  createdAt: string;
+}
+
+export interface MarketPriceUpdatedPayload {
+  marketId: string;
+  prices: Record<string, number>; // selection → price
+  updatedAt: string;
+}
+
+export interface UserNotificationPayload {
+  userId: string;
+  type: string;
+  message: string;
+  meta?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Room helpers
+// ---------------------------------------------------------------------------
+
+const marketRoom = (marketId: string) => `market:${marketId}`;
+const userRoom = (userId: string) => `user:${userId}`;
+
+// ---------------------------------------------------------------------------
+// Gateway
+// ---------------------------------------------------------------------------
+
+@WebSocketGateway({
+  cors: {
+    origin: '*', // tighten in production via ConfigService
+    credentials: true,
+  },
+  namespace: '/ws',
+})
+export class EventsGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  private readonly server: Server;
+
+  private readonly logger = new Logger(EventsGateway.name);
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  // -------------------------------------------------------------------------
+  // Lifecycle hooks
+  // -------------------------------------------------------------------------
+
+  afterInit(server: Server) {
+    this.logger.log('WebSocket gateway initialised');
+  }
+
+  handleConnection(client: Socket) {
+    this.logger.log(`Client connected: ${client.id}`);
+    // Optionally send a welcome event so the client knows the socket is ready
+    client.emit('connected', { socketId: client.id });
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Client disconnected: ${client.id}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Public subscriptions — Market rooms
+  // -------------------------------------------------------------------------
+
+  /**
+   * Any client (authenticated or anonymous) can subscribe to a market room
+   * to receive live stake events and price updates for that market.
+   *
+   * Client → server:
+   *   emit('market:subscribe', { marketId: 'abc123' })
+   *
+   * Server → client confirmations:
+   *   emit('market:subscribed', { marketId })   on success
+   *   emit('error', { message })                on failure
+   */
+  @SubscribeMessage('market:subscribe')
+  handleMarketSubscribe(
+    @MessageBody() data: { marketId: string },
+    @ConnectedSocket() client: Socket,
+  ) {
+    const { marketId } = data ?? {};
+
+    if (!marketId || typeof marketId !== 'string') {
+      client.emit('error', { message: 'marketId is required' });
+      return;
+    }
+
+    const room = marketRoom(marketId);
+    client.join(room);
+    this.logger.log(`Socket ${client.id} joined room "${room}"`);
+
+    client.emit('market:subscribed', { marketId });
+  }
+
+  /**
+   * Unsubscribe from a market room.
+   *
+   * Client → server:
+   *   emit('market:unsubscribe', { marketId: 'abc123' })
+   */
+  @SubscribeMessage('market:unsubscribe')
+  handleMarketUnsubscribe(
+    @MessageBody() data: { marketId: string },
+    @ConnectedSocket() client: Socket,
+  ) {
+    const { marketId } = data ?? {};
+
+    if (!marketId) return;
+
+    const room = marketRoom(marketId);
+    client.leave(room);
+    this.logger.log(`Socket ${client.id} left room "${room}"`);
+
+    client.emit('market:unsubscribed', { marketId });
+  }
+
+  // -------------------------------------------------------------------------
+  // Private subscriptions — User notification rooms (requires JWT)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Authenticated clients subscribe to their own private notification room.
+   *
+   * Client → server:
+   *   emit('user:subscribe', { token: '<jwt>' })
+   *
+   * Server → client:
+   *   emit('user:subscribed', { userId })   on success
+   *   emit('error', { message })            on failure
+   */
+  @SubscribeMessage('user:subscribe')
+  async handleUserSubscribe(
+    @MessageBody() data: { token: string },
+    @ConnectedSocket() client: Socket,
+  ) {
+    const { token } = data ?? {};
+
+    if (!token) {
+      client.emit('error', {
+        message: 'JWT token is required for private subscriptions',
+      });
+      return;
+    }
+
+    try {
+      const secret = this.configService.get<string>('JWT_SECRET');
+      const payload = await this.jwtService.verifyAsync(token, { secret });
+      const userId: string = payload.sub ?? payload.userId;
+
+      if (!userId)
+        throw new Error('Token does not contain a valid user identifier');
+
+      const room = userRoom(userId);
+      client.join(room);
+
+      // Store userId on socket data for later reference
+      client.data.userId = userId;
+
+      this.logger.log(`Socket ${client.id} joined private room "${room}"`);
+      client.emit('user:subscribed', { userId });
+    } catch (err) {
+      this.logger.warn(
+        `Authentication failed for socket ${client.id}: ${(err as Error).message}`,
+      );
+      client.emit('error', {
+        message: 'Authentication failed: invalid or expired token',
+      });
+    }
+  }
+
+  /**
+   * Leave the private user room.
+   *
+   * Client → server:
+   *   emit('user:unsubscribe')
+   */
+  @SubscribeMessage('user:unsubscribe')
+  handleUserUnsubscribe(@ConnectedSocket() client: Socket) {
+    const userId: string | undefined = client.data.userId;
+
+    if (userId) {
+      const room = userRoom(userId);
+      client.leave(room);
+      delete client.data.userId;
+      this.logger.log(`Socket ${client.id} left private room "${room}"`);
+      client.emit('user:unsubscribed', { userId });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // EventEmitter2 listeners — bridge internal events → WebSocket broadcasts
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fired by the Stakes service when a new stake is placed.
+   * Broadcasts to all clients subscribed to the affected market room.
+   *
+   * Internal event name: 'stake.created'  (matches Issue 9 convention)
+   */
+  @OnEvent('stake.created')
+  onStakeCreated(payload: StakeCreatedPayload) {
+    const room = marketRoom(payload.marketId);
+    this.logger.debug(`Broadcasting stake.created to room "${room}"`);
+    this.server.to(room).emit('stake:created', payload);
+  }
+
+  /**
+   * Fired when market prices are updated (e.g. odds change).
+   * Broadcasts to all clients in the affected market room.
+   *
+   * Internal event name: 'market.priceUpdated'
+   */
+  @OnEvent('market.priceUpdated')
+  onMarketPriceUpdated(payload: MarketPriceUpdatedPayload) {
+    const room = marketRoom(payload.marketId);
+    this.logger.debug(`Broadcasting market.priceUpdated to room "${room}"`);
+    this.server.to(room).emit('market:priceUpdated', payload);
+  }
+
+  /**
+   * Fired when a push notification should be delivered to a specific user.
+   * Broadcasts only to the private room of that user.
+   *
+   * Internal event name: 'notification.push'
+   */
+  @OnEvent('notification.push')
+  onNotificationPush(payload: UserNotificationPayload) {
+    const room = userRoom(payload.userId);
+    this.logger.debug(`Broadcasting notification to room "${room}"`);
+    this.server.to(room).emit('notification', payload);
+  }
+
+  // -------------------------------------------------------------------------
+  // Utility — push a notification from elsewhere in the codebase
+  // -------------------------------------------------------------------------
+
+  /** Programmatically push a notification to a user without going through EventEmitter. */
+  pushNotificationToUser(
+    userId: string,
+    notification: Omit<UserNotificationPayload, 'userId'>,
+  ) {
+    const room = userRoom(userId);
+    this.server.to(room).emit('notification', { userId, ...notification });
+  }
+}

--- a/packages/backend/src/gateways/gateways.module.ts
+++ b/packages/backend/src/gateways/gateways.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventsGateway } from './events.gateway';
+
+@Module({
+  imports: [
+    /**
+     * JwtModule is registered asynchronously so the secret is pulled from
+     * ConfigService at runtime, identical to the AuthModule setup.
+     */
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: config.get<string>('JWT_EXPIRES_IN', '7d') },
+      }),
+    }),
+  ],
+  providers: [EventsGateway],
+  exports: [EventsGateway], // export so other modules can call pushNotificationToUser()
+})
+export class GatewaysModule {}

--- a/packages/backend/src/gateways/websocket-client.example.ts
+++ b/packages/backend/src/gateways/websocket-client.example.ts
@@ -1,0 +1,80 @@
+/**
+ * websocket-client.example.ts
+ *
+ * Shows how a frontend (React / plain TS) connects to the gateway
+ * and subscribes to market rooms and user notifications.
+ *
+ * Install: npm install socket.io-client
+ */
+
+import { io, Socket } from 'socket.io-client';
+
+const BACKEND_URL = 'http://localhost:3000';
+
+// ─── Connect ───────────────────────────────────────────────────────────────
+
+const socket: Socket = io(`${BACKEND_URL}/ws`, {
+  transports: ['websocket'],
+  autoConnect: true,
+});
+
+socket.on('connect', () => {
+  console.log('🟢 Connected to WebSocket gateway, socket id:', socket.id);
+});
+
+socket.on('connect_error', (err) => {
+  console.error('🔴 Connection error:', err.message);
+});
+
+socket.on('disconnect', (reason) => {
+  console.warn('🟡 Disconnected:', reason);
+});
+
+// ─── Subscribe to a Market ─────────────────────────────────────────────────
+
+export function subscribeToMarket(marketId: string) {
+  socket.emit('market:subscribe', { marketId });
+
+  socket.on('market:subscribed', ({ marketId }) => {
+    console.log(`✅ Subscribed to market ${marketId}`);
+  });
+
+  // Live stake events for this market
+  socket.on('stake:created', (stake) => {
+    console.log('📌 New stake on market:', stake);
+    // update your UI state here
+  });
+
+  // Live price updates for this market
+  socket.on('market:priceUpdated', (update) => {
+    console.log('💲 Prices updated:', update);
+    // update your odds display here
+  });
+}
+
+export function unsubscribeFromMarket(marketId: string) {
+  socket.emit('market:unsubscribe', { marketId });
+}
+
+// ─── Subscribe to Private User Notifications ───────────────────────────────
+
+export function subscribeToUserNotifications(jwtToken: string) {
+  socket.emit('user:subscribe', { token: jwtToken });
+
+  socket.on('user:subscribed', ({ userId }) => {
+    console.log(`🔔 Listening for notifications for user ${userId}`);
+  });
+
+  socket.on('notification', (notification) => {
+    console.log('🔔 Incoming notification:', notification);
+    // show toast / badge in your UI
+  });
+
+  socket.on('error', ({ message }) => {
+    console.error('WebSocket error:', message);
+  });
+}
+
+export function unsubscribeFromUserNotifications() {
+  socket.emit('user:unsubscribe');
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -1,10 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { IoAdapter } from '@nestjs/platform-socket.io';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Attach the Socket.io WebSocket adapter — required for the EventsGateway
+  app.useWebSocketAdapter(new IoAdapter(app));
 
   // Enable CORS
   app.enableCors({
@@ -92,11 +96,12 @@ async function bootstrap() {
 
   const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
   await app.listen(port);
-  
+
   Logger.log(`🚀 Backend running on http://localhost:${port}`, 'Bootstrap');
   Logger.log(`📚 Swagger documentation available at http://localhost:${port}/api/docs`, 'Bootstrap');
   Logger.log(`📊 API JSON spec available at http://localhost:${port}/api/docs-json`, 'Bootstrap');
   Logger.log(`💚 Health check available at http://localhost:${port}/health`, 'Bootstrap');
+  Logger.log(`🔌 WebSocket gateway available at ws://localhost:${port}/ws`, 'Bootstrap');
   Logger.log(`🌍 Environment: ${process.env.NODE_ENV || 'development'}`, 'Bootstrap');
 }
 


### PR DESCRIPTION
## Summary
Implements three backend infrastructure features in a single cohesive PR since they
share the same module registration touchpoints (AppModule, main.ts) and the firewall
controller intentionally reuses the `@Audited()` decorator from the audit feature.

## Changes

### #76 — Real-time WebSocket Gateway
- `src/gateways/events.gateway.ts` — Socket.io gateway on `/ws` namespace
- `src/gateways/gateways.module.ts`
- Market rooms (public): `market:subscribe` / `market:unsubscribe`
- User rooms (private): `user:subscribe` requires a valid JWT
- Internal bridge: `@OnEvent('stake.created')`, `@OnEvent('market.priceUpdated')`, `@OnEvent('notification.push')`

### #81 — Centralized Audit Logging
- `src/audit/audit-log.entity.ts` — immutable entity (all columns `update: false`)
- `src/audit/interceptors/audit.interceptor.ts` — taps RxJS success/failure streams
- `src/audit/decorators/audited.decorator.ts` — `@Audited(actionType, resourceFn)`
- `src/audit/audit.controller.ts` — `GET /admin/audit-logs`, `GET /admin/audit-logs/:id`

### #83 — Malicious IP / Bot Blocking Middleware
- `src/firewall/entities/ip-rule.entity.ts` — WHITELIST / BLACKLIST CIDR rules
- `src/firewall/entities/blocked-request.entity.ts` — immutable drop log
- `src/firewall/utils/ip-matcher.util.ts` — CIDR math, bot UA patterns, IP extraction
- `src/firewall/firewall.middleware.ts` — runs before every controller
- `src/firewall/guards/turnstile.guard.ts` — optional Cloudflare Turnstile challenge
- `src/firewall/firewall.controller.ts` — `GET/POST/DELETE /admin/firewall/rules`, `GET /admin/firewall/blocked-requests`

## Testing checklist
- [ ] WebSocket: connect to `ws://localhost:3001/ws`, subscribe to a market room, trigger a stake event, confirm broadcast received
- [ ] WebSocket: subscribe to user room with valid/invalid JWT — confirm admission/rejection
- [ ] Audit: hit an `@Audited()` route, confirm row appears in `audit_logs` table
- [ ] Audit: `GET /admin/audit-logs` returns paginated results with filters working
- [ ] Firewall: add a blacklist rule for your local IP via `POST /admin/firewall/rules`, confirm 403 with `BACKIT-FW-*` error code on next request
- [ ] Firewall: add a whitelist rule for same IP, confirm it overrides the blacklist
- [ ] Firewall: send request with `User-Agent: curl/7.88` — confirm 403
- [ ] Firewall: `/health` always returns 200 regardless of rules

## Env vars added
| Variable | Required | Description |
|---|---|---|
| `TURNSTILE_SECRET_KEY` | No | Cloudflare Turnstile secret — omit to disable |
| `TURNSTILE_ENABLED` | No | Set to `false` to skip verification in dev |

Closes #76
Closes #81
Closes #83