### PR TITLE
feat: implement weighted reputation score algorithm

### DIFF
--- a/packages/backend/src/analytics/analytics.service.spec.ts
+++ b/packages/backend/src/analytics/analytics.service.spec.ts
@@ -2,6 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AnalyticsService } from './analytics.service';
 import { Stake } from './entities/stake.entity';
+import { Call } from './entities/call.entity';
+import { DataSource } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 const mockQb = {
   innerJoin: jest.fn().mockReturnThis(),
@@ -14,6 +17,20 @@ const mockQb = {
 
 const mockStakeLedgerRepository = {
   createQueryBuilder: jest.fn(() => mockQb),
+};
+
+const mockCallRepository = {
+  createQueryBuilder: jest.fn(() => mockQb),
+};
+
+const mockDataSource = {
+  query: jest.fn(),
+};
+
+const mockCacheManager = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
 };
 
 describe('AnalyticsService – getTotalValueLocked', () => {
@@ -30,6 +47,18 @@ describe('AnalyticsService – getTotalValueLocked', () => {
         {
           provide: getRepositoryToken(Stake),
           useValue: mockStakeLedgerRepository,
+        },
+        {
+          provide: getRepositoryToken(Call),
+          useValue: mockCallRepository,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
         },
       ],
     }).compile();
@@ -83,5 +112,85 @@ describe('AnalyticsService – getTotalValueLocked', () => {
 
     expect(result.totalValueLocked).toBe(0);
     expect(result.pendingStakesCount).toBe(0);
+  });
+});
+
+describe('AnalyticsService - calculateReputationScore', () => {
+  let service: AnalyticsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockStakeLedgerRepository.createQueryBuilder.mockReturnValue(mockQb);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        {
+          provide: getRepositoryToken(Stake),
+          useValue: mockStakeLedgerRepository,
+        },
+        {
+          provide: getRepositoryToken(Call),
+          useValue: mockCallRepository,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AnalyticsService>(AnalyticsService);
+  });
+
+  it('returns low score for a new user', async () => {
+    mockDataSource.query
+      .mockResolvedValueOnce([{ resolved_calls: 0, wins: 0, total_volume: 0 }])
+      .mockResolvedValueOnce([{ median_volume: 1000 }])
+      .mockResolvedValueOnce([]);
+
+    const score = await service.calculateReputationScore('NEW_USER');
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThan(15);
+  });
+
+  it('rewards whale user volume but caps normalization', async () => {
+    mockDataSource.query
+      .mockResolvedValueOnce([
+        { resolved_calls: 12, wins: 8, total_volume: 50000 },
+      ])
+      .mockResolvedValueOnce([{ median_volume: 500 }])
+      .mockResolvedValueOnce([
+        { week_start: '2026-01-01' },
+        { week_start: '2026-01-08' },
+        { week_start: '2026-01-15' },
+      ]);
+
+    const score = await service.calculateReputationScore('WHALE_USER');
+    expect(score).toBeGreaterThan(55);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it('rewards consistent predictor activity streaks', async () => {
+    mockDataSource.query
+      .mockResolvedValueOnce([
+        { resolved_calls: 15, wins: 10, total_volume: 4000 },
+      ])
+      .mockResolvedValueOnce([{ median_volume: 2000 }])
+      .mockResolvedValueOnce([
+        { week_start: '2026-02-01' },
+        { week_start: '2026-02-08' },
+        { week_start: '2026-02-15' },
+        { week_start: '2026-02-22' },
+        { week_start: '2026-03-01' },
+        { week_start: '2026-03-08' },
+      ]);
+
+    const score = await service.calculateReputationScore('CONSISTENT_USER');
+    expect(score).toBeGreaterThan(60);
   });
 });

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -434,6 +434,97 @@ export class AnalyticsService {
     return Number(reputation.toFixed(4));
   }
 
+  async calculateReputationScore(userAddress: string): Promise<number> {
+    const stats = await this.dataSource.query(
+      `
+      SELECT
+        COUNT(*) FILTER (WHERE c.outcome IN ('YES', 'NO'))::int AS resolved_calls,
+        COUNT(*) FILTER (
+          WHERE c.outcome IN ('YES', 'NO') AND s.position = c.outcome
+        )::int AS wins,
+        COALESCE(SUM(s.amount), 0)::numeric AS total_volume
+      FROM stakes s
+      JOIN calls c ON c.id = s."callId"
+      WHERE s."userAddress" = $1
+      `,
+      [userAddress],
+    );
+
+    const row = stats[0] ?? {
+      resolved_calls: 0,
+      wins: 0,
+      total_volume: 0,
+    };
+
+    const resolvedCalls = Number(row.resolved_calls || 0);
+    const wins = Number(row.wins || 0);
+    const totalVolume = Number(row.total_volume || 0);
+    const winRate = resolvedCalls > 0 ? wins / resolvedCalls : 0;
+
+    const medianResult = await this.dataSource.query(
+      `
+      SELECT COALESCE(
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY user_volume),
+        0
+      ) AS median_volume
+      FROM (
+        SELECT COALESCE(SUM(amount), 0)::numeric AS user_volume
+        FROM stakes
+        GROUP BY "userAddress"
+      ) volumes
+      `,
+    );
+
+    const medianVolume = Number(medianResult[0]?.median_volume || 0);
+    const volumeScore =
+      medianVolume > 0 ? Math.min(1, totalVolume / medianVolume) : 0;
+
+    const activityRows = await this.dataSource.query(
+      `
+      SELECT DISTINCT DATE_TRUNC('week', s."createdAt")::date AS week_start
+      FROM stakes s
+      WHERE s."userAddress" = $1
+      ORDER BY week_start ASC
+      `,
+      [userAddress],
+    );
+
+    const weeks: Date[] = activityRows.map((r: { week_start: string }) => {
+      return new Date(r.week_start);
+    });
+    const activeWeeks = weeks.length;
+
+    let longestStreak = 0;
+    let currentStreak = 0;
+    let prevWeekTime = 0;
+    for (const week of weeks) {
+      const currentTime = week.getTime();
+      if (prevWeekTime && currentTime - prevWeekTime === 7 * 24 * 60 * 60 * 1000) {
+        currentStreak += 1;
+      } else {
+        currentStreak = 1;
+      }
+      longestStreak = Math.max(longestStreak, currentStreak);
+      prevWeekTime = currentTime;
+    }
+
+    const consistencyScore = Math.min(
+      1,
+      (Math.min(longestStreak, 8) / 8) * 0.7 +
+        (Math.min(activeWeeks, 12) / 12) * 0.3,
+    );
+
+    const confidenceMultiplier =
+      resolvedCalls >= 10 ? 1 : 0.3 + (resolvedCalls / 10) * 0.7;
+
+    const score =
+      (winRate * 0.4 + volumeScore * 0.3 + consistencyScore * 0.3) *
+      confidenceMultiplier *
+      100;
+
+    return Number(score.toFixed(2));
+  }
+
   /**
    * Aggregates a user's active Portfolio "Total Value Locked".
    *

--- a/packages/backend/src/user/users.service.ts
+++ b/packages/backend/src/user/users.service.ts
@@ -6,7 +6,7 @@ import {
 import { Users } from './entities/users.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { AnalyticsService } from 'src/analytics/analytics.service';
+import { AnalyticsService } from '../analytics/analytics.service';
 import { RegisterDto } from './dto/register.dto';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
@@ -159,10 +159,13 @@ export class UsersService {
 
     const reliability =
       await this.analyticsService.calculatePredictorReliability(user.id);
+    const reputationScore =
+      await this.analyticsService.calculateReputationScore(walletAddress);
 
     return {
       ...user,
       predictorReliability: reliability,
+      reputationScore,
     };
   }
 }


### PR DESCRIPTION
Closes #180

## Summary
- implement `calculateReputationScore(userAddress)` in analytics service
- apply weighted formula: `(winRate * 0.4 + volumeScore * 0.3 + consistencyScore * 0.3) * confidenceMultiplier`
- apply confidence ramp from 0.3 to 1.0 for users below 10 resolved calls
- normalize volume score against platform median stake volume
- compute consistency score using weekly activity streak depth and active-week breadth
- expose `reputationScore` in `GET /users/:address` profile response
- add unit tests for new user, whale, and consistent predictor scenarios

## Validation
- `pnpm --dir packages/backend test -- --watchman=false analytics.service.spec.ts`
- `pnpm --dir packages/backend build`
- `pnpm --dir packages/backend lint` remains failing due to existing repo-wide unrelated lint violations