### PR TITLE
Implemented the requested backend support for the stakes view

### DIFF
--- a/packages/backend/src/analytics/analytics.controller.ts
+++ b/packages/backend/src/analytics/analytics.controller.ts
@@ -19,6 +19,10 @@ import {
 import { AnalyticsService } from './analytics.service';
 import { AnalyticsQueryDto, DateRangeFilter } from './dto/analytics-query.dto';
 import { UserAnalyticsResponse } from './dto/analytics-response.dto';
+import {
+  UserStakesQueryDto,
+  UserStakesResponseDto,
+} from './dto/user-stakes.dto';
 
 @ApiTags('Analytics')
 @Controller('users')
@@ -65,5 +69,43 @@ export class AnalyticsController {
   ): Promise<UserAnalyticsResponse> {
     const range = query.range || DateRangeFilter.SEVEN_DAYS;
     return this.analyticsService.getUserAnalytics(address, range);
+  }
+
+  @Get(':address/stakes')
+  @ApiOperation({
+    summary: 'Get user stakes ledger',
+    description:
+      'Retrieve a paginated ledger of a user’s stakes joined with call information and resolution status',
+  })
+  @ApiParam({
+    name: 'address',
+    description: 'Stellar wallet address of the user',
+    example: 'GCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    description: 'Page number (1-based)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Number of items per page',
+    example: 20,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'User stakes retrieved successfully',
+    type: UserStakesResponseDto,
+  })
+  async getUserStakes(
+    @Param('address') address: string,
+    @Query(new ValidationPipe({ transform: true }))
+    query: UserStakesQueryDto,
+  ): Promise<UserStakesResponseDto> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    return this.analyticsService.getUserStakes(address, page, limit);
   }
 }

--- a/packages/backend/src/analytics/dto/user-stakes.dto.ts
+++ b/packages/backend/src/analytics/dto/user-stakes.dto.ts
@@ -1,0 +1,107 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class UserStakesQueryDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Results per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  limit?: number = 20;
+}
+
+export class CallSummaryDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  description: string;
+
+  @ApiProperty({ enum: ['YES', 'NO', 'PENDING'] })
+  outcome: 'YES' | 'NO' | 'PENDING';
+
+  @ApiPropertyOptional({ description: 'When the call was resolved, if applicable', type: String })
+  resolvedAt?: Date | null;
+
+  @ApiPropertyOptional({ description: 'When the call expires, if applicable', type: String })
+  expiresAt?: Date | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiPropertyOptional({ description: 'Address of the on-chain contract', nullable: true })
+  contractAddress?: string | null;
+
+  @ApiProperty({ description: 'Total YES stake on this call' })
+  totalYesStake: number;
+
+  @ApiProperty({ description: 'Total NO stake on this call' })
+  totalNoStake: number;
+}
+
+export class StakeLedgerItemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  callId: string;
+
+  @ApiProperty()
+  userAddress: string;
+
+  @ApiProperty({ description: 'Stake amount in XLM' })
+  amount: number;
+
+  @ApiProperty({ enum: ['YES', 'NO'] })
+  position: 'YES' | 'NO';
+
+  @ApiPropertyOptional({ description: 'Realized profit or loss in XLM', nullable: true })
+  profitLoss?: number | null;
+
+  @ApiPropertyOptional({ description: 'Underlying transaction hash', nullable: true })
+  transactionHash?: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+
+  @ApiProperty({
+    description: 'Derived resolution status for this stake based on the underlying call',
+    enum: ['PENDING', 'RESOLVED'],
+  })
+  resolutionStatus: 'PENDING' | 'RESOLVED';
+
+  @ApiPropertyOptional({ type: CallSummaryDto })
+  call?: CallSummaryDto;
+}
+
+export class UserStakesResponseDto {
+  @ApiProperty({ type: [StakeLedgerItemDto] })
+  data: StakeLedgerItemDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+}
+


### PR DESCRIPTION
Implemented the requested backend support for the stakes view closes #100 

- Added a new `GET /users/:address/stakes` endpoint in `AnalyticsController` under the existing `users` route.
- Implemented `AnalyticsService.getUserStakes` to return a **paginated** ledger of stakes for the given `userAddress`, ordered by `stake.createdAt DESC`.
- Joined each `Stake` with its corresponding `Call` entity and exposed a summarized `call` payload (description, outcome, resolvedAt, expiresAt, totals, etc.).
- Added `UserStakesQueryDto`, `StakeLedgerItemDto`, `CallSummaryDto`, and `UserStakesResponseDto` to model the query params and response shape, including a derived `resolutionStatus` field (`PENDING` or `RESOLVED`).

This should provide the frontend with everything needed to render the user’s stakes ledger, including call info and resolution status, with standard pagination.