### PR TITLE
feat: implement staking activity feed on market detail page (#221)

### DIFF
--- a/packages/frontend/src/app/api/calls/[id]/stakes/recent/route.ts
+++ b/packages/frontend/src/app/api/calls/[id]/stakes/recent/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Mock recent stakes per call — in production, query the DB ordered by timestamp DESC LIMIT 50
+const mockStakes: Record<string, any[]> = {
+  "1": [
+    { address: "GB7DR76FZ2Z3Y5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "YES", amount: "500", timestamp: new Date(Date.now() - 2 * 60000).toISOString(), txHash: "0xabc123def456ghi789" },
+    { address: "GC8ES87GZ3Z4Y5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "NO",  amount: "250", timestamp: new Date(Date.now() - 7 * 60000).toISOString(), txHash: "0xdef456ghi789jkl012" },
+    { address: "GD9FT98HZ4Z5Y5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "YES", amount: "1000", timestamp: new Date(Date.now() - 15 * 60000).toISOString(), txHash: "0xghi789jkl012mno345" },
+  ],
+  "2": [
+    { address: "GE0GU10HZ5Z6Y5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "YES", amount: "1000", timestamp: new Date(Date.now() - 3 * 60000).toISOString(), txHash: "0xghi789jkl012mno345" },
+    { address: "GF1HV21IZ6Z7Y5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "NO",  amount: "500",  timestamp: new Date(Date.now() - 20 * 60000).toISOString(), txHash: "0xjkl012mno345pqr678" },
+  ],
+  "3": [
+    { address: "GG2JW32JZ7Z8Y5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "YES", amount: "750", timestamp: new Date(Date.now() - 1 * 60000).toISOString(), txHash: "0xmno345pqr678stu901" },
+    { address: "GH3KX43KZ8Z9Y5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "NO",  amount: "300", timestamp: new Date(Date.now() - 5 * 60000).toISOString(), txHash: "0xpqr678stu901vwx234" },
+    { address: "GI4LY54LZ9ZAY5YKZ7XQYBZQZQZQZQZQZQZQZQZQZQZQZQZQZQZQ", side: "YES", amount: "425", timestamp: new Date(Date.now() - 30 * 60000).toISOString(), txHash: "0xstu901vwx234yz567" },
+  ],
+};
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const stakes = (mockStakes[id] ?? []).slice(0, 50);
+  return NextResponse.json(stakes);
+}

--- a/packages/frontend/src/components/ActivityLog.tsx
+++ b/packages/frontend/src/components/ActivityLog.tsx
@@ -1,7 +1,20 @@
 "use client";
 
 import { Participant } from "@/types";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+const PAGE_SIZE = 10;
+const POLL_INTERVAL = 15_000;
+
+function timeAgo(timestamp: string) {
+  const s = Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
 
 interface Props {
   participants: Participant[];
@@ -9,84 +22,108 @@ interface Props {
 }
 
 export default function ActivityLog({ participants, callId }: Props) {
-  const [activities, setActivities] = useState(participants);
-  
-  // Simulate real-time updates (replace with WebSocket in production)
+  const [entries, setEntries] = useState<Participant[]>(participants.slice(0, 50));
+  const [visible, setVisible] = useState(PAGE_SIZE);
+  const [newIds, setNewIds] = useState<Set<string>>(new Set());
+  const prevTxHashes = useRef<Set<string>>(new Set(participants.map(p => p.txHash)));
+
   useEffect(() => {
-    const interval = setInterval(async () => {
+    const poll = setInterval(async () => {
       try {
         const res = await fetch(`/api/calls/${callId}/stakes/recent`);
-        const newStakes = await res.json();
-        if (newStakes.length > 0) {
-          setActivities(prev => [...newStakes, ...prev].slice(0, 20));
-        }
-      } catch (error) {
-        console.error('Failed to fetch recent stakes:', error);
-      }
-    }, 10000); // Poll every 10 seconds
-    
-    return () => clearInterval(interval);
-  }, [callId]);
+        if (!res.ok) return;
+        const fresh: Participant[] = await res.json();
+        const incoming = fresh.filter(p => !prevTxHashes.current.has(p.txHash));
+        if (incoming.length === 0) return;
 
-  const formatTimeAgo = (timestamp: string) => {
-    const seconds = Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000);
-    if (seconds < 60) return `${seconds}s ago`;
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    return new Date(timestamp).toLocaleDateString();
-  };
+        incoming.forEach(p => prevTxHashes.current.add(p.txHash));
+        setNewIds(new Set(incoming.map(p => p.txHash)));
+        setEntries(prev => [...incoming, ...prev].slice(0, 50));
+
+        // Clear slide-in highlight after animation completes
+        setTimeout(() => setNewIds(new Set()), 600);
+      } catch {
+        // silently ignore poll errors
+      }
+    }, POLL_INTERVAL);
+
+    return () => clearInterval(poll);
+  }, [callId]);
 
   return (
     <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50">
-        <h3 className="font-semibold text-gray-900">Activity Log</h3>
-        <p className="text-xs text-gray-500">Recent stakes and transactions</p>
-      </div>
-      
-      <div className="divide-y divide-gray-100 max-h-[400px] overflow-y-auto">
-        {activities.length === 0 ? (
-          <p className="p-4 text-center text-gray-500">No activity yet</p>
-        ) : (
-          activities.map((activity, index) => (
-            <div key={`${activity.txHash}-${index}`} className="p-4 hover:bg-gray-50 transition">
-              <div className="flex justify-between items-start">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm font-medium">
-                      {activity.address.slice(0, 6)}...{activity.address.slice(-4)}
-                    </span>
-                    <span className={`text-xs px-2 py-0.5 rounded-full ${
-                      activity.side === 'YES' 
-                        ? 'bg-green-100 text-green-700' 
-                        : 'bg-red-100 text-red-700'
-                    }`}>
-                      {activity.side}
-                    </span>
-                  </div>
-                  <p className="text-sm mt-1">
-                    <span className="font-medium">{activity.amount} USDC</span>
-                  </p>
-                </div>
-                <div className="text-right">
-                  <div className="text-xs text-gray-500">
-                    {formatTimeAgo(activity.timestamp)}
-                  </div>
-                  <a 
-                    href={`https://stellar.expert/explorer/testnet/tx/${activity.txHash}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs text-blue-500 hover:text-blue-700 mt-1 inline-block"
-                  >
-                    View tx ↗
-                  </a>
-                </div>
-              </div>
-            </div>
-          ))
+      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+        <div>
+          <h3 className="font-semibold text-gray-900">Activity</h3>
+          <p className="text-xs text-gray-500">Recent stakes</p>
+        </div>
+        {entries.length > 0 && (
+          <span className="text-xs text-gray-400">{entries.length} entries</span>
         )}
       </div>
+
+      <style>{`
+        @keyframes slideIn {
+          from { opacity: 0; transform: translateY(-8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .slide-in { animation: slideIn 0.35s ease-out; }
+      `}</style>
+
+      <div className="divide-y divide-gray-100 max-h-[420px] overflow-y-auto">
+        {entries.length === 0 ? (
+          <div className="py-12 text-center text-gray-400">
+            <p className="text-2xl mb-2">📭</p>
+            <p className="text-sm">No activity yet. Be the first to stake!</p>
+          </div>
+        ) : (
+          entries.slice(0, visible).map((entry, i) => {
+            const isUp = entry.side === "YES";
+            return (
+              <div
+                key={`${entry.txHash}-${i}`}
+                className={`px-4 py-3 hover:bg-gray-50 transition-colors ${newIds.has(entry.txHash) ? "slide-in" : ""}`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    {/* Avatar placeholder */}
+                    <div className="w-7 h-7 rounded-full bg-gray-200 flex-shrink-0 flex items-center justify-center text-[10px] font-bold text-gray-500">
+                      {entry.address.slice(0, 2).toUpperCase()}
+                    </div>
+                    <span className="font-mono text-xs text-gray-700 truncate">
+                      {entry.address.slice(0, 6)}…{entry.address.slice(-4)}
+                    </span>
+                    <span className={`flex-shrink-0 text-xs font-bold px-2 py-0.5 rounded-full ${
+                      isUp
+                        ? "bg-green-100 text-green-700"
+                        : "bg-red-100 text-red-700"
+                    }`}>
+                      {isUp ? "▲ UP" : "▼ DOWN"}
+                    </span>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <p className={`text-sm font-semibold ${isUp ? "text-green-600" : "text-red-600"}`}>
+                      {entry.amount} USDC
+                    </p>
+                    <p className="text-[10px] text-gray-400">{timeAgo(entry.timestamp)}</p>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {visible < entries.length && (
+        <div className="px-4 py-3 border-t border-gray-100 text-center">
+          <button
+            onClick={() => setVisible(v => Math.min(v + PAGE_SIZE, entries.length))}
+            className="text-sm text-indigo-600 hover:text-indigo-800 font-medium transition-colors"
+          >
+            Load more ({entries.length - visible} remaining)
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What
  Implements a live staking activity feed on the market detail page, giving users visibility into
  recent stakes and market momentum.
  
  ## Changes
  - **`ActivityLog.tsx`** — rewritten to meet all acceptance criteria:
    - Displays staker address (truncated), UP ▲ / DOWN ▼ side with green/red color, amount, and
  relative timestamp ("2m ago")
    - Polls `/api/calls/[id]/stakes/recent` every 15s; new entries slide in from the top
    - Deduplicates by `txHash` to prevent duplicate entries on poll
    - Capped at 50 entries with a "Load More" button (10 at a time)
    - Empty state when no activity exists yet
  
  - **`src/app/api/calls/[id]/stakes/recent/route.ts`** — new API route returning up to 50 recent
  stakes for a call (mock data; swap for DB query when backend is wired up)
  
  ## Not changed
  `CallDetail.tsx` and `calls/[id]/page.tsx` required no modifications — the component was
  already integrated correctly.
  
  ## Notes
  - `side` remains `'YES' | 'NO'` in the data layer; UP/DOWN is display-only labeling
  - The mock API route uses fresh relative timestamps so the feed looks live during development
  

Closes #221 