### PR TITLE
feat: implement rate-limited DexScreener proxy service

### DIFF
--- a/packages/backend/src/token/tokens.controller.ts
+++ b/packages/backend/src/token/tokens.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { TokensService } from './tokens.service';
 import { Token } from './entities/token.entity';
 
@@ -13,5 +13,15 @@ export class TokensController {
   @Get()
   async getTokens(): Promise<Token[]> {
     return this.tokensService.getAll();
+  }
+
+  @Get('search')
+  async searchTokens(@Query('q') query: string) {
+    return this.tokensService.searchDexPairs(query ?? '');
+  }
+
+  @Get(':pair/price')
+  async getPairPrice(@Param('pair') pair: string) {
+    return this.tokensService.getPairPrice(pair);
   }
 }

--- a/packages/backend/src/token/tokens.module.ts
+++ b/packages/backend/src/token/tokens.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
+import { HttpModule } from '@nestjs/axios';
 import { Token } from './entities/token.entity';
 import { TokensRepository } from './tokens.repository';
 import { TokensService } from './tokens.service';
@@ -10,6 +11,7 @@ import { TokensSyncWorker } from './tokens.sync.worker';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Token]),
+    HttpModule,
     ScheduleModule.forRoot(), // safe to call in child modules
   ],
   controllers: [TokensController],

--- a/packages/backend/src/token/tokens.service.spec.ts
+++ b/packages/backend/src/token/tokens.service.spec.ts
@@ -1,0 +1,82 @@
+import { of, throwError } from 'rxjs';
+import { TokensService } from './tokens.service';
+
+describe('TokensService DexScreener proxy', () => {
+  const tokensRepository: any = {
+    findAllActive: jest.fn(),
+    findByAsset: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
+
+  const httpService: any = {
+    get: jest.fn(),
+  };
+
+  let service: TokensService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new TokensService(tokensRepository, httpService);
+  });
+
+  it('proxies search and returns normalized format', async () => {
+    httpService.get.mockReturnValue(
+      of({
+        data: {
+          pairs: [
+            {
+              pairAddress: 'pair_1',
+              baseToken: { symbol: 'XLM' },
+              quoteToken: { symbol: 'USDC' },
+              priceUsd: '0.12',
+              liquidity: { usd: '1000' },
+              dexId: 'stellar',
+              url: 'https://dexscreener.com/stellar/pair_1',
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await service.searchDexPairs('xlm');
+    expect(result.query).toBe('XLM');
+    expect(result.items[0].pairAddress).toBe('pair_1');
+    expect(result.items[0].priceUsd).toBe(0.12);
+  });
+
+  it('returns cached search response on 429', async () => {
+    httpService.get.mockReturnValueOnce(
+      of({
+        data: {
+          pairs: [{ pairAddress: 'pair_2', baseToken: { symbol: 'XLM' } }],
+        },
+      }),
+    );
+    await service.searchDexPairs('XLM');
+
+    httpService.get.mockReturnValueOnce(
+      throwError(() => ({ response: { status: 429 } })),
+    );
+    const fallback = await service.searchDexPairs('XLM');
+    expect(fallback.cached).toBe(true);
+    expect(fallback.items[0].pairAddress).toBe('pair_2');
+  });
+
+  it('returns cached pair price on upstream failure', async () => {
+    (service as any).priceCache.set('pair_3', {
+      expiresAt: Date.now() + 15_000,
+      data: {
+        pairAddress: 'pair_3',
+        priceUsd: 0.55,
+        updatedAt: new Date().toISOString(),
+        cached: false,
+      },
+    });
+
+    httpService.get.mockReturnValueOnce(throwError(() => new Error('down')));
+    const fallback = await service.getPairPrice('pair_3');
+    expect(fallback.cached).toBe(true);
+    expect(fallback.priceUsd).toBe(0.55);
+  });
+});

--- a/packages/backend/src/token/tokens.service.ts
+++ b/packages/backend/src/token/tokens.service.ts
@@ -1,6 +1,8 @@
+import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 import { TokensRepository } from './tokens.repository';
 import { Token } from './entities/token.entity';
+import { firstValueFrom } from 'rxjs';
 
 // Whitelist of trusted tokens — extend as needed
 export const WHITELISTED_TOKENS: Partial<Token>[] = [
@@ -29,8 +31,141 @@ export const WHITELISTED_TOKENS: Partial<Token>[] = [
 @Injectable()
 export class TokensService {
   private readonly logger = new Logger(TokensService.name);
+  private readonly outboundRequestTimestamps: number[] = [];
+  private readonly searchCache = new Map<
+    string,
+    { expiresAt: number; data: DexSearchResponse }
+  >();
+  private readonly priceCache = new Map<
+    string,
+    { expiresAt: number; data: DexPriceResponse }
+  >();
 
-  constructor(private readonly tokensRepository: TokensRepository) {}
+  constructor(
+    private readonly tokensRepository: TokensRepository,
+    private readonly httpService: HttpService,
+  ) {}
+
+  private async consumeQuota(): Promise<void> {
+    const now = Date.now();
+    const minuteAgo = now - 60_000;
+    while (
+      this.outboundRequestTimestamps.length > 0 &&
+      this.outboundRequestTimestamps[0] < minuteAgo
+    ) {
+      this.outboundRequestTimestamps.shift();
+    }
+
+    if (this.outboundRequestTimestamps.length >= 10) {
+      const waitForMs = this.outboundRequestTimestamps[0] + 60_000 - now;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.max(waitForMs, 0)),
+      );
+    }
+
+    this.outboundRequestTimestamps.push(Date.now());
+  }
+
+  async searchDexPairs(query: string): Promise<DexSearchResponse> {
+    const q = query.trim().toUpperCase();
+    if (!q) {
+      return { query: '', items: [], cached: false };
+    }
+
+    const cacheKey = q;
+    const cached = this.searchCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return { ...cached.data, cached: true };
+    }
+
+    try {
+      await this.consumeQuota();
+      this.logger.log(`DexScreener outbound: /latest/dex/search?q=${q}`);
+      const response = await firstValueFrom(
+        this.httpService.get(
+          `https://api.dexscreener.com/latest/dex/search?q=${encodeURIComponent(q)}`,
+        ),
+      );
+
+      const pairs: any[] = Array.isArray(response.data?.pairs)
+        ? response.data.pairs
+        : [];
+      const data: DexSearchResponse = {
+        query: q,
+        cached: false,
+        items: pairs.map((pair) => ({
+          pairAddress: String(pair?.pairAddress ?? ''),
+          baseSymbol: String(pair?.baseToken?.symbol ?? ''),
+          quoteSymbol: String(pair?.quoteToken?.symbol ?? ''),
+          priceUsd: Number(pair?.priceUsd ?? 0),
+          liquidityUsd: Number(pair?.liquidity?.usd ?? 0),
+          dexId: String(pair?.dexId ?? ''),
+          url: String(pair?.url ?? ''),
+        })),
+      };
+
+      this.searchCache.set(cacheKey, {
+        expiresAt: Date.now() + 60_000,
+        data,
+      });
+      return data;
+    } catch (error: any) {
+      const status = error?.response?.status;
+      const fallback = cached ?? this.searchCache.get(cacheKey);
+      if ((status === 429 || !status) && fallback) {
+        return { ...fallback.data, cached: true };
+      }
+      return { query: q, items: [], cached: false };
+    }
+  }
+
+  async getPairPrice(pair: string): Promise<DexPriceResponse> {
+    const pairId = pair.trim();
+    const cached = this.priceCache.get(pairId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return { ...cached.data, cached: true };
+    }
+
+    try {
+      await this.consumeQuota();
+      this.logger.log(
+        `DexScreener outbound: /latest/dex/pairs/stellar/${pairId}`,
+      );
+      const response = await firstValueFrom(
+        this.httpService.get(
+          `https://api.dexscreener.com/latest/dex/pairs/stellar/${encodeURIComponent(pairId)}`,
+        ),
+      );
+      const firstPair = Array.isArray(response.data?.pairs)
+        ? response.data.pairs[0]
+        : null;
+
+      const data: DexPriceResponse = {
+        pairAddress: pairId,
+        priceUsd: Number(firstPair?.priceUsd ?? 0),
+        updatedAt: new Date().toISOString(),
+        cached: false,
+      };
+
+      this.priceCache.set(pairId, {
+        expiresAt: Date.now() + 15_000,
+        data,
+      });
+      return data;
+    } catch (error: any) {
+      const status = error?.response?.status;
+      const fallback = cached ?? this.priceCache.get(pairId);
+      if ((status === 429 || !status) && fallback) {
+        return { ...fallback.data, cached: true };
+      }
+      return {
+        pairAddress: pairId,
+        priceUsd: 0,
+        updatedAt: new Date().toISOString(),
+        cached: false,
+      };
+    }
+  }
 
   async getAll(): Promise<Token[]> {
     return this.tokensRepository.findAllActive();
@@ -68,3 +203,24 @@ export class TokensService {
     this.logger.log('Token whitelist sync complete.');
   }
 }
+
+export type DexSearchResponse = {
+  query: string;
+  items: Array<{
+    pairAddress: string;
+    baseSymbol: string;
+    quoteSymbol: string;
+    priceUsd: number;
+    liquidityUsd: number;
+    dexId: string;
+    url: string;
+  }>;
+  cached: boolean;
+};
+
+export type DexPriceResponse = {
+  pairAddress: string;
+  priceUsd: number;
+  updatedAt: string;
+  cached: boolean;
+};


### PR DESCRIPTION
Closes #214

## Summary
- add `GET /tokens/search?q=` endpoint to proxy DexScreener pair search
- add `GET /tokens/:pair/price` endpoint to return current pair price
- add in-memory outbound request queue limiter (max 10 DexScreener calls/min)
- add per-endpoint response caching (60s for search, 15s for price)
- return cached responses when upstream is rate-limited or unavailable
- add outbound API call logging and normalized response DTO shapes
- add unit tests with mocked DexScreener responses/failures

## Validation
- `pnpm --dir packages/backend test -- --watchman=false tokens.service.spec.ts`
- `pnpm --dir packages/backend build`
- `pnpm --dir packages/backend lint` fails due existing repo-wide unrelated issues (see lint output); build and targeted tests pass