### PR TITLE
feat: add dark/light theme toggle with system preference detection

### DIFF
--- a/packages/frontend/src/contexts/ThemeContext.tsx
+++ b/packages/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+type Theme = "light" | "dark";
+interface ThemeContextValue { theme: Theme; toggle: () => void; }
+
+const ThemeContext = createContext<ThemeContextValue>({ theme: "light", toggle: () => {} });
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    const preferred: Theme = window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+    const initial = stored ?? preferred;
+    setTheme(initial);
+    document.documentElement.setAttribute("data-theme", initial);
+  }, []);
+
+  const toggle = () => {
+    setTheme((prev) => {
+      const next: Theme = prev === "light" ? "dark" : "light";
+      localStorage.setItem("theme", next);
+      document.documentElement.setAttribute("data-theme", next);
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary

Adds a ThemeProvider context that manages dark/light mode switching with persistence and system preference detection.

**Changes:**
- ThemeProvider detects system prefers-color-scheme on first load
- Persists chosen theme to localStorage across sessions
- Sets data-theme attribute on the root html element for CSS variable scoping
- useTheme hook exposes current theme and toggle function to any component
- Smooth opt-in: wrapping a subtree in ThemeProvider is enough to enable theming

closes #228