### PR TITLE
feat: add animated StakeDistributionBar component

### DIFF
--- a/packages/frontend/src/components/CallCard.tsx
+++ b/packages/frontend/src/components/CallCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import StakeBar from "./StakeBar";
+import StakeDistributionBar from "./StakeDistributionBar";
 import { useState, useEffect } from "react";
 
 interface CallCardProps {
@@ -88,11 +88,8 @@ export default function CallCard({ call }: CallCardProps) {
 
       {/* Progress bar */}
       <div className="mb-5">
-        <div className="flex justify-between text-[10px] font-bold text-gray-400 uppercase mb-2">
-          <span>Staking Distribution</span>
-          <span>Pool: {((call.stakes?.yes || 0) + (call.stakes?.no || 0)).toLocaleString()} USDC</span>
-        </div>
-        <StakeBar yes={call.stakes?.yes || 0} no={call.stakes?.no || 0} />
+        <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">Staking Distribution</p>
+        <StakeDistributionBar yes={call.stakes?.yes || 0} no={call.stakes?.no || 0} />
       </div>
 
       {/* Creator info */}

--- a/packages/frontend/src/components/CallDetail.tsx
+++ b/packages/frontend/src/components/CallDetail.tsx
@@ -3,7 +3,7 @@
 import ReactMarkdown from "react-markdown";
 import { useEffect, useState } from "react";
 import CallDetailHeader from "./CallDetailHeader";
-import StakeBar from "./StakeBar";
+import StakeDistributionBar from "./StakeDistributionBar";
 import ActivityLog from "./ActivityLog";
 import StakingInterface from "./StakingInterface";
 import StakingDrawer from "./StakingDrawer";
@@ -81,7 +81,7 @@ export default function CallDetail({ call }: { call: CallDetailData }) {
               <h4 className="font-bold text-gray-900 uppercase tracking-widest text-xs">Market Liquidity</h4>
               <span className="bg-gray-100 text-gray-600 text-[10px] font-bold px-2 py-1 rounded-md">LIVE POOL</span>
             </div>
-            <StakeBar yes={call.stakes.yes} no={call.stakes.no} />
+            <StakeDistributionBar yes={call.stakes.yes} no={call.stakes.no} showPool={false} />
             <div className="mt-6 flex justify-between items-end">
               <div>
                 <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1">Total Vaulted</p>

--- a/packages/frontend/src/components/StakeDistributionBar.tsx
+++ b/packages/frontend/src/components/StakeDistributionBar.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface StakeDistributionBarProps {
+  yes: number;
+  no: number;
+  showPool?: boolean;
+}
+
+export default function StakeDistributionBar({ yes, no, showPool = true }: StakeDistributionBarProps) {
+  const total = yes + no;
+  const targetYesPct = total ? Math.round((yes / total) * 100) : 50;
+  const targetNoPct = 100 - targetYesPct;
+  const isEmpty = total === 0;
+
+  const [yesPct, setYesPct] = useState(50);
+
+  useEffect(() => {
+    // Animate from 50 to target on mount / data change
+    const raf = requestAnimationFrame(() => setYesPct(targetYesPct));
+    return () => cancelAnimationFrame(raf);
+  }, [targetYesPct]);
+
+  const barBase = "h-full transition-all duration-700 ease-out";
+
+  return (
+    <div>
+      {/* Bar */}
+      <div className="flex h-3 rounded-full overflow-hidden bg-gray-100">
+        {isEmpty ? (
+          <div className="w-full bg-gray-300 rounded-full" />
+        ) : (
+          <>
+            <div
+              className={`${barBase} bg-green-500`}
+              style={{ width: `${yesPct}%` }}
+            />
+            <div
+              className={`${barBase} bg-red-500`}
+              style={{ width: `${100 - yesPct}%` }}
+            />
+          </>
+        )}
+      </div>
+
+      {/* Labels */}
+      <div className="flex justify-between text-[11px] font-semibold mt-1.5">
+        <span className={isEmpty ? "text-gray-400" : "text-green-600"}>
+          {targetYesPct}% UP
+        </span>
+        <span className={isEmpty ? "text-gray-400" : "text-red-500"}>
+          {targetNoPct}% DOWN
+        </span>
+      </div>
+
+      {/* Pool size */}
+      {showPool && (
+        <p className="text-[10px] text-gray-400 font-medium mt-0.5 text-center">
+          {isEmpty ? "No stakes yet" : `Pool: ${total.toLocaleString()} USDC`}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
 Replaces the static StakeBar with a new StakeDistributionBar that gives users a clearer, more
  visual sense of market sentiment at a glance.
  
  Changes:
  
  - StakeDistributionBar.tsx — new component with:
    - Animated green/red progress bar (CSS transition triggered on mount and data updates)
    - Percentage labels: 65% UP | 35% DOWN
    - Total pool size display (toggleable via showPool prop)
    - Edge cases: empty pool → grey 50/50 bar + "No stakes yet"; single-sided → 100% one color
  
  - CallCard.tsx — integrated StakeDistributionBar, removed redundant pool label
  - CallDetail.tsx — integrated StakeDistributionBar in the Market Liquidity panel
  (showPool=false since total is shown separately)

▸closes #235 