### PR TITLE
feat: implement user social graph follow system

### DIFF
--- a/packages/backend/src/database/migrations/1760000000000-CreateFollowsTable.ts
+++ b/packages/backend/src/database/migrations/1760000000000-CreateFollowsTable.ts
@@ -1,0 +1,79 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateFollowsTable1760000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'follows',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'followerAddress', type: 'varchar', length: '64' },
+          { name: 'followingAddress', type: 'varchar', length: '64' },
+          { name: 'createdAt', type: 'timestamp', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'follows',
+      new TableIndex({
+        name: 'IDX_follows_followerAddress',
+        columnNames: ['followerAddress'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'follows',
+      new TableIndex({
+        name: 'IDX_follows_followingAddress',
+        columnNames: ['followingAddress'],
+      }),
+    );
+
+    await queryRunner.query(
+      'CREATE UNIQUE INDEX "UQ_follows_follower_following" ON "follows" ("followerAddress", "followingAddress")',
+    );
+
+    await queryRunner.createForeignKey(
+      'follows',
+      new TableForeignKey({
+        columnNames: ['followerAddress'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['walletAddress'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'follows',
+      new TableForeignKey({
+        columnNames: ['followingAddress'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['walletAddress'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "UQ_follows_follower_following"',
+    );
+    await queryRunner.dropIndex('follows', 'IDX_follows_followerAddress');
+    await queryRunner.dropIndex('follows', 'IDX_follows_followingAddress');
+    await queryRunner.dropTable('follows', true);
+  }
+}

--- a/packages/backend/src/user/entities/follow.entity.ts
+++ b/packages/backend/src/user/entities/follow.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+} from 'typeorm';
+import { Users } from './users.entity';
+
+@Entity('follows')
+@Unique('UQ_follows_follower_following', [
+  'followerAddress',
+  'followingAddress',
+])
+export class Follow {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  followerAddress: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  followingAddress: string;
+
+  @ManyToOne(() => Users, { onDelete: 'CASCADE' })
+  @JoinColumn({
+    name: 'followerAddress',
+    referencedColumnName: 'walletAddress',
+  })
+  follower: Users;
+
+  @ManyToOne(() => Users, { onDelete: 'CASCADE' })
+  @JoinColumn({
+    name: 'followingAddress',
+    referencedColumnName: 'walletAddress',
+  })
+  following: Users;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/user/entities/users.entity.ts
+++ b/packages/backend/src/user/entities/users.entity.ts
@@ -4,11 +4,13 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
+  ManyToOne,
   ManyToMany,
   JoinTable,
-  ManyToOne,
 } from 'typeorm';
 import { Badge } from './badge.entity';
+import { Follow } from './follow.entity';
 
 @Entity('users')
 export class Users {
@@ -27,17 +29,11 @@ export class Users {
   @ManyToOne(() => Users, { nullable: true, onDelete: 'SET NULL' })
   referredBy: Users | null;
 
-  // ─── social graph ──────────────────────────────────────────────────────
-  @ManyToMany(() => Users, (user) => user.followers)
-  @JoinTable({
-    name: 'user_follows',
-    joinColumn: { name: 'followerId' },
-    inverseJoinColumn: { name: 'followingId' },
-  })
-  following: Users[];
+  @OneToMany(() => Follow, (follow) => follow.follower)
+  following: Follow[];
 
-  @ManyToMany(() => Users, (user) => user.following)
-  followers: Users[];
+  @OneToMany(() => Follow, (follow) => follow.following)
+  followers: Follow[];
 
   // ─── badges ────────────────────────────────────────────────────────────
   @ManyToMany(() => Badge, (badge) => badge.users, { eager: false })

--- a/packages/backend/src/user/users.controller.ts
+++ b/packages/backend/src/user/users.controller.ts
@@ -8,6 +8,9 @@ import {
   HttpStatus,
   ValidationPipe,
   UsePipes,
+  Query,
+  DefaultValuePipe,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { UsersService } from './users.service';
@@ -25,10 +28,8 @@ export class UsersController {
   @ApiOperation({ summary: 'Follow a user' })
   @ApiParam({ name: 'address', description: 'Address of the user to follow' })
   @ApiResponse({ status: 200, description: 'User followed successfully.' })
-  @ApiResponse({
-    status: 400,
-    description: 'Invalid request or already following.',
-  })
+  @ApiResponse({ status: 400, description: 'Invalid request.' })
+  @ApiResponse({ status: 409, description: 'Already following.' })
   @UsePipes(new ValidationPipe({ whitelist: true }))
   async follow(
     @Param('address') address: string,
@@ -61,8 +62,12 @@ export class UsersController {
     status: 200,
     description: 'Successfully retrieved followers.',
   })
-  async getFollowers(@Param('address') address: string) {
-    return this.usersService.getFollowers(address);
+  async getFollowers(
+    @Param('address') address: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.usersService.getFollowers(address, page, limit);
   }
 
   @Get(':address/following')
@@ -72,8 +77,12 @@ export class UsersController {
     status: 200,
     description: 'Successfully retrieved following list.',
   })
-  async getFollowing(@Param('address') address: string) {
-    return this.usersService.getFollowing(address);
+  async getFollowing(
+    @Param('address') address: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.usersService.getFollowing(address, page, limit);
   }
 
   // ─── NEW: profile with badges ─────────────────────────────────────────────

--- a/packages/backend/src/user/users.module.ts
+++ b/packages/backend/src/user/users.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Users } from './entities/users.entity';
 import { Badge } from './entities/badge.entity';
+import { Follow } from './entities/follow.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Users, Badge]), AnalyticsModule],
+  imports: [TypeOrmModule.forFeature([Users, Badge, Follow]), AnalyticsModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/packages/backend/src/user/users.service.spec.ts
+++ b/packages/backend/src/user/users.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { UsersService } from './users.service';
+import { Users } from './entities/users.entity';
+import { Follow } from './entities/follow.entity';
+import { AnalyticsService } from '../analytics/analytics.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  const usersRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const followsRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    findAndCount: jest.fn(),
+    remove: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const analyticsService = {
+    calculatePredictorReliability: jest.fn().mockResolvedValue(0.5),
+  };
+
+  const cacheManager = {
+    del: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getRepositoryToken(Users), useValue: usersRepo },
+        { provide: getRepositoryToken(Follow), useValue: followsRepo },
+        { provide: AnalyticsService, useValue: analyticsService },
+        { provide: CACHE_MANAGER, useValue: cacheManager },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('prevents self-follow', async () => {
+    await expect(service.follow('A', 'A')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('throws 409 for duplicate follow', async () => {
+    usersRepo.findOne.mockResolvedValue({ id: 'u1', walletAddress: 'A' });
+    followsRepo.findOne.mockResolvedValue({ id: 'f1' });
+
+    await expect(service.follow('A', 'B')).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it('creates a new follow relation', async () => {
+    usersRepo.findOne
+      .mockResolvedValueOnce({ id: 'u1', walletAddress: 'A' })
+      .mockResolvedValueOnce({ id: 'u2', walletAddress: 'B' });
+    followsRepo.findOne.mockResolvedValue(null);
+    followsRepo.create.mockReturnValue({
+      followerAddress: 'A',
+      followingAddress: 'B',
+    });
+    followsRepo.save.mockResolvedValue({
+      id: 'f1',
+      followerAddress: 'A',
+      followingAddress: 'B',
+    });
+
+    const result = await service.follow('A', 'B');
+    expect(result.id).toBe('f1');
+  });
+
+  it('returns paginated followers', async () => {
+    followsRepo.findAndCount.mockResolvedValue([[{ id: 'f1' }], 1]);
+    const result = await service.getFollowers('B', 2, 10);
+    expect(result).toEqual({
+      data: [{ id: 'f1' }],
+      total: 1,
+      page: 2,
+      limit: 10,
+    });
+  });
+});

--- a/packages/backend/src/user/users.service.ts
+++ b/packages/backend/src/user/users.service.ts
@@ -1,22 +1,26 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { Users } from './entities/users.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { AnalyticsService } from 'src/analytics/analytics.service';
+import { AnalyticsService } from '../analytics/analytics.service';
 import { RegisterDto } from './dto/register.dto';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { Inject } from '@nestjs/common';
+import { Follow } from './entities/follow.entity';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(Users)
     private readonly usersRepo: Repository<Users>,
+    @InjectRepository(Follow)
+    private readonly followsRepo: Repository<Follow>,
     private readonly analyticsService: AnalyticsService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
@@ -42,47 +46,33 @@ export class UsersService {
       throw new BadRequestException('You cannot follow yourself');
     }
 
-    const follower = await this.findOrCreateByAddress(followerAddress);
-    const following = await this.findOrCreateByAddress(followingAddress);
+    await this.findOrCreateByAddress(followerAddress);
+    await this.findOrCreateByAddress(followingAddress);
 
-    const loadedFollower = await this.usersRepo.findOne({
-      where: { id: follower.id },
-      relations: ['following'],
+    const existing = await this.followsRepo.findOne({
+      where: { followerAddress, followingAddress },
     });
-
-    if (!loadedFollower) {
-      throw new BadRequestException('Follower user not found');
+    if (existing) {
+      throw new ConflictException('Already following this user');
     }
 
-    if (loadedFollower.following.some((u) => u.id === following.id)) {
-      throw new BadRequestException('Already following this user');
-    }
-
-    loadedFollower.following.push(following);
-    const result = await this.usersRepo.save(loadedFollower);
+    const result = await this.followsRepo.save(
+      this.followsRepo.create({ followerAddress, followingAddress }),
+    );
     await this.invalidateUserProfile(followerAddress);
     await this.invalidateUserProfile(followingAddress);
     return result;
   }
 
   async unfollow(followerAddress: string, followingAddress: string) {
-    const follower = await this.usersRepo.findOne({
-      where: { walletAddress: followerAddress },
-      relations: ['following'],
+    const follow = await this.followsRepo.findOne({
+      where: { followerAddress, followingAddress },
     });
+    if (!follow) {
+      throw new BadRequestException('Not following this user');
+    }
 
-    if (!follower) throw new BadRequestException('Follower user not found');
-
-    const following = await this.usersRepo.findOne({
-      where: { walletAddress: followingAddress },
-    });
-
-    if (!following) throw new BadRequestException('User to unfollow not found');
-
-    follower.following = follower.following.filter(
-      (u) => u.id !== following.id,
-    );
-    const result = await this.usersRepo.save(follower);
+    const result = await this.followsRepo.remove(follow);
     await this.invalidateUserProfile(followerAddress);
     await this.invalidateUserProfile(followingAddress);
     return result;
@@ -95,20 +85,26 @@ export class UsersService {
     }
   }
 
-  async getFollowers(address: string) {
-    const user = await this.usersRepo.findOne({
-      where: { walletAddress: address },
-      relations: ['followers'],
+  async getFollowers(address: string, page = 1, limit = 20) {
+    const [data, total] = await this.followsRepo.findAndCount({
+      where: { followingAddress: address },
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
     });
-    return user?.followers ?? [];
+
+    return { data, total, page, limit };
   }
 
-  async getFollowing(address: string) {
-    const user = await this.usersRepo.findOne({
-      where: { walletAddress: address },
-      relations: ['following'],
+  async getFollowing(address: string, page = 1, limit = 20) {
+    const [data, total] = await this.followsRepo.findAndCount({
+      where: { followerAddress: address },
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
     });
-    return user?.following ?? [];
+
+    return { data, total, page, limit };
   }
 
   async register(registerDto: RegisterDto) {
@@ -159,10 +155,16 @@ export class UsersService {
 
     const reliability =
       await this.analyticsService.calculatePredictorReliability(user.id);
+    const [followerCount, followingCount] = await Promise.all([
+      this.followsRepo.count({ where: { followingAddress: walletAddress } }),
+      this.followsRepo.count({ where: { followerAddress: walletAddress } }),
+    ]);
 
     return {
       ...user,
       predictorReliability: reliability,
+      followerCount,
+      followingCount,
     };
   }
 }


### PR DESCRIPTION
Closes #177

## Summary
- add explicit `follows` join entity/table with follower and following wallet addresses
- implement follow and unfollow service logic with self-follow prevention and duplicate follow conflict handling
- add paginated followers/following endpoints and include follower/following counts in profile response
- add migration to create follows table and indexes
- add unit tests for social graph service edge cases

## Validation
- `pnpm --dir packages/backend test -- --watchman=false users.service.spec.ts`
- `pnpm --dir packages/backend build`
- `pnpm --dir packages/backend lint` (fails due to existing repo-wide lint violations unrelated to this change)