### PR TITLE
feat: implement payout claim status tracking

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { FirewallMiddleware } from './firewall/firewall.middleware';
 import { CacheModule } from '@nestjs/cache-manager';
 import { TokensModule } from './token/tokens.module';
 import { RelayModule } from './relay/relay.module';
+import { PayoutsModule } from './payouts/payouts.module';
 
 @Module({
   imports: [
@@ -67,6 +68,7 @@ import { RelayModule } from './relay/relay.module';
     SearchModule,
     UsersModule,
     TokensModule,
+    PayoutsModule,
     GatewaysModule,
     AuditModule,
     FirewallModule,

--- a/packages/backend/src/database/migrations/1760000002000-CreatePayoutClaimsTable.ts
+++ b/packages/backend/src/database/migrations/1760000002000-CreatePayoutClaimsTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreatePayoutClaimsTable1760000002000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'payout_claims',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'callId', type: 'uuid' },
+          { name: 'stakerAddress', type: 'varchar', length: '56' },
+          {
+            name: 'amount',
+            type: 'decimal',
+            precision: 20,
+            scale: 7,
+            default: '0',
+          },
+          { name: 'txHash', type: 'varchar', length: '128', isNullable: true },
+          { name: 'claimedAt', type: 'timestamp', isNullable: true },
+          {
+            name: 'status',
+            type: 'varchar',
+            default: `'PENDING'`,
+          },
+          { name: 'createdAt', type: 'timestamp', default: 'now()' },
+          { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'payout_claims',
+      new TableIndex({
+        name: 'IDX_payout_claims_call_staker_unique',
+        columnNames: ['callId', 'stakerAddress'],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('payout_claims', 'IDX_payout_claims_call_staker_unique');
+    await queryRunner.dropTable('payout_claims', true);
+  }
+}

--- a/packages/backend/src/indexer/indexer.module.ts
+++ b/packages/backend/src/indexer/indexer.module.ts
@@ -10,6 +10,7 @@ import { PlatformSettings } from './entities/platform-settings.entity';
 import { PlatformSettingsService } from './platform-settings.service';
 import { PlatformConfigModule } from '../config/config.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { PayoutsModule } from '../payouts/payouts.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     ScheduleModule.forRoot(),
     PlatformConfigModule,
     NotificationsModule,
+    PayoutsModule,
   ],
   controllers: [IndexerController],
   providers: [

--- a/packages/backend/src/indexer/indexer.service.ts
+++ b/packages/backend/src/indexer/indexer.service.ts
@@ -7,6 +7,7 @@ import { PlatformSettings } from './entities/platform-settings.entity';
 import { retryWithBackoff } from '../utils/retry';
 import { ConfigService } from '../config/config.service';
 import { parseAdminParamsChanged } from './parsers/admin-params.parser';
+import { PayoutsService } from '../payouts/payouts.service';
 
 @Injectable()
 export class IndexerService {
@@ -20,6 +21,7 @@ export class IndexerService {
     @InjectRepository(PlatformSettings)
     private readonly platformSettingsRepository: Repository<PlatformSettings>,
     private readonly configService: ConfigService,
+    private readonly payoutsService: PayoutsService,
   ) {}
 
   // ─── Status ───────────────────────────────────────────────────────────────
@@ -98,6 +100,9 @@ export class IndexerService {
       case 'AdminParamsChanged':
         await this.handleAdminParamsChanged(topics, data, txHash, ledger);
         break;
+      case 'PayoutClaimed':
+        await this.handlePayoutClaimed(topics, txHash, ledger);
+        break;
 
       // ── extend here as you add more contract events ───────────────────
       // case 'MarketCreated':  await this.handleMarketCreated(...); break;
@@ -140,6 +145,28 @@ export class IndexerService {
         timestamp: new Date(),
       }),
     );
+  }
+
+  private async handlePayoutClaimed(
+    topics: xdr.ScVal[],
+    txHash: string,
+    ledger: number,
+  ): Promise<void> {
+    try {
+      const callId = topics[1]?.u64()?.toString() ?? '';
+      const stakerAddress = topics[2]?.str()?.toString() ?? '';
+      if (!callId || !stakerAddress) return;
+
+      await this.payoutsService.markClaimed(
+        callId,
+        stakerAddress,
+        txHash,
+        new Date(),
+      );
+      this.logger.log(`PayoutClaimed synced: call=${callId} staker=${stakerAddress}`);
+    } catch (err: any) {
+      this.logger.warn(`Failed to parse PayoutClaimed event: ${err.message}`);
+    }
   }
 
   // ─── Platform Settings ────────────────────────────────────────────────────

--- a/packages/backend/src/payouts/entities/payout-claim.entity.ts
+++ b/packages/backend/src/payouts/entities/payout-claim.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum PayoutClaimStatus {
+  PENDING = 'PENDING',
+  CLAIMED = 'CLAIMED',
+  FAILED = 'FAILED',
+}
+
+@Entity('payout_claims')
+@Index(['callId', 'stakerAddress'], { unique: true })
+export class PayoutClaim {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @Index()
+  callId: string;
+
+  @Column({ type: 'varchar', length: 56 })
+  @Index()
+  stakerAddress: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 7, default: 0 })
+  amount: string;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  txHash: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  claimedAt: Date | null;
+
+  @Column({
+    type: 'enum',
+    enum: PayoutClaimStatus,
+    default: PayoutClaimStatus.PENDING,
+  })
+  status: PayoutClaimStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/packages/backend/src/payouts/payouts.controller.ts
+++ b/packages/backend/src/payouts/payouts.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { PayoutsService } from './payouts.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+
+@Controller()
+export class PayoutsController {
+  constructor(private readonly payoutsService: PayoutsService) {}
+
+  @Get('users/:address/payouts')
+  getUserPayouts(@Param('address') address: string) {
+    return this.payoutsService.listUserPayouts(address);
+  }
+
+  @Get('calls/:id/payouts')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getCallPayouts(@Param('id') callId: string) {
+    return this.payoutsService.listCallPayouts(callId);
+  }
+
+  @Get('admin/payouts/unclaimed-overdue')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getOverdueUnclaimed() {
+    return this.payoutsService.getOverdueUnclaimed();
+  }
+}

--- a/packages/backend/src/payouts/payouts.module.ts
+++ b/packages/backend/src/payouts/payouts.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PayoutClaim } from './entities/payout-claim.entity';
+import { PayoutsService } from './payouts.service';
+import { PayoutsController } from './payouts.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PayoutClaim])],
+  providers: [PayoutsService],
+  controllers: [PayoutsController],
+  exports: [PayoutsService],
+})
+export class PayoutsModule {}

--- a/packages/backend/src/payouts/payouts.service.spec.ts
+++ b/packages/backend/src/payouts/payouts.service.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PayoutClaim, PayoutClaimStatus } from './entities/payout-claim.entity';
+import { PayoutsService } from './payouts.service';
+
+describe('PayoutsService', () => {
+  let service: PayoutsService;
+
+  const repository = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PayoutsService,
+        { provide: getRepositoryToken(PayoutClaim), useValue: repository },
+      ],
+    }).compile();
+
+    service = module.get<PayoutsService>(PayoutsService);
+  });
+
+  it('marks claim as CLAIMED when payout event arrives', async () => {
+    repository.findOne.mockResolvedValue({
+      callId: 'call-1',
+      stakerAddress: 'GA1',
+      status: PayoutClaimStatus.PENDING,
+    });
+    repository.save.mockImplementation(async (value: any) => value);
+
+    const result = await service.markClaimed(
+      'call-1',
+      'GA1',
+      'tx-hash',
+      new Date('2026-01-01T00:00:00Z'),
+    );
+
+    expect(result.status).toBe(PayoutClaimStatus.CLAIMED);
+    expect(result.txHash).toBe('tx-hash');
+  });
+
+  it('marks claim as FAILED', async () => {
+    repository.findOne.mockResolvedValue(null);
+    repository.create.mockReturnValue({
+      callId: 'call-2',
+      stakerAddress: 'GA2',
+      amount: '0',
+    });
+    repository.save.mockImplementation(async (value: any) => value);
+
+    const result = await service.markFailed('call-2', 'GA2');
+    expect(result.status).toBe(PayoutClaimStatus.FAILED);
+  });
+
+  it('returns payouts by user address', async () => {
+    repository.find.mockResolvedValue([{ id: 'p1' }]);
+    const data = await service.listUserPayouts('GA3');
+    expect(data).toEqual([{ id: 'p1' }]);
+  });
+});

--- a/packages/backend/src/payouts/payouts.service.ts
+++ b/packages/backend/src/payouts/payouts.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import { PayoutClaim, PayoutClaimStatus } from './entities/payout-claim.entity';
+
+@Injectable()
+export class PayoutsService {
+  constructor(
+    @InjectRepository(PayoutClaim)
+    private readonly payoutClaimsRepository: Repository<PayoutClaim>,
+  ) {}
+
+  async listUserPayouts(stakerAddress: string): Promise<PayoutClaim[]> {
+    return this.payoutClaimsRepository.find({
+      where: { stakerAddress },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async listCallPayouts(callId: string): Promise<Array<PayoutClaim & { isOverdue: boolean }>> {
+    const claims = await this.payoutClaimsRepository.find({
+      where: { callId },
+      order: { createdAt: 'DESC' },
+    });
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    return claims.map((claim) => ({
+      ...claim,
+      isOverdue:
+        claim.status === PayoutClaimStatus.PENDING &&
+        claim.createdAt.getTime() < sevenDaysAgo,
+    }));
+  }
+
+  async upsertPendingClaim(
+    callId: string,
+    stakerAddress: string,
+    amount: string,
+  ): Promise<PayoutClaim> {
+    const existing = await this.payoutClaimsRepository.findOne({
+      where: { callId, stakerAddress },
+    });
+
+    if (existing) {
+      existing.amount = amount;
+      existing.status = PayoutClaimStatus.PENDING;
+      return this.payoutClaimsRepository.save(existing);
+    }
+
+    return this.payoutClaimsRepository.save(
+      this.payoutClaimsRepository.create({
+        callId,
+        stakerAddress,
+        amount,
+        status: PayoutClaimStatus.PENDING,
+      }),
+    );
+  }
+
+  async markClaimed(
+    callId: string,
+    stakerAddress: string,
+    txHash: string,
+    claimedAt: Date,
+  ): Promise<PayoutClaim> {
+    const existing = await this.payoutClaimsRepository.findOne({
+      where: { callId, stakerAddress },
+    });
+
+    const claim =
+      existing ??
+      this.payoutClaimsRepository.create({
+        callId,
+        stakerAddress,
+        amount: '0',
+      });
+
+    claim.txHash = txHash;
+    claim.claimedAt = claimedAt;
+    claim.status = PayoutClaimStatus.CLAIMED;
+    return this.payoutClaimsRepository.save(claim);
+  }
+
+  async markFailed(callId: string, stakerAddress: string): Promise<PayoutClaim> {
+    const existing = await this.payoutClaimsRepository.findOne({
+      where: { callId, stakerAddress },
+    });
+
+    const claim =
+      existing ??
+      this.payoutClaimsRepository.create({
+        callId,
+        stakerAddress,
+        amount: '0',
+      });
+
+    claim.status = PayoutClaimStatus.FAILED;
+    return this.payoutClaimsRepository.save(claim);
+  }
+
+  async getOverdueUnclaimed(): Promise<PayoutClaim[]> {
+    const threshold = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    return this.payoutClaimsRepository.find({
+      where: {
+        status: PayoutClaimStatus.PENDING,
+        createdAt: LessThan(threshold),
+      },
+      order: { createdAt: 'ASC' },
+    });
+  }
+}


### PR DESCRIPTION
Closes #215

## Summary
- add `PayoutClaim` entity with lifecycle status (`PENDING`, `CLAIMED`, `FAILED`)
- add payout endpoints:
  - `GET /users/:address/payouts`
  - `GET /calls/:id/payouts` (admin-guarded)
  - `GET /admin/payouts/unclaimed-overdue` for unclaimed payouts older than 7 days
- add indexer hook for `PayoutClaimed` events to mark claims as claimed
- add migration for `payout_claims` table and unique call/user claim index
- add unit tests for claim lifecycle transitions and user lookup

## Validation
- `pnpm --dir packages/backend test -- --watchman=false payouts.service.spec.ts`
- `pnpm --dir packages/backend build`
- lint remains failing repo-wide due existing unrelated violations