### PR TITLE
feat: implement configurable platform settings API

### DIFF
--- a/packages/backend/src/config/config.controller.ts
+++ b/packages/backend/src/config/config.controller.ts
@@ -1,10 +1,23 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { ConfigService } from './config.service';
 import { PlatformSettings } from './entities/platform-settings.entity';
+import { UpdateConfigDto } from './dto/update-config.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { Audited } from '../audit/decorators/audited.decorator';
+import { AuditActionType } from '../audit/audit-log.entity';
 
 @ApiTags('config')
-@Controller('config')
+@Controller()
 export class PlatformConfigController {
   constructor(private readonly configService: ConfigService) {}
 
@@ -23,7 +36,7 @@ export class PlatformConfigController {
    *   "updatedAt": "2024-01-26T10:30:00.000Z"
    * }
    */
-  @Get()
+  @Get('config')
   @ApiOperation({
     summary: 'Get platform configuration',
     description:
@@ -46,6 +59,19 @@ export class PlatformConfigController {
   async getConfig(): Promise<Omit<PlatformSettings, 'id' | 'createdAt'>> {
     const { id, createdAt, ...settings } =
       await this.configService.getSettings();
+    return settings;
+  }
+
+  @Patch('admin/config')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
+  @Audited(AuditActionType.ADMIN_ACTION, () => 'config:platform')
+  @ApiOperation({
+    summary: 'Update platform configuration (admin)',
+  })
+  async updateConfig(@Body() dto: UpdateConfigDto) {
+    const { id, createdAt, ...settings } =
+      await this.configService.updateOffChainSettings(dto);
     return settings;
   }
 }

--- a/packages/backend/src/config/config.service.spec.ts
+++ b/packages/backend/src/config/config.service.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConfigService } from './config.service';
+import { PlatformSettings } from './entities/platform-settings.entity';
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+
+  const repo = {
+    findOne: jest.fn(),
+    findOneOrFail: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
+  const cache = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+  };
+  const eventEmitter = {
+    emit: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConfigService,
+        { provide: getRepositoryToken(PlatformSettings), useValue: repo },
+        { provide: CACHE_MANAGER, useValue: cache },
+        { provide: EventEmitter2, useValue: eventEmitter },
+      ],
+    }).compile();
+
+    service = module.get<ConfigService>(ConfigService);
+  });
+
+  it('returns cached config when present', async () => {
+    cache.get.mockResolvedValue({ feePercent: 2.5 });
+    const result = await service.getSettings();
+    expect(result).toEqual({ feePercent: 2.5 });
+    expect(repo.findOneOrFail).not.toHaveBeenCalled();
+  });
+
+  it('updates config and emits websocket refresh event', async () => {
+    const row = {
+      id: 1,
+      feePercent: 1,
+      minStake: 0,
+      maxDuration: 100,
+      supportedTokens: [],
+      contractAddresses: {},
+    };
+    cache.get.mockResolvedValue(null);
+    repo.findOneOrFail.mockResolvedValue(row);
+    repo.save.mockImplementation(async (value: any) => value);
+
+    const result = await service.updateOffChainSettings({
+      feePercent: 3,
+      minStake: 10,
+    });
+
+    expect(result.feePercent).toBe(3);
+    expect(result.minStake).toBe(10);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'config.updated',
+      expect.objectContaining({ source: 'admin' }),
+    );
+  });
+});

--- a/packages/backend/src/config/config.service.ts
+++ b/packages/backend/src/config/config.service.ts
@@ -2,6 +2,11 @@ import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PlatformSettings } from './entities/platform-settings.entity';
+import { UpdateConfigDto } from './dto/update-config.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { Inject } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 export interface AdminParamsChangedEvent {
   feePercent?: number;
@@ -19,6 +24,8 @@ export class ConfigService implements OnApplicationBootstrap {
   constructor(
     @InjectRepository(PlatformSettings)
     private readonly settingsRepo: Repository<PlatformSettings>,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   /**
@@ -32,9 +39,15 @@ export class ConfigService implements OnApplicationBootstrap {
   // ─── Public API ───────────────────────────────────────────────────────────
 
   async getSettings(): Promise<PlatformSettings> {
-    return this.settingsRepo.findOneOrFail({
+    const cacheKey = 'config:public';
+    const cached = await this.cacheManager.get<PlatformSettings>(cacheKey);
+    if (cached) return cached;
+
+    const settings = await this.settingsRepo.findOneOrFail({
       where: { id: this.SINGLETON_ID },
     });
+    await this.cacheManager.set(cacheKey, settings, 300_000);
+    return settings;
   }
 
   /**
@@ -65,7 +78,34 @@ export class ConfigService implements OnApplicationBootstrap {
     settings.lastUpdatedByTxHash = event.txHash;
     settings.lastUpdatedAtLedger = event.ledger;
 
-    return this.settingsRepo.save(settings);
+    const saved = await this.settingsRepo.save(settings);
+    await this.cacheManager.del('config:public');
+    this.eventEmitter.emit('config.updated', {
+      feePercent: saved.feePercent,
+      source: 'indexer',
+    });
+    return saved;
+  }
+
+  async updateOffChainSettings(dto: UpdateConfigDto): Promise<PlatformSettings> {
+    const settings = await this.getSettings();
+    if (dto.feePercent !== undefined) settings.feePercent = dto.feePercent;
+    if (dto.minStake !== undefined) settings.minStake = dto.minStake;
+    if (dto.maxDuration !== undefined) settings.maxDuration = dto.maxDuration;
+    if (dto.supportedTokens !== undefined) {
+      settings.supportedTokens = dto.supportedTokens;
+    }
+    if (dto.contractAddresses !== undefined) {
+      settings.contractAddresses = dto.contractAddresses;
+    }
+
+    const saved = await this.settingsRepo.save(settings);
+    await this.cacheManager.del('config:public');
+    this.eventEmitter.emit('config.updated', {
+      feePercent: saved.feePercent,
+      source: 'admin',
+    });
+    return saved;
   }
 
   // ─── Private ──────────────────────────────────────────────────────────────
@@ -82,6 +122,10 @@ export class ConfigService implements OnApplicationBootstrap {
           feePercent: parseFloat(process.env.DEFAULT_FEE_PERCENT ?? '1.0'),
           contractId: process.env.SOROBAN_CONTRACT_ID ?? null,
           oracleContractId: process.env.ORACLE_CONTRACT_ID ?? null,
+          minStake: 0,
+          maxDuration: 86400,
+          supportedTokens: [],
+          contractAddresses: {},
         }),
       );
       this.logger.log('PlatformSettings singleton created with defaults');

--- a/packages/backend/src/config/dto/update-config.dto.ts
+++ b/packages/backend/src/config/dto/update-config.dto.ts
@@ -1,0 +1,37 @@
+import {
+  IsArray,
+  IsInt,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class UpdateConfigDto {
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  feePercent?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  minStake?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(60)
+  maxDuration?: number;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  supportedTokens?: string[];
+
+  @IsOptional()
+  @IsObject()
+  contractAddresses?: Record<string, string>;
+}

--- a/packages/backend/src/config/entities/platform-settings.entity.ts
+++ b/packages/backend/src/config/entities/platform-settings.entity.ts
@@ -30,6 +30,18 @@ export class PlatformSettings {
   @Column({ type: 'varchar', length: 56, nullable: true })
   oracleContractId: string | null;
 
+  @Column({ type: 'decimal', precision: 20, scale: 7, default: 0 })
+  minStake: number;
+
+  @Column({ type: 'int', default: 86400 })
+  maxDuration: number;
+
+  @Column({ type: 'jsonb', default: () => "'[]'" })
+  supportedTokens: string[];
+
+  @Column({ type: 'jsonb', default: () => "'{}'" })
+  contractAddresses: Record<string, string>;
+
   // ─── audit trail ─────────────────────────────────────────────────────────
   @Column({ type: 'varchar', length: 100, nullable: true })
   lastUpdatedByTxHash: string | null;

--- a/packages/backend/src/database/migrations/1760000003000-ExtendPlatformSettings.ts
+++ b/packages/backend/src/database/migrations/1760000003000-ExtendPlatformSettings.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ExtendPlatformSettings1760000003000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "platform_settings"
+      ADD COLUMN IF NOT EXISTS "minStake" decimal(20,7) NOT NULL DEFAULT 0
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "platform_settings"
+      ADD COLUMN IF NOT EXISTS "maxDuration" integer NOT NULL DEFAULT 86400
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "platform_settings"
+      ADD COLUMN IF NOT EXISTS "supportedTokens" jsonb NOT NULL DEFAULT '[]'
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "platform_settings"
+      ADD COLUMN IF NOT EXISTS "contractAddresses" jsonb NOT NULL DEFAULT '{}'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "platform_settings" DROP COLUMN IF EXISTS "contractAddresses"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "platform_settings" DROP COLUMN IF EXISTS "supportedTokens"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "platform_settings" DROP COLUMN IF EXISTS "maxDuration"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "platform_settings" DROP COLUMN IF EXISTS "minStake"`,
+    );
+  }
+}

--- a/packages/backend/src/gateways/events.gateway.ts
+++ b/packages/backend/src/gateways/events.gateway.ts
@@ -42,6 +42,11 @@ export interface UserNotificationPayload {
   meta?: Record<string, unknown>;
 }
 
+export interface ConfigUpdatedPayload {
+  feePercent: number;
+  source: 'admin' | 'indexer';
+}
+
 // ---------------------------------------------------------------------------
 // Room helpers
 // ---------------------------------------------------------------------------
@@ -261,6 +266,11 @@ export class EventsGateway
     const room = userRoom(payload.userId);
     this.logger.debug(`Broadcasting notification to room "${room}"`);
     this.server.to(room).emit('notification', payload);
+  }
+
+  @OnEvent('config.updated')
+  onConfigUpdated(payload: ConfigUpdatedPayload) {
+    this.server.emit('config:updated', payload);
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #216

## Summary
- extend platform settings model with `minStake`, `maxDuration`, `supportedTokens`, and `contractAddresses`
- keep public `GET /config` endpoint and add 5-minute cache layer
- add `PATCH /admin/config` (admin-only) with DTO validation and audit decorator
- invalidate config cache and emit `config.updated` WebSocket event when settings change
- preserve indexer-driven fee sync (`applyAdminParamsChanged`) and emit refresh events for frontend updates
- add migration for new platform settings fields
- add unit tests for cached reads and admin updates

## Validation
- `pnpm --dir packages/backend test -- --watchman=false config.service.spec.ts`
- `pnpm --dir packages/backend build`
- lint remains failing repository-wide due existing unrelated violations