### PR TITLE
feat: add PostgreSQL full-text search with tsvector

### DIFF
--- a/packages/backend/src/database/migrations/1760000001000-AddCallsSearchVector.ts
+++ b/packages/backend/src/database/migrations/1760000001000-AddCallsSearchVector.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCallsSearchVector1760000001000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "calls"
+      ADD COLUMN IF NOT EXISTS "searchVector" tsvector
+    `);
+
+    await queryRunner.query(`
+      UPDATE "calls"
+      SET "searchVector" =
+        to_tsvector(
+          'simple',
+          COALESCE("title", '') || ' ' ||
+          COALESCE("thesis", '') || ' ' ||
+          COALESCE("pairId", '')
+        )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_calls_search_vector"
+      ON "calls" USING GIN ("searchVector")
+    `);
+
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION calls_search_vector_update()
+      RETURNS trigger AS $$
+      BEGIN
+        NEW."searchVector" :=
+          to_tsvector(
+            'simple',
+            COALESCE(NEW."title", '') || ' ' ||
+            COALESCE(NEW."thesis", '') || ' ' ||
+            COALESCE(NEW."pairId", '')
+          );
+        RETURN NEW;
+      END
+      $$ LANGUAGE plpgsql
+    `);
+
+    await queryRunner.query(`
+      DROP TRIGGER IF EXISTS trg_calls_search_vector_update ON "calls"
+    `);
+
+    await queryRunner.query(`
+      CREATE TRIGGER trg_calls_search_vector_update
+      BEFORE INSERT OR UPDATE OF "title", "thesis", "pairId"
+      ON "calls"
+      FOR EACH ROW
+      EXECUTE FUNCTION calls_search_vector_update()
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP TRIGGER IF EXISTS trg_calls_search_vector_update ON "calls"
+    `);
+    await queryRunner.query(`DROP FUNCTION IF EXISTS calls_search_vector_update`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_calls_search_vector"`);
+    await queryRunner.query(`
+      ALTER TABLE "calls"
+      DROP COLUMN IF EXISTS "searchVector"
+    `);
+  }
+}

--- a/packages/backend/src/search/search.service.spec.ts
+++ b/packages/backend/src/search/search.service.spec.ts
@@ -1,0 +1,28 @@
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  it('returns grouped calls and users', async () => {
+    const dataSource = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ id: 'c1', title: 'BTC rally' }])
+        .mockResolvedValueOnce([{ id: 'u1', walletAddress: 'GBABC' }]),
+    };
+
+    const service = new SearchService(dataSource as any);
+    const result = await service.globalSearch('btc ral');
+
+    expect(result).toEqual({
+      calls: [{ id: 'c1', title: 'BTC rally' }],
+      users: [{ id: 'u1', walletAddress: 'GBABC' }],
+    });
+  });
+
+  it('returns empty groups for empty query', async () => {
+    const dataSource = { query: jest.fn() };
+    const service = new SearchService(dataSource as any);
+    const result = await service.globalSearch('   ');
+    expect(result).toEqual({ calls: [], users: [] });
+    expect(dataSource.query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/search/search.service.ts
+++ b/packages/backend/src/search/search.service.ts
@@ -5,14 +5,27 @@ import { DataSource } from 'typeorm';
 export class SearchService {
   constructor(private readonly dataSource: DataSource) {}
 
+  private toPrefixTsQuery(query: string): string {
+    return query
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((term) => `${term.replace(/[':]/g, '')}:*`)
+      .join(' & ');
+  }
+
   async globalSearch(query: string) {
-    const formattedQuery = query.split(' ').join(' & ');
+    const formattedQuery = this.toPrefixTsQuery(query);
+    if (!formattedQuery) {
+      return { calls: [], users: [] };
+    }
 
     const calls = await this.dataSource.query(
       `
-      SELECT id, title, ts_rank(search_vector, to_tsquery($1)) as rank
-      FROM call
-      WHERE search_vector @@ to_tsquery($1)
+      SELECT id, title, "creatorAddress", "createdAt",
+             ts_rank("searchVector", to_tsquery('simple', $1)) as rank
+      FROM calls
+      WHERE "searchVector" @@ to_tsquery('simple', $1)
       ORDER BY rank DESC
       LIMIT 10
       `,
@@ -21,13 +34,14 @@ export class SearchService {
 
     const users = await this.dataSource.query(
       `
-      SELECT id, display_name, ts_rank(search_vector, to_tsquery($1)) as rank
-      FROM "user"
-      WHERE search_vector @@ to_tsquery($1)
+      SELECT id, "walletAddress",
+             CASE WHEN LOWER("walletAddress") LIKE LOWER($2) THEN 1 ELSE 0 END as rank
+      FROM users
+      WHERE LOWER("walletAddress") LIKE LOWER($2)
       ORDER BY rank DESC
       LIMIT 10
       `,
-      [formattedQuery],
+      [formattedQuery, `%${query}%`],
     );
 
     return {


### PR DESCRIPTION
Closes #179

## Summary
- add migration to create `calls.searchVector` tsvector column and GIN index
- backfill existing rows from `title`, `thesis`, and `pairId`
- add trigger function to keep `searchVector` updated on insert/update
- update `/search?q=` implementation to use tsquery prefix matching (`:*`) and rank sorting via `ts_rank`
- keep grouped response format: `{ calls: [...], users: [...] }`
- add focused unit tests for grouped results and empty query handling

## Validation
- `pnpm --dir packages/backend test -- --watchman=false search.service.spec.ts`
- `pnpm --dir packages/backend build`
- `pnpm --dir packages/backend lint` remains failing due to pre-existing unrelated repo-wide lint issues