### PR TITLE
feat(call_registry): implement void_call and claim_void_refund (#159)

### DIFF
--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -101,3 +101,21 @@ pub fn emit_admin_params_changed_u32(
         ),
     );
 }
+
+// ── Void events ───────────────────────────────────────────────────────────────
+
+/// Emitted when an admin voids a call
+pub fn emit_call_voided(env: &Env, call_id: u64, voided_by: &Address) {
+    env.events().publish(
+        ("call_registry", "call_voided"),
+        (call_id, voided_by.clone()),
+    );
+}
+
+/// Emitted when a staker claims a void refund
+pub fn emit_void_refund_claimed(env: &Env, call_id: u64, staker: &Address, amount: i128) {
+    env.events().publish(
+        ("call_registry", "void_refund_claimed"),
+        (call_id, staker.clone(), amount),
+    );
+}

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -6,6 +6,8 @@ mod admin;
 mod events;
 mod storage;
 mod types;
+#[cfg(test)]
+mod test;
 
 use events::*;
 use storage::*;
@@ -80,6 +82,7 @@ impl CallRegistry {
             start_price: 0,
             end_price: 0,
             settled: false,
+            voided: false,
             created_at: current_timestamp,
         };
 
@@ -129,6 +132,10 @@ impl CallRegistry {
             panic!("Call has been settled");
         }
 
+        if call.voided {
+            panic!("Call has been voided");
+        }
+
         let stake_position = match StakePosition::from_u32(position) {
             Some(p) => p,
             None => panic!("Invalid position: must be 1 (UP) or 2 (DOWN)"),
@@ -137,18 +144,15 @@ impl CallRegistry {
         let token_client = token::Client::new(&env, &call.stake_token);
         token_client.transfer(&staker, &env.current_contract_address(), &amount);
 
-        // We rely on events for attribution. The indexer already handles this.
-        // Hence call.up_stakes.set(...) / call.down_stakes.set(...) are commented out;
-        // uncomment in the future if the rule changes.
         match stake_position {
             StakePosition::Up => {
-                let _current_stake = call.up_stakes.get(staker.clone()).unwrap_or(0);
-                // call.up_stakes.set(staker.clone(), _current_stake + amount);
+                let current_stake = call.up_stakes.get(staker.clone()).unwrap_or(0);
+                call.up_stakes.set(staker.clone(), current_stake + amount);
                 call.total_up_stake += amount;
             }
             StakePosition::Down => {
-                let _current_stake = call.down_stakes.get(staker.clone()).unwrap_or(0);
-                // call.down_stakes.set(staker.clone(), _current_stake + amount);
+                let current_stake = call.down_stakes.get(staker.clone()).unwrap_or(0);
+                call.down_stakes.set(staker.clone(), current_stake + amount);
                 call.total_down_stake += amount;
             }
         }
@@ -232,6 +236,10 @@ impl CallRegistry {
 
         if outcome != 1 && outcome != 2 {
             panic!("Invalid outcome: must be 1 (UP) or 2 (DOWN)");
+        }
+
+        if call.voided {
+            panic!("Call has been voided");
         }
 
         let current_timestamp = env.ledger().timestamp();
@@ -320,5 +328,62 @@ impl CallRegistry {
 
         call.settled = true;
         set_call(&env, &call);
+    }
+
+    /// Void a call (admin only). Can be called at any time.
+    /// Once voided, no new stakes or resolutions are accepted.
+    /// Emits CallVoided.
+    pub fn void_call(env: Env, call_id: u64) {
+        let config = get_config(&env).expect("Not initialized");
+        config.admin.require_auth();
+
+        let mut call = get_call(&env, call_id).expect("Call not found");
+
+        if call.voided {
+            panic!("Call already voided");
+        }
+
+        if call.settled {
+            panic!("Call already settled");
+        }
+
+        call.voided = true;
+        set_call(&env, &call);
+        extend_storage_ttl(&env);
+
+        emit_call_voided(&env, call_id, &config.admin);
+    }
+
+    /// Claim a full refund for a voided call.
+    /// Refunds the exact stake the caller placed (up + down combined).
+    /// Emits VoidRefundClaimed.
+    pub fn claim_void_refund(env: Env, staker: Address, call_id: u64) {
+        staker.require_auth();
+
+        let call = get_call(&env, call_id).expect("Call not found");
+
+        if !call.voided {
+            panic!("Call is not voided");
+        }
+
+        if is_void_refund_claimed(&env, call_id, &staker) {
+            panic!("Refund already claimed");
+        }
+
+        let up_stake = call.up_stakes.get(staker.clone()).unwrap_or(0);
+        let down_stake = call.down_stakes.get(staker.clone()).unwrap_or(0);
+        let total_refund = up_stake + down_stake;
+
+        if total_refund <= 0 {
+            panic!("No stake to refund");
+        }
+
+        set_void_refund_claimed(&env, call_id, &staker);
+        extend_storage_ttl(&env);
+
+        let token_client = token::Client::new(&env, &call.stake_token);
+        token_client.transfer(&env.current_contract_address(), &staker, &total_refund);
+
+        emit_void_refund_claimed(&env, call_id, &staker, total_refund);
     }
 }

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -7,6 +7,7 @@ pub enum DataKey {
     CallCounter,
     Call(u64),
     StakerCalls(Address),
+    VoidRefundClaimed(u64, Address),
 }
 
 /// Store contract configuration
@@ -87,4 +88,18 @@ pub fn get_call_counter(env: &Env) -> u64 {
 pub fn extend_storage_ttl(env: &Env) {
     // Extend storage for 1 year (approximately 31,536,000 ledgers at ~5 second blocks)
     env.storage().instance().extend_ttl(31_536_000, 31_536_000);
+}
+
+/// Mark that a staker has claimed their void refund for a call
+pub fn set_void_refund_claimed(env: &Env, call_id: u64, staker: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::VoidRefundClaimed(call_id, staker.clone()), &true);
+}
+
+/// Check whether a staker has already claimed their void refund
+pub fn is_void_refund_claimed(env: &Env, call_id: u64, staker: &Address) -> bool {
+    env.storage()
+        .instance()
+        .has(&DataKey::VoidRefundClaimed(call_id, staker.clone()))
 }

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Events, Vec, Address, Env, IntoVal, Symbol, Bytes, String as SorobanString};
+use soroban_sdk::{testutils::{Address as _, Events, Ledger as _}, vec, Address, Env, IntoVal, Symbol, Bytes};
 
 mod call_registry {
     use super::*;
@@ -45,17 +45,17 @@ fn test_set_admin_emits_admin_params_changed() {
  
     // Topic: ("call_registry", "admin_params_changed")
     assert_eq!(
-        last.0,
+        last.1,
         vec![
             &env,
             "call_registry".into_val(&env),
             "admin_params_changed".into_val(&env),
         ]
     );
- 
+
     // First element of the payload tuple is the param discriminant
     let (param, _changed_by, old_val, new_val): (Symbol, Address, Address, Address) =
-        last.1.into_val(&env);
+        last.2.into_val(&env);
  
     assert_eq!(param, Symbol::new(&env, "admin"));
     assert_eq!(old_val, old_admin);
@@ -85,8 +85,8 @@ fn test_set_outcome_manager_emits_admin_params_changed() {
     let last = events.last().expect("no events");
  
     let (param, _changed_by, old_val, new_val): (Symbol, Address, Address, Address) =
-        last.1.into_val(&env);
- 
+        last.2.into_val(&env);
+
     assert_eq!(param, Symbol::new(&env, "outcome_manager"));
     assert_eq!(old_val, old_om);
     assert_eq!(new_val, new_om);
@@ -113,7 +113,7 @@ fn test_set_fee_emits_admin_params_changed() {
     let last = events.last().expect("no events");
  
     let (param, _changed_by, old_val, new_val): (Symbol, Address, u32, u32) =
-        last.1.into_val(&env);
+        last.2.into_val(&env);
  
     assert_eq!(param, Symbol::new(&env, "fee_bps"));
     assert_eq!(old_val, 0_u32);   // default set in initialize()
@@ -143,6 +143,7 @@ fn test_set_fee_above_max_panics() {
 
     fn create_test_env() -> (Env, Address, Address, Address) {
         let env = Env::default();
+        env.mock_all_auths();
         let admin = Address::generate(&env);
         let outcome_manager = Address::generate(&env);
         let creator = Address::generate(&env);
@@ -272,11 +273,11 @@ fn test_set_fee_above_max_panics() {
         let contract_id = env.register_contract(None, CallRegistry);
         let client = CallRegistryClient::new(&env, &contract_id);
 
-        // Setup
         client.initialize(&admin, &outcome_manager);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let stake_token = env.register_stellar_asset_contract(token_admin);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -291,8 +292,7 @@ fn test_set_fee_above_max_panics() {
             &ipfs_cid,
         );
 
-        // Mock token transfer for test
-        env.budget().reset_unlimited();
+        mint(&env, &stake_token, &staker, 100_000_000_i128);
 
         // Stake UP
         let updated_call = client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
@@ -309,11 +309,11 @@ fn test_set_fee_above_max_panics() {
         let contract_id = env.register_contract(None, CallRegistry);
         let client = CallRegistryClient::new(&env, &contract_id);
 
-        // Setup
         client.initialize(&admin, &outcome_manager);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let stake_token = env.register_stellar_asset_contract(token_admin);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -328,7 +328,7 @@ fn test_set_fee_above_max_panics() {
             &ipfs_cid,
         );
 
-        env.budget().reset_unlimited();
+        mint(&env, &stake_token, &staker, 100_000_000_i128);
 
         // Stake DOWN
         let updated_call = client.stake_on_call(&staker, &call.id, &30_000_000_i128, &2);
@@ -459,7 +459,8 @@ fn test_set_fee_above_max_panics() {
         client.initialize(&admin, &outcome_manager);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let stake_token = env.register_stellar_asset_contract(token_admin);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -474,7 +475,8 @@ fn test_set_fee_above_max_panics() {
             &ipfs_cid,
         );
 
-        env.budget().reset_unlimited();
+        mint(&env, &stake_token, &staker1, 100_000_000_i128);
+        mint(&env, &stake_token, &staker2, 100_000_000_i128);
 
         // Add stakes
         client.stake_on_call(&staker1, &call.id, &50_000_000_i128, &1);
@@ -638,7 +640,8 @@ fn test_set_fee_above_max_panics() {
         client.initialize(&admin, &outcome_manager);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let stake_token = env.register_stellar_asset_contract(token_admin);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -653,7 +656,7 @@ fn test_set_fee_above_max_panics() {
             &ipfs_cid,
         );
 
-        env.budget().reset_unlimited();
+        mint(&env, &stake_token, &staker, 100_000_000_i128);
 
         // Add stake
         client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
@@ -678,7 +681,8 @@ fn test_set_fee_above_max_panics() {
         client.initialize(&admin, &outcome_manager);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let stake_token = env.register_stellar_asset_contract(token_admin);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -693,7 +697,9 @@ fn test_set_fee_above_max_panics() {
             &ipfs_cid,
         );
 
-        env.budget().reset_unlimited();
+        mint(&env, &stake_token, &staker1, 100_000_000_i128);
+        mint(&env, &stake_token, &staker2, 100_000_000_i128);
+        mint(&env, &stake_token, &staker3, 100_000_000_i128);
 
         // Multiple stakers
         client.stake_on_call(&staker1, &call.id, &50_000_000_i128, &1);
@@ -705,5 +711,199 @@ fn test_set_fee_above_max_panics() {
         // Verify totals
         assert_eq!(call_updated.total_up_stake, 80_000_000);
         assert_eq!(call_updated.total_down_stake, 40_000_000);
+    }
+
+    // ── void lifecycle ────────────────────────────────────────────────────────
+
+    fn make_call(
+        env: &Env,
+        client: &CallRegistryClient,
+        creator: &Address,
+    ) -> (crate::types::Call, Address) {
+        let token_admin = Address::generate(env);
+        let stake_token = env.register_stellar_asset_contract(token_admin);
+        let token_address = Address::generate(env);
+        let pair_id = Bytes::from_slice(env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(env, b"QmXxxx");
+        let call = client.create_call(
+            creator,
+            &stake_token,
+            &100_000_000_i128,
+            &5000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+        (call, stake_token)
+    }
+
+    fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+        soroban_sdk::token::StellarAssetClient::new(env, token).mint(to, &amount);
+    }
+
+    #[test]
+    fn test_void_call_sets_voided_flag() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.void_call(&call.id);
+
+        let updated = client.get_call(&call.id);
+        assert!(updated.voided);
+    }
+
+    #[test]
+    fn test_void_call_emits_call_voided_event() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.void_call(&call.id);
+
+        let events = env.events().all();
+        let last = events.last().expect("no events");
+        assert_eq!(
+            last.1,
+            vec![
+                &env,
+                "call_registry".into_val(&env),
+                "call_voided".into_val(&env),
+            ]
+        );
+        let (event_call_id, _voided_by): (u64, Address) = last.2.into_val(&env);
+        assert_eq!(event_call_id, call.id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Call has been voided")]
+    fn test_void_prevents_staking() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.void_call(&call.id);
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Call has been voided")]
+    fn test_void_prevents_resolution() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.void_call(&call.id);
+        env.ledger().set_timestamp(6000);
+        client.resolve_call(&call.id, &1, &150_000_000_i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Call already voided")]
+    fn test_void_call_twice_panics() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.void_call(&call.id);
+        client.void_call(&call.id);
+    }
+
+    #[test]
+    fn test_claim_void_refund_success() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, stake_token) = make_call(&env, &client, &creator);
+
+        mint(&env, &stake_token, &staker, 200_000_000_i128);
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+        client.stake_on_call(&staker, &call.id, &20_000_000_i128, &2);
+
+        client.void_call(&call.id);
+        client.claim_void_refund(&staker, &call.id);
+    }
+
+    #[test]
+    fn test_claim_void_refund_emits_event() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, stake_token) = make_call(&env, &client, &creator);
+
+        mint(&env, &stake_token, &staker, 100_000_000_i128);
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        client.void_call(&call.id);
+        client.claim_void_refund(&staker, &call.id);
+
+        let events = env.events().all();
+        let last = events.last().expect("no events");
+        assert_eq!(
+            last.1,
+            vec![
+                &env,
+                "call_registry".into_val(&env),
+                "void_refund_claimed".into_val(&env),
+            ]
+        );
+        let (event_call_id, event_staker, amount): (u64, Address, i128) =
+            last.2.into_val(&env);
+        assert_eq!(event_call_id, call.id);
+        assert_eq!(event_staker, staker);
+        assert_eq!(amount, 50_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "Refund already claimed")]
+    fn test_double_claim_void_refund_panics() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, stake_token) = make_call(&env, &client, &creator);
+
+        mint(&env, &stake_token, &staker, 100_000_000_i128);
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        client.void_call(&call.id);
+        client.claim_void_refund(&staker, &call.id);
+        client.claim_void_refund(&staker, &call.id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Call is not voided")]
+    fn test_claim_refund_on_non_voided_call_panics() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, stake_token) = make_call(&env, &client, &creator);
+
+        mint(&env, &stake_token, &staker, 100_000_000_i128);
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        client.claim_void_refund(&staker, &call.id);
+    }
+
+    #[test]
+    #[should_panic(expected = "No stake to refund")]
+    fn test_claim_refund_with_no_stake_panics() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let non_staker = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.void_call(&call.id);
+        client.claim_void_refund(&non_staker, &call.id);
     }
 }

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -36,6 +36,8 @@ pub struct Call {
     pub end_price: i128,
     /// Whether the call has been settled
     pub settled: bool,
+    /// Whether the call has been voided by admin (triggers full refunds)
+    pub voided: bool,
     /// Creation timestamp
     pub created_at: u64,
 }


### PR DESCRIPTION
Add admin-only void mechanism so invalid markets can be cancelled and all stakers refunded in full.

- Add `voided: bool` to `Call` struct
- Add `DataKey::VoidRefundClaimed(u64, Address)` storage key with `set_void_refund_claimed` / `is_void_refund_claimed` helpers
- Add `emit_call_voided` and `emit_void_refund_claimed` events
- `void_call(env, call_id)` — admin only, callable at any time; blocks further staking and resolution once set
- `claim_void_refund(env, staker, call_id)` — refunds exact stake (up + down) to each staker; prevents double-claims via claimed flag
- Enable per-staker stake-map tracking (up_stakes / down_stakes) so refund amounts are available on-chain
- Wire `mod test` into lib.rs and fix all pre-existing test infrastructure issues (missing trait imports, events API v23 layout, missing token contract registration)
- Add 10 new tests covering the full void lifecycle

Closes #159