### PR TITLE
Implement paginated retrieval for calls and calls by creator in CallR…

### DIFF
--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -11,6 +11,8 @@ use events::*;
 use storage::*;
 use types::*;
 
+const MAX_CALL_PAGE_SIZE: u32 = 20;
+
 /// CallRegistry contract implementation
 /// Manages prediction calls and staking on market outcomes
 #[contract]
@@ -181,6 +183,63 @@ impl CallRegistry {
                     calls.push_back(call);
                 }
             }
+        }
+
+        calls
+    }
+
+    /// Get a paginated slice of calls starting at `start_id`.
+    /// Returns up to `limit` calls and enforces a maximum page size.
+    pub fn get_calls_paginated(env: Env, start_id: u64, limit: u32) -> Vec<Call> {
+        let mut calls = Vec::new(&env);
+        let total_calls = get_call_counter(&env);
+        let page_size = limit.min(MAX_CALL_PAGE_SIZE);
+
+        if page_size == 0 {
+            return calls;
+        }
+
+        let mut count = 0;
+        let mut current = if start_id < 1 { 1 } else { start_id };
+
+        while count < page_size && current <= total_calls {
+            if let Some(call) = get_call(&env, current) {
+                calls.push_back(call);
+                count += 1;
+            }
+            current += 1;
+        }
+
+        calls
+    }
+
+    /// Get a paginated slice of calls created by a specific address.
+    /// Returns up to `limit` calls starting from `start_id`.
+    pub fn get_calls_by_creator_paginated(
+        env: Env,
+        creator: Address,
+        start_id: u64,
+        limit: u32,
+    ) -> Vec<Call> {
+        let mut calls = Vec::new(&env);
+        let total_calls = get_call_counter(&env);
+        let page_size = limit.min(MAX_CALL_PAGE_SIZE);
+
+        if page_size == 0 {
+            return calls;
+        }
+
+        let mut count = 0;
+        let mut current = if start_id < 1 { 1 } else { start_id };
+
+        while count < page_size && current <= total_calls {
+            if let Some(call) = get_call(&env, current) {
+                if call.creator == creator {
+                    calls.push_back(call);
+                    count += 1;
+                }
+            }
+            current += 1;
         }
 
         calls

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{testutils::Events, Vec, Address, Env, IntoVal, Symbol, Bytes, 
 mod call_registry {
     use super::*;
     use crate::{CallRegistry, CallRegistryClient};
+    use crate::types::DataKey;
 
     fn setup() -> (Env, CallRegistryClient<'static>, Address, Address) {
     let env = Env::default();
@@ -626,6 +627,194 @@ fn test_set_fee_above_max_panics() {
         );
 
         assert_eq!(client.get_call_count(), 2);
+    }
+
+    #[test]
+    fn test_get_calls_paginated_respects_limit_and_start_id() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = Address::generate(&env);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        client.create_call(
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+        client.create_call(
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &3000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+        client.create_call(
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &4000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+
+        let results = client.get_calls_paginated(&2u64, &2u32);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap().id, 2);
+        assert_eq!(results.get(1).unwrap().id, 3);
+    }
+
+    #[test]
+    fn test_get_calls_by_creator_paginated_handles_gaps_and_max_limit() {
+        let (env, admin, outcome_manager, creator1) = create_test_env();
+        let creator2 = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = Address::generate(&env);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        client.create_call(
+            &creator1,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+        client.create_call(
+            &creator2,
+            &stake_token,
+            &100_000_000_i128,
+            &3000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+
+        env.storage().instance().set(&DataKey::CallCounter, &4u64);
+
+        let last_call = client.create_call(
+            &creator1,
+            &stake_token,
+            &100_000_000_i128,
+            &4000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+
+        let results = client.get_calls_by_creator_paginated(&creator1, &1u64, &100u32);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap().id, 1);
+        assert_eq!(results.get(1).unwrap().id, last_call.id);
+        assert_eq!(results.get(1).unwrap().id, 5);
+        assert!(results.len() <= 20);
+    }
+
+    #[test]
+    fn test_get_calls_paginated_respects_maximum_limit() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = Address::generate(&env);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        for _ in 0..25 {
+            client.create_call(
+                &creator,
+                &stake_token,
+                &100_000_000_i128,
+                &2000u64,
+                &token_address,
+                &pair_id,
+                &ipfs_cid,
+            );
+        }
+
+        let results = client.get_calls_paginated(&1u64, &100u32);
+        assert_eq!(results.len(), 20);
+        assert_eq!(results.get(0).unwrap().id, 1);
+        assert_eq!(results.get(19).unwrap().id, 20);
+    }
+
+    #[test]
+    fn test_get_calls_by_creator_paginated_returns_creator_specific_results() {
+        let (env, admin, outcome_manager, creator1) = create_test_env();
+        let creator2 = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = Address::generate(&env);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        client.create_call(
+            &creator1,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+        client.create_call(
+            &creator2,
+            &stake_token,
+            &100_000_000_i128,
+            &3000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+        client.create_call(
+            &creator1,
+            &stake_token,
+            &100_000_000_i128,
+            &4000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+
+        let results = client.get_calls_by_creator_paginated(&creator1, &1u64, &10u32);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap().creator, creator1);
+        assert_eq!(results.get(1).unwrap().creator, creator1);
+        assert_eq!(results.get(0).unwrap().id, 1);
+        assert_eq!(results.get(1).unwrap().id, 3);
     }
 
     #[test]


### PR DESCRIPTION
Closes #148 

## Completed

- Implemented `get_calls_paginated(env, start_id, limit)` in lib.rs
- Implemented `get_calls_by_creator_paginated(env, creator, start_id, limit)` in lib.rs
- Enforced a maximum page size of `20`
- Added tests in test.rs
  - pagination respects `limit` and `start_id`
  - creator-specific pagination works
  - max limit enforcement
  - gaps in IDs are handled correctly via manual storage gap simulation

## Verification

- `get_errors` reports no diagnostics for lib.rs and test.rs

Made changes.