### PR TITLE
feat: implement following feed endpoint

### DIFF
--- a/packages/backend/src/calls/calls.controller.ts
+++ b/packages/backend/src/calls/calls.controller.ts
@@ -30,6 +30,14 @@ export class CallsController {
     return this.callsService.getFeed(query);
   }
 
+  @Get('feed/following')
+  getFollowingFeed(
+    @Query('address') address: string,
+    @Query() query: QueryCallsDto,
+  ) {
+    return this.callsService.getFollowingFeed(address, query);
+  }
+
   @Get('search')
   search(@Query() query: QueryCallsDto) {
     return this.callsService.search(query);

--- a/packages/backend/src/calls/calls.repository.ts
+++ b/packages/backend/src/calls/calls.repository.ts
@@ -30,6 +30,28 @@ export class CallsRepository extends Repository<Call> {
       .getManyAndCount();
   }
 
+  async findFeedByFollowing(
+    address: string,
+    page: number,
+    limit: number,
+  ): Promise<[Call[], number]> {
+    return this.visibleQuery()
+      .andWhere(
+        `call.creatorAddress IN (
+          SELECT u_following.walletAddress
+          FROM users u_follower
+          JOIN user_follows uf ON uf."followerId" = u_follower.id
+          JOIN users u_following ON u_following.id = uf."followingId"
+          WHERE u_follower.walletAddress = :address
+        )`,
+        { address },
+      )
+      .orderBy('call.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+  }
+
   async searchVisible(
     search: string,
     page: number,

--- a/packages/backend/src/calls/calls.service.spec.ts
+++ b/packages/backend/src/calls/calls.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CallsService } from './calls.service';
+import { CallsRepository } from './calls.repository';
+import { CallReport } from './entities/call-report.entity';
+import { OracleService } from '../oracle/oracle.service';
+
+describe('CallsService', () => {
+  let service: CallsService;
+
+  const callsRepository = {
+    findFeedByFollowing: jest.fn(),
+  };
+
+  const callReportRepository = {};
+  const oracleService = {};
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CallsService,
+        { provide: CallsRepository, useValue: callsRepository },
+        { provide: getRepositoryToken(CallReport), useValue: callReportRepository },
+        { provide: OracleService, useValue: oracleService },
+      ],
+    }).compile();
+
+    service = module.get<CallsService>(CallsService);
+  });
+
+  it('returns following feed with pagination', async () => {
+    callsRepository.findFeedByFollowing.mockResolvedValue([[{ id: 'c1' }], 1]);
+
+    const result = await service.getFollowingFeed('GA123', { page: 2, limit: 5 });
+
+    expect(callsRepository.findFeedByFollowing).toHaveBeenCalledWith(
+      'GA123',
+      2,
+      5,
+    );
+    expect(result).toEqual({
+      data: [{ id: 'c1' }],
+      total: 1,
+      page: 2,
+      limit: 5,
+    });
+  });
+
+  it('returns empty list when user follows nobody', async () => {
+    callsRepository.findFeedByFollowing.mockResolvedValue([[], 0]);
+
+    const result = await service.getFollowingFeed('GA999', {});
+
+    expect(result.data).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+});

--- a/packages/backend/src/calls/calls.service.ts
+++ b/packages/backend/src/calls/calls.service.ts
@@ -43,6 +43,19 @@ export class CallsService {
     return { data, total, page, limit };
   }
 
+  async getFollowingFeed(
+    address: string,
+    query: QueryCallsDto,
+  ): Promise<{ data: Call[]; total: number; page: number; limit: number }> {
+    const { page = 1, limit = 20 } = query;
+    const [data, total] = await this.callsRepository.findFeedByFollowing(
+      address,
+      page,
+      limit,
+    );
+    return { data, total, page, limit };
+  }
+
   // ─── Single Call Lookup ───────────────────────────────────────────────────
 
   async getCallOrThrow(id: string): Promise<Call> {


### PR DESCRIPTION
Closes #178

## Summary
- add `GET /calls/feed/following?address=<stellar_address>` endpoint
- query calls created by users followed by the requester
- support pagination with existing `page` and `limit` query params
- preserve descending chronological sort by `createdAt`
- return empty array + zero total when no followed creators have calls
- add focused unit tests for following feed behavior

## Validation
- `pnpm --dir packages/backend test -- --watchman=false calls.service.spec.ts`
- `pnpm --dir packages/backend build`
- `pnpm --dir packages/backend lint` is currently failing repo-wide due to pre-existing unrelated violations