### PR TITLE
feat(frontend): add keyboard shortcuts and accessibility improvements

### DIFF
--- a/packages/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Fragment } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import { Keyboard, X } from "lucide-react";
+
+interface KeyboardShortcutsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModalProps) {
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" aria-hidden="true" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-3xl border border-white/10 bg-slate-950 p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <Dialog.Title className="flex items-center gap-3 text-xl font-semibold text-white">
+                      <Keyboard className="h-5 w-5 text-emerald-400" aria-hidden="true" />
+                      Keyboard Shortcuts
+                    </Dialog.Title>
+                    <Dialog.Description className="mt-1 text-sm text-slate-400">
+                      Press any of these keys to move faster around BACKit.
+                    </Dialog.Description>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close keyboard shortcuts"
+                    className="rounded-full p-2 text-slate-400 transition hover:bg-white/5 hover:text-white"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <div className="mt-6 grid gap-3 text-sm text-slate-200 sm:grid-cols-2">
+                  {[
+                    { key: "Cmd+K / Ctrl+K", description: "Open search" },
+                    { key: "?", description: "Open this shortcuts guide" },
+                    { key: "N", description: "Go to create call" },
+                    { key: "F", description: "Go to feed" },
+                    { key: "L", description: "Go to leaderboard section" },
+                    { key: "Escape", description: "Close open modals or drawers" },
+                  ].map((item) => (
+                    <div key={item.key} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                      <p className="font-semibold text-white">{item.key}</p>
+                      <p className="text-slate-400">{item.description}</p>
+                    </div>
+                  ))}
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -1,45 +1,99 @@
 "use client";
 
 import Link from "next/link";
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import { useWalletContext } from "./WalletContext";
 import { ConnectButton } from "./ConnectButton";
 import { NotificationBell } from "./NotificationBell";
-import { TrendingUp } from "lucide-react";
+import { Search, Keyboard, HelpCircle, TrendingUp } from "lucide-react";
 import { usePlatformConfig } from "@/contexts/PlatformConfigContext";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { KeyboardShortcutsModal } from "@/components/KeyboardShortcutsModal";
+import { SearchModal } from "@/components/SearchModal";
 
 export function NavBar() {
     const { publicKey } = useWalletContext();
     const { config } = usePlatformConfig();
+    const router = useRouter();
+    const [isSearchOpen, setIsSearchOpen] = useState(false);
+    const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
+
+    const handleOpenSearch = useCallback(() => setIsSearchOpen(true), []);
+    const handleOpenShortcuts = useCallback(() => setIsShortcutsOpen(true), []);
+    const handleCloseUI = useCallback(() => {
+        setIsSearchOpen(false);
+        setIsShortcutsOpen(false);
+    }, []);
+    const handleNavigateCreate = useCallback(() => router.push("/create"), [router]);
+    const handleNavigateFeed = useCallback(() => router.push("/feed"), [router]);
+    const handleNavigateLeaderboard = useCallback(() => router.push("/#leaderboard"), [router]);
+
+    useKeyboardShortcuts({
+        onOpenSearch: handleOpenSearch,
+        onOpenShortcuts: handleOpenShortcuts,
+        onNavigateCreate: handleNavigateCreate,
+        onNavigateFeed: handleNavigateFeed,
+        onNavigateLeaderboard: handleNavigateLeaderboard,
+        onCloseUI: handleCloseUI,
+    });
+
+    const handleSearch = (query: string) => {
+        if (!query.trim()) {
+            return;
+        }
+        router.push("/feed");
+    };
 
     return (
-        <nav
-            className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 md:px-12 py-4"
-            style={{
-                background: "rgba(8,11,20,0.85)",
-                backdropFilter: "blur(20px)",
-                borderBottom: "1px solid rgba(59,130,246,0.1)",
-            }}
-        >
-            <div className="flex items-center gap-2">
-                <Link href="/" className="flex items-center gap-2">
-                    <div
-                        className="w-8 h-8 rounded-lg flex items-center justify-center bg-gradient-to-br from-green-500 to-blue-500"
-                    >
-                        <TrendingUp className="w-4 h-4 text-white" />
-                    </div>
-                    <span className="font-bold text-lg tracking-tight text-white">
-                        BACK<span className="text-green-500">IT</span>
-                    </span>
-                </Link>
-            </div>
+        <>
+            <nav
+                className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 md:px-12 py-4"
+                style={{
+                    background: "rgba(8,11,20,0.85)",
+                    backdropFilter: "blur(20px)",
+                    borderBottom: "1px solid rgba(59,130,246,0.1)",
+                }}
+            >
+                <div className="flex items-center gap-2">
+                    <Link href="/" aria-label="Back to home" className="flex items-center gap-2">
+                        <div
+                            className="w-8 h-8 rounded-lg flex items-center justify-center bg-gradient-to-br from-green-500 to-blue-500"
+                        >
+                            <TrendingUp className="w-4 h-4 text-white" aria-hidden="true" />
+                        </div>
+                        <span className="font-bold text-lg tracking-tight text-white">
+                            BACK<span className="text-green-500">IT</span>
+                        </span>
+                    </Link>
+                </div>
 
-            <div className="flex items-center gap-4">
-                {config && (
-                    <div className="text-sm text-gray-300 mr-4">Fee: {config.feePercent}%</div>
-                )}
-                {publicKey && <NotificationBell userId={publicKey} />}
-                <ConnectButton />
-            </div>
-        </nav>
+                <div className="flex items-center gap-3">
+                    <button
+                        type="button"
+                        onClick={handleOpenSearch}
+                        aria-label="Open search (Cmd+K / Ctrl+K)"
+                        className="rounded-2xl border border-white/10 bg-white/5 p-2 text-slate-200 transition hover:border-white/20 hover:bg-white/10"
+                    >
+                        <Search className="h-5 w-5" aria-hidden="true" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleOpenShortcuts}
+                        aria-label="Show keyboard shortcuts"
+                        className="rounded-2xl border border-white/10 bg-white/5 p-2 text-slate-200 transition hover:border-white/20 hover:bg-white/10"
+                    >
+                        <Keyboard className="h-5 w-5" aria-hidden="true" />
+                    </button>
+                    {config && (
+                        <div className="text-sm text-gray-300 mr-4">Fee: {config.feePercent}%</div>
+                    )}
+                    {publicKey && <NotificationBell userId={publicKey} />}
+                    <ConnectButton />
+                </div>
+            </nav>
+            <SearchModal open={isSearchOpen} onClose={handleCloseUI} onSearch={handleSearch} />
+            <KeyboardShortcutsModal open={isShortcutsOpen} onClose={handleCloseUI} />
+        </>
     );
 }

--- a/packages/frontend/src/components/ProfileEditor.tsx
+++ b/packages/frontend/src/components/ProfileEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, Fragment } from "react";
+import { Dialog, Transition } from "@headlessui/react";
 import { useWalletContext } from "./WalletContext";
 import { Check, Loader2, X, User, FileText } from "lucide-react";
 
@@ -12,6 +13,7 @@ interface ProfileEditorProps {
 
 export function ProfileEditor({ inline = false, onClose }: ProfileEditorProps) {
   const { profile, saveStatus, saveProfile, publicKey } = useWalletContext();
+  const displayNameRef = useRef<HTMLInputElement | null>(null);
 
   const [displayName, setDisplayName] = useState("");
   const [bio, setBio] = useState("");
@@ -92,6 +94,7 @@ export function ProfileEditor({ inline = false, onClose }: ProfileEditorProps) {
             <button
               onClick={onClose}
               className="ml-2 p-1.5 rounded-lg hover:bg-white/5 transition-colors text-gray-500 hover:text-white"
+              aria-label="Close profile editor"
             >
               <X className="w-4 h-4" />
             </button>
@@ -101,12 +104,14 @@ export function ProfileEditor({ inline = false, onClose }: ProfileEditorProps) {
 
       {/* Display Name */}
       <div className="mb-4">
-        <label className="flex items-center gap-1.5 text-xs text-gray-400 mb-2">
-          <User className="w-3.5 h-3.5" />
+        <label className="flex items-center gap-1.5 text-xs text-gray-400 mb-2" htmlFor="profile-display-name">
+          <User className="w-3.5 h-3.5" aria-hidden="true" />
           Display Name
           <span className="ml-auto text-gray-600">{displayName.length}/40</span>
         </label>
         <input
+          id="profile-display-name"
+          ref={displayNameRef}
           type="text"
           value={displayName}
           maxLength={40}
@@ -131,12 +136,13 @@ export function ProfileEditor({ inline = false, onClose }: ProfileEditorProps) {
 
       {/* Bio */}
       <div className="mb-6">
-        <label className="flex items-center gap-1.5 text-xs text-gray-400 mb-2">
-          <FileText className="w-3.5 h-3.5" />
+        <label className="flex items-center gap-1.5 text-xs text-gray-400 mb-2" htmlFor="profile-bio">
+          <FileText className="w-3.5 h-3.5" aria-hidden="true" />
           Bio
           <span className="ml-auto text-gray-600">{bio.length}/160</span>
         </label>
         <textarea
+          id="profile-bio"
           value={bio}
           maxLength={160}
           rows={3}
@@ -175,6 +181,7 @@ export function ProfileEditor({ inline = false, onClose }: ProfileEditorProps) {
           cursor:
             isDirty && saveStatus !== "saving" ? "pointer" : "not-allowed",
         }}
+        aria-label="Save profile"
       >
         {saveStatus === "saving" ? "Saving…" : "Save Profile"}
       </button>
@@ -183,18 +190,48 @@ export function ProfileEditor({ inline = false, onClose }: ProfileEditorProps) {
 
   if (inline) return panel;
 
-  // Modal wrapper
+  const handleDialogClose = (value: boolean) => {
+    if (onClose) onClose();
+  };
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      style={{ background: "rgba(0,0,0,0.7)", backdropFilter: "blur(8px)" }}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose?.();
-      }}
-    >
-      <div className="w-full max-w-md" onClick={(e) => e.stopPropagation()}>
-        {panel}
-      </div>
-    </div>
+    <Transition.Root appear show={true} as={Fragment}>
+      <Dialog
+        as="div"
+        className="relative z-50"
+        onClose={handleDialogClose}
+        initialFocus={displayNameRef}
+      >
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/70 backdrop-blur-sm" aria-hidden="true" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-3xl text-left align-middle transition-all">
+                {panel}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
   );
 }

--- a/packages/frontend/src/components/SearchModal.tsx
+++ b/packages/frontend/src/components/SearchModal.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Fragment, FormEvent, useEffect, useRef, useState } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import { Search, X } from "lucide-react";
+
+interface SearchModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSearch: (query: string) => void;
+}
+
+export function SearchModal({ open, onClose, onSearch }: SearchModalProps) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+    }
+  }, [open]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (query.trim()) {
+      onSearch(query.trim());
+    }
+    onClose();
+  };
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog
+        as="div"
+        className="relative z-50"
+        onClose={onClose}
+        initialFocus={inputRef}
+      >
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" aria-hidden="true" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-xl transform overflow-hidden rounded-3xl border border-white/10 bg-slate-950 p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-center justify-between gap-4 mb-4">
+                  <div>
+                    <Dialog.Title className="text-xl font-semibold text-white">
+                      Search BACKit
+                    </Dialog.Title>
+                    <Dialog.Description className="text-sm text-slate-400">
+                      Quickly navigate with Cmd+K / Ctrl+K.
+                    </Dialog.Description>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close search"
+                    className="rounded-full p-2 text-slate-400 transition hover:bg-white/5 hover:text-white"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <label htmlFor="search-input" className="sr-only">
+                    Search query
+                  </label>
+                  <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-slate-900 px-4 py-3">
+                    <Search className="h-5 w-5 text-slate-400" aria-hidden="true" />
+                    <input
+                      id="search-input"
+                      ref={inputRef}
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                      placeholder="Search calls, users and tokens"
+                      className="w-full bg-transparent text-white outline-none placeholder:text-slate-500"
+                      aria-label="Search calls, users, and tokens"
+                      autoComplete="off"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-white/20 hover:bg-white/10"
+                      aria-label="Cancel search"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      className="rounded-2xl bg-gradient-to-r from-emerald-500 to-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:opacity-95"
+                      aria-label="Submit search"
+                    >
+                      Search
+                    </button>
+                  </div>
+                </form>
+
+                <div className="mt-5 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-400">
+                  <p className="font-semibold text-slate-200">Tip</p>
+                  <p>Use <span className="font-semibold">? </span>to open the keyboard shortcuts guide.</p>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/packages/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect } from "react";
+
+export interface KeyboardShortcutActions {
+  onOpenSearch: () => void;
+  onOpenShortcuts: () => void;
+  onNavigateCreate: () => void;
+  onNavigateFeed: () => void;
+  onNavigateLeaderboard: () => void;
+  onCloseUI: () => void;
+}
+
+function isTextInput(target: EventTarget | null) {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  );
+}
+
+export function useKeyboardShortcuts(actions: KeyboardShortcutActions) {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const key = event.key;
+
+      if (key === "Escape") {
+        event.preventDefault();
+        actions.onCloseUI();
+        window.dispatchEvent(new Event("closeAllUI"));
+        return;
+      }
+
+      if (isTextInput(target)) {
+        return;
+      }
+
+      if ((event.metaKey || event.ctrlKey) && key.toLowerCase() === "k") {
+        event.preventDefault();
+        actions.onOpenSearch();
+        return;
+      }
+
+      if (key === "?") {
+        event.preventDefault();
+        actions.onOpenShortcuts();
+        return;
+      }
+
+      if (key.toLowerCase() === "n") {
+        event.preventDefault();
+        actions.onNavigateCreate();
+        return;
+      }
+
+      if (key.toLowerCase() === "f") {
+        event.preventDefault();
+        actions.onNavigateFeed();
+        return;
+      }
+
+      if (key.toLowerCase() === "l") {
+        event.preventDefault();
+        actions.onNavigateLeaderboard();
+        return;
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [actions]);
+}


### PR DESCRIPTION
closes #237 
## Summary
Closes #237 
This PR adds global keyboard shortcuts and accessibility improvements to the frontend.

### What changed
- Added `useKeyboardShortcuts` hook to centralize shortcut handling.
- Integrated keyboard support into the global `NavBar` component.
- Added a searchable modal overlay triggered by `Cmd+K / Ctrl+K`.
- Added a keyboard shortcuts help modal triggered by `?`.
- Updated `ProfileEditor` to use `@headlessui/react` dialog for focus trapping and better modal accessibility.
- Added `aria-label`s to new interactive controls for screen reader support.

### Keyboard shortcuts
- `Cmd+K / Ctrl+K` — open search
- `N` — navigate to create call
- `F` — navigate to feed
- `L` — navigate to leaderboard section
- `Escape` — close modals/drawers
- `?` — open keyboard shortcuts modal

### Verification
- `pnpm install --frozen-lockfile`
- `pnpm type-check`
- `pnpm build`

### Notes
- Search modal currently routes to `/feed` on submission.
- Leaderboard shortcut targets the homepage leaderboard anchor.