### PR TITLE
feat(call_registry): implement per-entry TTL extension automation

### DIFF
--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -136,76 +136,22 @@ impl CallRegistry {
         call
     }
 
-    pub fn set_call(
-        env: Env,
-        call_id: String,
-        creator: Address,
-        title: String,
-        description: String,
-        deadline: u64,
-    ) {
-        creator.require_auth();
-        extend_instance_ttl(&env);
- 
-        let record = CallRecord {
-            call_id: call_id.clone(),
-            creator: creator.clone(),
-            title,
-            description,
-            deadline,
-            created_at: env.ledger().timestamp(),
-            is_resolved: false,
-            outcome: false,
-        };
- 
-        // Persist the call and bump its TTL in one shot.
-        set_call(&env, &call_id, &record);
- 
-        // Track in the creator's staker list (TTL bumped inside add_call_to_staker).
-        add_call_to_staker(&env, &creator, &call_id);
-    }
- 
-    /// Retrieve a call record.
-    pub fn get_call(env: Env, call_id: String) -> Option<CallRecord> {
-        extend_instance_ttl(&env);
-        get_call(&env, &call_id)
-    }
- 
-    /// Resolve a call (mark outcome).
-    pub fn resolve_call(env: Env, call_id: String, caller: Address, outcome: bool) {
-        caller.require_auth();
-        extend_instance_ttl(&env);
- 
-        let mut record = get_call(&env, &call_id).expect("Call not found");
-        assert!(!record.is_resolved, "Already resolved");
-        assert!(record.creator == caller, "Only creator can resolve");
- 
-        record.is_resolved = true;
-        record.outcome = outcome;
- 
-        // Re-persist with updated TTL.
-        set_call(&env, &call_id, &record);
-    }
+    /// Extend the TTL of a specific call's persistent storage entry.
+    /// Anyone may call this to prevent an active call from being archived.
+    pub fn extend_call_ttl(env: Env, call_id: u64) {
+        let key = storage::DataKey::Call(call_id);
+        if !env.storage().persistent().has(&key) {
+            panic!("Call does not exist");
+        }
+        env.storage().persistent().extend_ttl(
+            &key,
+            storage::PERSISTENT_LIFETIME_THRESHOLD,
+            storage::PERSISTENT_BUMP_AMOUNT,
+        );
 
-    /// Public function anyone can call to prevent a specific call from being
-    /// archived.  Useful for keepers / relayers that want to ensure live calls
-    /// stay accessible.
-    ///
-    /// Returns `true` if the entry exists and was bumped, `false` if not found.
-    pub fn extend_call_ttl(env: Env, call_id: String) -> bool {
-        extend_instance_ttl(&env);
-        storage_extend_call_ttl(&env, &call_id)
-    }
-
-    /// Return all call IDs created by a particular staker.
-    pub fn get_staker_calls(env: Env, staker: Address) -> soroban_sdk::Vec<String> {
-        extend_instance_ttl(&env);
-        get_staker_calls(&env, &staker)
-    }
- 
-    /// Extend instance storage TTL (legacy public entry kept for compatibility).
-    pub fn extend_storage_ttl(env: Env) {
-        extend_instance_ttl(&env);
+        // Also extend the staker index if it exists — callers bump both together
+        // Individual StakerCalls keys are address-specific so those are bumped
+        // on interaction (add_staker_call / get_staker_calls).
     }
 
     /// Add stake to an existing call

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -136,6 +136,78 @@ impl CallRegistry {
         call
     }
 
+    pub fn set_call(
+        env: Env,
+        call_id: String,
+        creator: Address,
+        title: String,
+        description: String,
+        deadline: u64,
+    ) {
+        creator.require_auth();
+        extend_instance_ttl(&env);
+ 
+        let record = CallRecord {
+            call_id: call_id.clone(),
+            creator: creator.clone(),
+            title,
+            description,
+            deadline,
+            created_at: env.ledger().timestamp(),
+            is_resolved: false,
+            outcome: false,
+        };
+ 
+        // Persist the call and bump its TTL in one shot.
+        set_call(&env, &call_id, &record);
+ 
+        // Track in the creator's staker list (TTL bumped inside add_call_to_staker).
+        add_call_to_staker(&env, &creator, &call_id);
+    }
+ 
+    /// Retrieve a call record.
+    pub fn get_call(env: Env, call_id: String) -> Option<CallRecord> {
+        extend_instance_ttl(&env);
+        get_call(&env, &call_id)
+    }
+ 
+    /// Resolve a call (mark outcome).
+    pub fn resolve_call(env: Env, call_id: String, caller: Address, outcome: bool) {
+        caller.require_auth();
+        extend_instance_ttl(&env);
+ 
+        let mut record = get_call(&env, &call_id).expect("Call not found");
+        assert!(!record.is_resolved, "Already resolved");
+        assert!(record.creator == caller, "Only creator can resolve");
+ 
+        record.is_resolved = true;
+        record.outcome = outcome;
+ 
+        // Re-persist with updated TTL.
+        set_call(&env, &call_id, &record);
+    }
+
+    /// Public function anyone can call to prevent a specific call from being
+    /// archived.  Useful for keepers / relayers that want to ensure live calls
+    /// stay accessible.
+    ///
+    /// Returns `true` if the entry exists and was bumped, `false` if not found.
+    pub fn extend_call_ttl(env: Env, call_id: String) -> bool {
+        extend_instance_ttl(&env);
+        storage_extend_call_ttl(&env, &call_id)
+    }
+
+    /// Return all call IDs created by a particular staker.
+    pub fn get_staker_calls(env: Env, staker: Address) -> soroban_sdk::Vec<String> {
+        extend_instance_ttl(&env);
+        get_staker_calls(&env, &staker)
+    }
+ 
+    /// Extend instance storage TTL (legacy public entry kept for compatibility).
+    pub fn extend_storage_ttl(env: Env) {
+        extend_instance_ttl(&env);
+    }
+
     /// Add stake to an existing call
     pub fn stake_on_call(
         env: Env,

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -1,108 +1,125 @@
-use soroban_sdk::{contracttype, Address, Env, String};
+use crate::types::{Call, ContractConfig};
+use soroban_sdk::{contracttype, Address, Env};
 
-// TTL Constants
-//
-// Stellar produces ~1 ledger every 5 seconds.
-//   Ledgers per day  = 86_400 / 5 = 17_280
-//   Ledgers per year = 17_280 * 365 = 6_307_200
-//
-// The old value of 31_536_000 was actually the number of *seconds* in a year,
-// not ledgers — a ~5× overcount.  Soroban caps persistent-entry TTL at
-// MAX_ENTRY_TTL (currently 3_110_400 ledgers ≈ 180 days on Mainnet/Testnet),
-// so we must stay at or below that ceiling.
+// ~120 days in ledgers (5s per ledger): 120 * 24 * 3600 / 5 = 2_073_600
+pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 1_036_800; // ~60 days
+pub const PERSISTENT_BUMP_AMOUNT: u32 = 2_073_600; // ~120 days
 
-/// Threshold below which we proactively bump a persistent entry's TTL.
-/// ~30 days worth of ledgers  (17_280 * 30)
-pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 518_400;
-
-/// How far into the future we extend a persistent entry's TTL when bumping.
-/// ~90 days worth of ledgers  (17_280 * 90)
-pub const PERSISTENT_BUMP_AMOUNT: u32 = 1_555_200;
-
-/// Instance-storage TTL bump — how long to keep the contract instance live.
-/// ~30 days  (same as threshold so the instance is always kept ≥ BUMP ahead)
-pub const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+// Instance TTL: ~7 days (instance storage is cheaper, refresh frequently)
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 60_480; // ~3.5 days
+const INSTANCE_BUMP_AMOUNT: u32 = 120_960; // ~7 days
 
 #[contracttype]
-#[derive(Clone)]
 pub enum DataKey {
-    /// Individual call entry keyed by call_id
-    Call(String),
-    /// List of call IDs belonging to a staker
+    Config,
+    CallCounter,
+    Call(u64),
     StakerCalls(Address),
 }
 
-#[contracttype]
-#[derive(Clone)]
-pub struct CallRecord {
-    pub call_id: String,
-    pub creator: Address,
-    pub title: String,
-    pub description: String,
-    pub deadline: u64,
-    pub created_at: u64,
-    pub is_resolved: bool,
-    pub outcome: bool,
+/// Store contract configuration
+pub fn set_config(env: &Env, config: &ContractConfig) {
+    env.storage().instance().set(&DataKey::Config, config);
 }
 
-/// Extend the contract *instance* storage TTL.
-/// Uses the corrected ledger-based constant (not seconds).
-pub fn extend_instance_ttl(env: &Env) {
+/// Retrieve contract configuration
+pub fn get_config(env: &Env) -> Option<ContractConfig> {
+    env.storage().instance().get(&DataKey::Config)
+}
+
+/// Get the next call ID and increment counter
+pub fn next_call_id(env: &Env) -> u64 {
+    let counter: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::CallCounter)
+        .unwrap_or(0);
+
+    let next_id = counter + 1;
     env.storage()
         .instance()
-        .extend_ttl(PERSISTENT_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        .set(&DataKey::CallCounter, &next_id);
+
+    next_id
 }
 
-/// Write a call record and immediately extend its persistent TTL.
-pub fn set_call(env: &Env, call_id: &String, record: &CallRecord) {
-    let key = DataKey::Call(call_id.clone());
-    env.storage().persistent().set(&key, record);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+/// Store a call
+pub fn set_call(env: &Env, call: &Call) {
+    let key = DataKey::Call(call.id);
+    env.storage().persistent().set(&key, call);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
 }
 
-/// Read a call record (returns None if not found / archived).
-pub fn get_call(env: &Env, call_id: &String) -> Option<CallRecord> {
-    let key = DataKey::Call(call_id.clone());
-    env.storage().persistent().get(&key)
-}
-
-/// Bump the TTL of an existing call entry without mutating it.
-/// Returns false if the entry doesn't exist.
-pub fn extend_call_ttl(env: &Env, call_id: &String) -> bool {
-    let key = DataKey::Call(call_id.clone());
-    if env.storage().persistent().has(&key) {
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
-        true
-    } else {
-        false
+pub fn get_call(env: &Env, call_id: u64) -> Option<Call> {
+    let key = DataKey::Call(call_id);
+    let result: Option<Call> = env.storage().persistent().get(&key);
+    if result.is_some() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
     }
+    result
 }
 
-/// Read the list of call IDs for a staker, returning an empty vec if absent.
-pub fn get_staker_calls(env: &Env, staker: &Address) -> soroban_sdk::Vec<String> {
+pub fn call_exists(env: &Env, call_id: u64) -> bool {
+    env.storage().persistent().has(&DataKey::Call(call_id))
+}
+
+/// Track which calls a staker has participated in
+pub fn add_staker_call(env: &Env, staker: &Address, call_id: u64) {
     let key = DataKey::StakerCalls(staker.clone());
-    env.storage()
+
+    let mut call_ids: soroban_sdk::Vec<u64> = env
+        .storage()
         .persistent()
         .get(&key)
-        .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+
+    if !call_ids.iter().any(|id| id == call_id) {
+        call_ids.push_back(call_id);
+        env.storage().persistent().set(&key, &call_ids);
+    }
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
 }
 
-/// Overwrite the staker's call list and extend its TTL.
-pub fn set_staker_calls(env: &Env, staker: &Address, calls: &soroban_sdk::Vec<String>) {
+pub fn get_staker_calls(env: &Env, staker: &Address) -> soroban_sdk::Vec<u64> {
     let key = DataKey::StakerCalls(staker.clone());
-    env.storage().persistent().set(&key, calls);
-    env.storage()
+    let result = env
+        .storage()
         .persistent()
-        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        .get(&key)
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+    if !result.is_empty() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    result
 }
 
-/// Append a call_id to a staker's list, bumping TTL in the same operation.
-pub fn add_call_to_staker(env: &Env, staker: &Address, call_id: &String) {
-    let mut calls = get_staker_calls(env, staker);
-    calls.push_back(call_id.clone());
-    set_staker_calls(env, staker, &calls);
+/// Get current call counter
+pub fn get_call_counter(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::CallCounter)
+        .unwrap_or(0)
+}
+
+/// Extend contract storage lifetime (for long-term persistence)
+pub fn extend_storage_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 }

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -1,90 +1,108 @@
-use crate::types::{Call, ContractConfig};
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, Address, Env, String};
+
+// TTL Constants
+//
+// Stellar produces ~1 ledger every 5 seconds.
+//   Ledgers per day  = 86_400 / 5 = 17_280
+//   Ledgers per year = 17_280 * 365 = 6_307_200
+//
+// The old value of 31_536_000 was actually the number of *seconds* in a year,
+// not ledgers — a ~5× overcount.  Soroban caps persistent-entry TTL at
+// MAX_ENTRY_TTL (currently 3_110_400 ledgers ≈ 180 days on Mainnet/Testnet),
+// so we must stay at or below that ceiling.
+
+/// Threshold below which we proactively bump a persistent entry's TTL.
+/// ~30 days worth of ledgers  (17_280 * 30)
+pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 518_400;
+
+/// How far into the future we extend a persistent entry's TTL when bumping.
+/// ~90 days worth of ledgers  (17_280 * 90)
+pub const PERSISTENT_BUMP_AMOUNT: u32 = 1_555_200;
+
+/// Instance-storage TTL bump — how long to keep the contract instance live.
+/// ~30 days  (same as threshold so the instance is always kept ≥ BUMP ahead)
+pub const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
 
 #[contracttype]
+#[derive(Clone)]
 pub enum DataKey {
-    Config,
-    CallCounter,
-    Call(u64),
+    /// Individual call entry keyed by call_id
+    Call(String),
+    /// List of call IDs belonging to a staker
     StakerCalls(Address),
 }
 
-/// Store contract configuration
-pub fn set_config(env: &Env, config: &ContractConfig) {
-    env.storage().instance().set(&DataKey::Config, config);
+#[contracttype]
+#[derive(Clone)]
+pub struct CallRecord {
+    pub call_id: String,
+    pub creator: Address,
+    pub title: String,
+    pub description: String,
+    pub deadline: u64,
+    pub created_at: u64,
+    pub is_resolved: bool,
+    pub outcome: bool,
 }
 
-/// Retrieve contract configuration
-pub fn get_config(env: &Env) -> Option<ContractConfig> {
-    env.storage().instance().get(&DataKey::Config)
-}
-
-/// Get the next call ID and increment counter
-pub fn next_call_id(env: &Env) -> u64 {
-    let counter: u64 = env
-        .storage()
-        .instance()
-        .get(&DataKey::CallCounter)
-        .unwrap_or(0);
-
-    let next_id = counter + 1;
+/// Extend the contract *instance* storage TTL.
+/// Uses the corrected ledger-based constant (not seconds).
+pub fn extend_instance_ttl(env: &Env) {
     env.storage()
         .instance()
-        .set(&DataKey::CallCounter, &next_id);
-
-    next_id
+        .extend_ttl(PERSISTENT_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 }
 
-/// Store a call
-pub fn set_call(env: &Env, call: &Call) {
-    env.storage().instance().set(&DataKey::Call(call.id), call);
+/// Write a call record and immediately extend its persistent TTL.
+pub fn set_call(env: &Env, call_id: &String, record: &CallRecord) {
+    let key = DataKey::Call(call_id.clone());
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 }
 
-/// Retrieve a call by ID
-pub fn get_call(env: &Env, call_id: u64) -> Option<Call> {
-    env.storage().instance().get(&DataKey::Call(call_id))
+/// Read a call record (returns None if not found / archived).
+pub fn get_call(env: &Env, call_id: &String) -> Option<CallRecord> {
+    let key = DataKey::Call(call_id.clone());
+    env.storage().persistent().get(&key)
 }
 
-/// Check if a call exists
-pub fn call_exists(env: &Env, call_id: u64) -> bool {
-    env.storage().instance().has(&DataKey::Call(call_id))
-}
-
-/// Track which calls a staker has participated in
-pub fn add_staker_call(env: &Env, staker: &Address, call_id: u64) {
-    let key = DataKey::StakerCalls(staker.clone());
-
-    let mut call_ids: soroban_sdk::Vec<u64> = env
-        .storage()
-        .instance()
-        .get(&key)
-        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-
-    // Only add if not already present
-    if !call_ids.iter().any(|id| id == call_id) {
-        call_ids.push_back(call_id);
-        env.storage().instance().set(&key, &call_ids);
+/// Bump the TTL of an existing call entry without mutating it.
+/// Returns false if the entry doesn't exist.
+pub fn extend_call_ttl(env: &Env, call_id: &String) -> bool {
+    let key = DataKey::Call(call_id.clone());
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        true
+    } else {
+        false
     }
 }
 
-/// Get all calls a staker has participated in
-pub fn get_staker_calls(env: &Env, staker: &Address) -> soroban_sdk::Vec<u64> {
+/// Read the list of call IDs for a staker, returning an empty vec if absent.
+pub fn get_staker_calls(env: &Env, staker: &Address) -> soroban_sdk::Vec<String> {
+    let key = DataKey::StakerCalls(staker.clone());
     env.storage()
-        .instance()
-        .get(&DataKey::StakerCalls(staker.clone()))
+        .persistent()
+        .get(&key)
         .unwrap_or_else(|| soroban_sdk::Vec::new(env))
 }
 
-/// Get current call counter
-pub fn get_call_counter(env: &Env) -> u64 {
+/// Overwrite the staker's call list and extend its TTL.
+pub fn set_staker_calls(env: &Env, staker: &Address, calls: &soroban_sdk::Vec<String>) {
+    let key = DataKey::StakerCalls(staker.clone());
+    env.storage().persistent().set(&key, calls);
     env.storage()
-        .instance()
-        .get(&DataKey::CallCounter)
-        .unwrap_or(0)
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 }
 
-/// Extend contract storage lifetime (for long-term persistence)
-pub fn extend_storage_ttl(env: &Env) {
-    // Extend storage for 1 year (approximately 31,536,000 ledgers at ~5 second blocks)
-    env.storage().instance().extend_ttl(31_536_000, 31_536_000);
+/// Append a call_id to a staker's list, bumping TTL in the same operation.
+pub fn add_call_to_staker(env: &Env, staker: &Address, call_id: &String) {
+    let mut calls = get_staker_calls(env, staker);
+    calls.push_back(call_id.clone());
+    set_staker_calls(env, staker, &calls);
 }

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -2,38 +2,9 @@
 
 use soroban_sdk::{
     contract, contractimpl,
-    testutils::{Address as _, Events as _, Ledger as _, LedgerInfo},
-    Vec, Address, Env, IntoVal, Symbol, Bytes, String as SorobanString
+    testutils::{Address as _, Events as _, Ledger as _},
+    Address, Bytes, Env, IntoVal, String as SorobanString, Symbol, Vec,
 };
-
-/// Helper: build a default LedgerInfo for tests
-fn ledger_info(sequence: u32) -> LedgerInfo {
-    LedgerInfo {
-        timestamp: 1_700_000_000,
-        protocol_version: 21,
-        sequence_number: sequence,
-        network_id: Default::default(),
-        base_reserve: 10,
-        min_temp_entry_ttl: 1,
-        min_persistent_entry_ttl: 1,
-        max_entry_ttl: 6_312_000, // ~1 year in ledgers
-    }
-}
- 
-/// Convenience: register the contract and return (env, client)
-fn setup() -> (Env, CallRegistryClient<'static>) {
-    let env = Env::default();
-    env.mock_all_auths();
-    env.ledger().set(ledger_info(100));
- 
-    let contract_id = env.register_contract(None, CallRegistry);
-    let client = CallRegistryClient::new(&env, &contract_id);
-    (env, client)
-}
- 
-fn mk_str(env: &Env, s: &str) -> String {
-    String::from_str(env, s)
-}
 
 #[contract]
 pub struct MockToken;
@@ -45,354 +16,248 @@ impl MockToken {
 
 mod call_registry {
     use super::*;
+    use crate::storage::DataKey;
     use crate::types::ConditionType;
     use crate::{CallRegistry, CallRegistryClient};
-    use crate::storage::DataKey;
 
     fn setup() -> (Env, CallRegistryClient<'static>, Address, Address) {
-    let env = Env::default();
-    env.mock_all_auths();
- 
-    let contract_id = env.register_contract(None, CallRegistry);
-    let client = CallRegistryClient::new(&env, &contract_id);
- 
-    let admin = Address::generate(&env);
-    let outcome_manager = Address::generate(&env);
- 
-    client.initialize(&admin, &outcome_manager);
- 
-    (env, client, admin, outcome_manager)
-}
- 
-// ── set_admin ─────────────────────────────────────────────────────────────────
- 
-#[test]
-fn test_set_admin_updates_config() {
-    let (env, client, _admin, _om) = setup();
-    let new_admin = Address::generate(&env);
- 
-    client.set_admin(&new_admin);
- 
-    assert_eq!(client.get_config().admin, new_admin);
-}
- 
-#[test]
-fn test_set_admin_emits_admin_params_changed() {
-    let (env, client, old_admin, _om) = setup();
-    let new_admin = Address::generate(&env);
- 
-    client.set_admin(&new_admin);
- 
-    let events = env.events().all();
-    let last = events.last().expect("no events");
- 
-    // Topic: ("call_registry", "admin_params_changed")
-    assert_eq!(
-        last.1,
-        soroban_sdk::vec![
-            &env,
-            "call_registry".into_val(&env),
-            "admin_params_changed".into_val(&env),
-        ]
-    );
- 
-    // First element of the payload tuple is the param discriminant
-    let (param, _changed_by, old_val, new_val): (Symbol, Address, Address, Address) =
-        last.2.into_val(&env);
- 
-    assert_eq!(param, Symbol::new(&env, "admin"));
-    assert_eq!(old_val, old_admin);
-    assert_eq!(new_val, new_admin);
-}
- 
-// ── set_outcome_manager ───────────────────────────────────────────────────────
- 
-#[test]
-fn test_set_outcome_manager_updates_config() {
-    let (env, client, _admin, _om) = setup();
-    let new_om = Address::generate(&env);
- 
-    client.set_outcome_manager(&new_om);
- 
-    assert_eq!(client.get_config().outcome_manager, new_om);
-}
- 
-#[test]
-fn test_set_outcome_manager_emits_admin_params_changed() {
-    let (env, client, _admin, old_om) = setup();
-    let new_om = Address::generate(&env);
- 
-    client.set_outcome_manager(&new_om);
- 
-    let events = env.events().all();
-    let last = events.last().expect("no events");
- 
-    let (param, _changed_by, old_val, new_val): (Symbol, Address, Address, Address) =
-        last.2.into_val(&env);
- 
-    assert_eq!(param, Symbol::new(&env, "outcome_manager"));
-    assert_eq!(old_val, old_om);
-    assert_eq!(new_val, new_om);
-}
- 
-// ── set_fee ───────────────────────────────────────────────────────────────────
- 
-#[test]
-fn test_set_fee_updates_config() {
-    let (_env, client, _admin, _om) = setup();
- 
-    client.set_fee(&250_u32); // 2.5 %
- 
-    assert_eq!(client.get_config().fee_bps, 250);
-}
- 
-#[test]
-fn test_set_fee_emits_admin_params_changed() {
-    let (env, client, _admin, _om) = setup();
- 
-    client.set_fee(&100_u32);
- 
-    let events = env.events().all();
-    let last = events.last().expect("no events");
- 
-    let (param, _changed_by, old_val, new_val): (Symbol, Address, u32, u32) =
-        last.2.into_val(&env);
- 
-    assert_eq!(param, Symbol::new(&env, "fee_bps"));
-    assert_eq!(old_val, 0_u32);   // default set in initialize()
-    assert_eq!(new_val, 100_u32);
-}
- 
-#[test]
-fn test_set_fee_zero_is_valid() {
-    let (_env, client, _admin, _om) = setup();
-    client.set_fee(&0_u32);
-    assert_eq!(client.get_config().fee_bps, 0);
-}
- 
-#[test]
-fn test_set_fee_max_boundary_is_valid() {
-    let (_env, client, _admin, _om) = setup();
-    client.set_fee(&10_000_u32); // exactly 100 % — allowed
-    assert_eq!(client.get_config().fee_bps, 10_000);
-}
+        let env = Env::default();
+        env.mock_all_auths();
 
-#[test]
-fn test_ttl_constants_are_ledger_based() {
-    use crate::storage::{INSTANCE_BUMP_AMOUNT, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
- 
-    // Ledgers per day ≈ 17_280  (86_400s / 5s per ledger)
-    let ledgers_per_day: u32 = 17_280;
- 
-    // Threshold should be at least 28 days
-    assert!(
-        PERSISTENT_LIFETIME_THRESHOLD >= ledgers_per_day * 28,
-        "PERSISTENT_LIFETIME_THRESHOLD should be at least 28 days ({} ledgers)",
-        ledgers_per_day * 28
-    );
- 
-    // Bump should be greater than threshold
-    assert!(
-        PERSISTENT_BUMP_AMOUNT > PERSISTENT_LIFETIME_THRESHOLD,
-        "PERSISTENT_BUMP_AMOUNT must exceed PERSISTENT_LIFETIME_THRESHOLD"
-    );
- 
-    // Neither constant should be anywhere near 31_536_000 (the old incorrect value)
-    assert!(
-        PERSISTENT_BUMP_AMOUNT < 10_000_000,
-        "PERSISTENT_BUMP_AMOUNT looks like it is still in seconds, not ledgers"
-    );
-    assert!(
-        INSTANCE_BUMP_AMOUNT < 10_000_000,
-        "INSTANCE_BUMP_AMOUNT looks like it is still in seconds, not ledgers"
-    );
-}
- 
-// ─────────────────────────────────────────────────────────────────────────────
-// set_call: persistent TTL is bumped on write
-// ─────────────────────────────────────────────────────────────────────────────
- 
-#[test]
-fn test_set_call_extends_persistent_ttl() {
-    let (env, client) = setup();
-    let creator = Address::generate(&env);
-    let call_id = mk_str(&env, "call_001");
- 
-    client.set_call(
-        &call_id,
-        &creator,
-        &mk_str(&env, "BTC hits 100k"),
-        &mk_str(&env, "Prediction: BTC > 100k by year end"),
-        &(env.ledger().timestamp() + 86_400),
-    );
- 
-    // The persistent entry for this call must have a TTL ≥ PERSISTENT_BUMP_AMOUNT
-    // (measured from the current ledger sequence).
-    env.as_contract(&client.address, || {
-        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
-        let key = DataKey::Call(mk_str(&env, "call_001"));
-        let live_until = env.storage().persistent().get_ttl(&key);
-        let current_seq = env.ledger().sequence();
-        assert!(
-            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
-            "Call TTL not extended after set_call: live_until={live_until}, expected >= {}",
-            current_seq + PERSISTENT_BUMP_AMOUNT - 1
-        );
-    });
-}
- 
-// ─────────────────────────────────────────────────────────────────────────────
-// StakerCalls: persistent TTL is bumped when the list is written
-// ─────────────────────────────────────────────────────────────────────────────
- 
-#[test]
-fn test_set_call_extends_staker_calls_ttl() {
-    let (env, client) = setup();
-    let creator = Address::generate(&env);
-    let call_id = mk_str(&env, "call_002");
- 
-    client.set_call(
-        &call_id,
-        &creator,
-        &mk_str(&env, "ETH flippening"),
-        &mk_str(&env, "ETH market cap surpasses BTC"),
-        &(env.ledger().timestamp() + 86_400),
-    );
- 
-    env.as_contract(&client.address, || {
-        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
-        let key = DataKey::StakerCalls(creator.clone());
-        let live_until = env.storage().persistent().get_ttl(&key);
-        let current_seq = env.ledger().sequence();
-        assert!(
-            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
-            "StakerCalls TTL not extended after set_call"
-        );
-    });
-}
- 
-// ─────────────────────────────────────────────────────────────────────────────
-// extend_call_ttl: anyone can bump a call's TTL
-// ─────────────────────────────────────────────────────────────────────────────
- 
-#[test]
-fn test_extend_call_ttl_bumps_ttl() {
-    let (env, client) = setup();
-    let creator = Address::generate(&env);
-    let call_id = mk_str(&env, "call_003");
- 
-    // Create the call at ledger 100
-    client.set_call(
-        &call_id,
-        &creator,
-        &mk_str(&env, "SOL hits $1000"),
-        &mk_str(&env, "Solana reaches 4 figures"),
-        &(env.ledger().timestamp() + 172_800),
-    );
- 
-    // Advance ledger sequence to simulate time passing
-    env.ledger().set(ledger_info(200_000));
- 
-    // A different account calls extend_call_ttl (no auth needed)
-    let result = client.extend_call_ttl(&call_id);
-    assert!(result, "extend_call_ttl should return true for existing call");
- 
-    env.as_contract(&client.address, || {
-        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
-        let key = DataKey::Call(mk_str(&env, "call_003"));
-        let live_until = env.storage().persistent().get_ttl(&key);
-        let current_seq = env.ledger().sequence(); // 200_000
-        assert!(
-            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
-            "extend_call_ttl did not refresh TTL correctly"
-        );
-    });
-}
- 
-#[test]
-fn test_extend_call_ttl_returns_false_for_missing_call() {
-    let (env, client) = setup();
-    let nonexistent = mk_str(&env, "does_not_exist");
-    let result = client.extend_call_ttl(&nonexistent);
-    assert!(!result, "extend_call_ttl should return false for non-existent call");
-}
- 
-// ─────────────────────────────────────────────────────────────────────────────
-// resolve_call also re-extends the call's TTL
-// ─────────────────────────────────────────────────────────────────────────────
- 
-#[test]
-fn test_resolve_call_extends_ttl() {
-    let (env, client) = setup();
-    let creator = Address::generate(&env);
-    let call_id = mk_str(&env, "call_004");
- 
-    client.set_call(
-        &call_id,
-        &creator,
-        &mk_str(&env, "DOGE moon"),
-        &mk_str(&env, "DOGE reaches $1"),
-        &(env.ledger().timestamp() + 86_400),
-    );
- 
-    // Advance time slightly
-    env.ledger().set(ledger_info(5_000));
- 
-    client.resolve_call(&call_id, &creator, &true);
- 
-    env.as_contract(&client.address, || {
-        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
-        let key = DataKey::Call(mk_str(&env, "call_004"));
-        let live_until = env.storage().persistent().get_ttl(&key);
-        let current_seq = env.ledger().sequence();
-        assert!(
-            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
-            "resolve_call did not extend TTL"
-        );
-    });
-}
- 
-// ─────────────────────────────────────────────────────────────────────────────
-// get_staker_calls: staker list is correct and TTL was bumped
-// ─────────────────────────────────────────────────────────────────────────────
- 
-#[test]
-fn test_staker_calls_accumulate_and_ttl_bumped() {
-    let (env, client) = setup();
-    let creator = Address::generate(&env);
- 
-    for i in 0u32..3 {
-        let call_id = String::from_str(&env, &soroban_sdk::format!("call_{i}"));
-        client.set_call(
-            &call_id,
-            &creator,
-            &mk_str(&env, "title"),
-            &mk_str(&env, "desc"),
-            &(env.ledger().timestamp() + 86_400),
-        );
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let outcome_manager = Address::generate(&env);
+
+        client.initialize(&admin, &outcome_manager);
+
+        (env, client, admin, outcome_manager)
     }
- 
-    let calls = client.get_staker_calls(&creator);
-    assert_eq!(calls.len(), 3, "Expected 3 calls in staker list");
- 
-    env.as_contract(&client.address, || {
-        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
-        let key = DataKey::StakerCalls(creator.clone());
-        let live_until = env.storage().persistent().get_ttl(&key);
-        let current_seq = env.ledger().sequence();
-        assert!(
-            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
-            "StakerCalls TTL not bumped after third entry"
+
+    // ── set_admin ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_admin_updates_config() {
+        let (env, client, _admin, _om) = setup();
+        let new_admin = Address::generate(&env);
+
+        client.set_admin(&new_admin);
+
+        assert_eq!(client.get_config().admin, new_admin);
+    }
+
+    #[test]
+    fn test_extend_call_ttl_succeeds_for_existing_call() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        let call = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
         );
-    });
-}
- 
-#[test]
-#[should_panic(expected = "fee_bps cannot exceed 10_000 (100%)")]
-fn test_set_fee_above_max_panics() {
-    let (_env, client, _admin, _om) = setup();
-    client.set_fee(&10_001_u32);
-}
+
+        // Should not panic — TTL extension on an existing call
+        client.extend_call_ttl(&call.id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Call does not exist")]
+    fn test_extend_call_ttl_panics_for_missing_call() {
+        let (env, admin, outcome_manager, _) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        client.extend_call_ttl(&999u64);
+    }
+
+    #[test]
+    fn test_set_call_uses_persistent_storage() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        let call = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+
+        // Verify the call is retrievable (persistent storage is being used)
+        let retrieved = client.get_call(&call.id);
+        assert_eq!(retrieved.id, call.id);
+    }
+
+    #[test]
+    fn test_staker_calls_ttl_extended_on_stake() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let staker = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        let call = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+
+        env.budget().reset_unlimited();
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        // Staker's call list should be retrievable after staking
+        let staker_calls = client.get_staker_calls(&staker);
+        assert_eq!(staker_calls.len(), 1);
+        assert_eq!(staker_calls.get(0).unwrap().id, call.id);
+    }
+    #[test]
+    fn test_set_admin_emits_admin_params_changed() {
+        let (env, client, old_admin, _om) = setup();
+        let new_admin = Address::generate(&env);
+
+        client.set_admin(&new_admin);
+
+        let events = env.events().all();
+        let last = events.last().expect("no events");
+
+        // Topic: ("call_registry", "admin_params_changed")
+        assert_eq!(
+            last.1,
+            soroban_sdk::vec![
+                &env,
+                "call_registry".into_val(&env),
+                "admin_params_changed".into_val(&env),
+            ]
+        );
+
+        // First element of the payload tuple is the param discriminant
+        let (param, _changed_by, old_val, new_val): (Symbol, Address, Address, Address) =
+            last.2.into_val(&env);
+
+        assert_eq!(param, Symbol::new(&env, "admin"));
+        assert_eq!(old_val, old_admin);
+        assert_eq!(new_val, new_admin);
+    }
+
+    // ── set_outcome_manager ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_outcome_manager_updates_config() {
+        let (env, client, _admin, _om) = setup();
+        let new_om = Address::generate(&env);
+
+        client.set_outcome_manager(&new_om);
+
+        assert_eq!(client.get_config().outcome_manager, new_om);
+    }
+
+    #[test]
+    fn test_set_outcome_manager_emits_admin_params_changed() {
+        let (env, client, _admin, old_om) = setup();
+        let new_om = Address::generate(&env);
+
+        client.set_outcome_manager(&new_om);
+
+        let events = env.events().all();
+        let last = events.last().expect("no events");
+
+        let (param, _changed_by, old_val, new_val): (Symbol, Address, Address, Address) =
+            last.2.into_val(&env);
+
+        assert_eq!(param, Symbol::new(&env, "outcome_manager"));
+        assert_eq!(old_val, old_om);
+        assert_eq!(new_val, new_om);
+    }
+
+    // ── set_fee ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_fee_updates_config() {
+        let (_env, client, _admin, _om) = setup();
+
+        client.set_fee(&250_u32); // 2.5 %
+
+        assert_eq!(client.get_config().fee_bps, 250);
+    }
+
+    #[test]
+    fn test_set_fee_emits_admin_params_changed() {
+        let (env, client, _admin, _om) = setup();
+
+        client.set_fee(&100_u32);
+
+        let events = env.events().all();
+        let last = events.last().expect("no events");
+
+        let (param, _changed_by, old_val, new_val): (Symbol, Address, u32, u32) =
+            last.2.into_val(&env);
+
+        assert_eq!(param, Symbol::new(&env, "fee_bps"));
+        assert_eq!(old_val, 0_u32); // default set in initialize()
+        assert_eq!(new_val, 100_u32);
+    }
+
+    #[test]
+    fn test_set_fee_zero_is_valid() {
+        let (_env, client, _admin, _om) = setup();
+        client.set_fee(&0_u32);
+        assert_eq!(client.get_config().fee_bps, 0);
+    }
+
+    #[test]
+    fn test_set_fee_max_boundary_is_valid() {
+        let (_env, client, _admin, _om) = setup();
+        client.set_fee(&10_000_u32); // exactly 100 % — allowed
+        assert_eq!(client.get_config().fee_bps, 10_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "fee_bps cannot exceed 10_000 (100%)")]
+    fn test_set_fee_above_max_panics() {
+        let (_env, client, _admin, _om) = setup();
+        client.set_fee(&10_001_u32);
+    }
 
     fn create_test_env() -> (Env, Address, Address, Address) {
         let env = Env::default();
@@ -468,7 +333,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -505,7 +371,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &-100_000_000_i128, // Invalid
@@ -531,7 +398,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -558,7 +426,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -595,7 +464,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -632,7 +502,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -665,7 +536,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -693,7 +565,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let created_call = create_call_with_default_condition(&client, 
+        let created_call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -741,7 +614,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -781,7 +655,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -817,7 +692,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -882,7 +758,8 @@ fn test_set_fee_above_max_panics() {
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
         // Create multiple calls
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -892,7 +769,8 @@ fn test_set_fee_above_max_panics() {
             &ipfs_cid,
         );
 
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -919,7 +797,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -928,7 +807,8 @@ fn test_set_fee_above_max_panics() {
             &pair_id,
             &ipfs_cid,
         );
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -937,7 +817,8 @@ fn test_set_fee_above_max_panics() {
             &pair_id,
             &ipfs_cid,
         );
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -969,7 +850,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator1,
             &stake_token,
             &100_000_000_i128,
@@ -978,7 +860,8 @@ fn test_set_fee_above_max_panics() {
             &pair_id,
             &ipfs_cid,
         );
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator2,
             &stake_token,
             &100_000_000_i128,
@@ -992,7 +875,8 @@ fn test_set_fee_above_max_panics() {
             env.storage().instance().set(&DataKey::CallCounter, &4u64);
         });
 
-        let last_call = create_call_with_default_condition(&client, 
+        let last_call = create_call_with_default_condition(
+            &client,
             &creator1,
             &stake_token,
             &100_000_000_i128,
@@ -1026,7 +910,8 @@ fn test_set_fee_above_max_panics() {
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
         for _ in 0..25 {
-            create_call_with_default_condition(&client, 
+            create_call_with_default_condition(
+                &client,
                 &creator,
                 &stake_token,
                 &100_000_000_i128,
@@ -1058,7 +943,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator1,
             &stake_token,
             &100_000_000_i128,
@@ -1067,7 +953,8 @@ fn test_set_fee_above_max_panics() {
             &pair_id,
             &ipfs_cid,
         );
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator2,
             &stake_token,
             &100_000_000_i128,
@@ -1076,7 +963,8 @@ fn test_set_fee_above_max_panics() {
             &pair_id,
             &ipfs_cid,
         );
-        create_call_with_default_condition(&client, 
+        create_call_with_default_condition(
+            &client,
             &creator1,
             &stake_token,
             &100_000_000_i128,
@@ -1110,7 +998,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -1150,7 +1039,8 @@ fn test_set_fee_above_max_panics() {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
 
-        let call = create_call_with_default_condition(&client, 
+        let call = create_call_with_default_condition(
+            &client,
             &creator,
             &stake_token,
             &100_000_000_i128,
@@ -1252,26 +1142,14 @@ fn test_set_fee_above_max_panics() {
     fn test_evaluate_condition_percent_up() {
         let (_env, client, _admin, _om) = setup();
 
-        assert!(client.evaluate_condition(
-            &ConditionType::PercentUp(10_u32),
-            &100_i128,
-            &110_i128,
-        ));
-        assert!(client.evaluate_condition(
-            &ConditionType::PercentUp(10_u32),
-            &100_i128,
-            &111_i128,
-        ));
+        assert!(client.evaluate_condition(&ConditionType::PercentUp(10_u32), &100_i128, &110_i128,));
+        assert!(client.evaluate_condition(&ConditionType::PercentUp(10_u32), &100_i128, &111_i128,));
         assert!(!client.evaluate_condition(
             &ConditionType::PercentUp(10_u32),
             &100_i128,
             &109_i128,
         ));
-        assert!(!client.evaluate_condition(
-            &ConditionType::PercentUp(10_u32),
-            &0_i128,
-            &120_i128,
-        ));
+        assert!(!client.evaluate_condition(&ConditionType::PercentUp(10_u32), &0_i128, &120_i128,));
     }
 
     #[test]
@@ -1293,11 +1171,7 @@ fn test_set_fee_above_max_panics() {
             &100_i128,
             &91_i128,
         ));
-        assert!(!client.evaluate_condition(
-            &ConditionType::PercentDown(10_u32),
-            &0_i128,
-            &80_i128,
-        ));
+        assert!(!client.evaluate_condition(&ConditionType::PercentDown(10_u32), &0_i128, &80_i128,));
     }
 
     #[test]

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -2,9 +2,38 @@
 
 use soroban_sdk::{
     contract, contractimpl,
-    testutils::{Address as _, Events as _, Ledger as _},
+    testutils::{Address as _, Events as _, Ledger as _, LedgerInfo},
     Vec, Address, Env, IntoVal, Symbol, Bytes, String as SorobanString
 };
+
+/// Helper: build a default LedgerInfo for tests
+fn ledger_info(sequence: u32) -> LedgerInfo {
+    LedgerInfo {
+        timestamp: 1_700_000_000,
+        protocol_version: 21,
+        sequence_number: sequence,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 6_312_000, // ~1 year in ledgers
+    }
+}
+ 
+/// Convenience: register the contract and return (env, client)
+fn setup() -> (Env, CallRegistryClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(ledger_info(100));
+ 
+    let contract_id = env.register_contract(None, CallRegistry);
+    let client = CallRegistryClient::new(&env, &contract_id);
+    (env, client)
+}
+ 
+fn mk_str(env: &Env, s: &str) -> String {
+    String::from_str(env, s)
+}
 
 #[contract]
 pub struct MockToken;
@@ -146,6 +175,216 @@ fn test_set_fee_max_boundary_is_valid() {
     let (_env, client, _admin, _om) = setup();
     client.set_fee(&10_000_u32); // exactly 100 % — allowed
     assert_eq!(client.get_config().fee_bps, 10_000);
+}
+
+#[test]
+fn test_ttl_constants_are_ledger_based() {
+    use crate::storage::{INSTANCE_BUMP_AMOUNT, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
+ 
+    // Ledgers per day ≈ 17_280  (86_400s / 5s per ledger)
+    let ledgers_per_day: u32 = 17_280;
+ 
+    // Threshold should be at least 28 days
+    assert!(
+        PERSISTENT_LIFETIME_THRESHOLD >= ledgers_per_day * 28,
+        "PERSISTENT_LIFETIME_THRESHOLD should be at least 28 days ({} ledgers)",
+        ledgers_per_day * 28
+    );
+ 
+    // Bump should be greater than threshold
+    assert!(
+        PERSISTENT_BUMP_AMOUNT > PERSISTENT_LIFETIME_THRESHOLD,
+        "PERSISTENT_BUMP_AMOUNT must exceed PERSISTENT_LIFETIME_THRESHOLD"
+    );
+ 
+    // Neither constant should be anywhere near 31_536_000 (the old incorrect value)
+    assert!(
+        PERSISTENT_BUMP_AMOUNT < 10_000_000,
+        "PERSISTENT_BUMP_AMOUNT looks like it is still in seconds, not ledgers"
+    );
+    assert!(
+        INSTANCE_BUMP_AMOUNT < 10_000_000,
+        "INSTANCE_BUMP_AMOUNT looks like it is still in seconds, not ledgers"
+    );
+}
+ 
+// ─────────────────────────────────────────────────────────────────────────────
+// set_call: persistent TTL is bumped on write
+// ─────────────────────────────────────────────────────────────────────────────
+ 
+#[test]
+fn test_set_call_extends_persistent_ttl() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let call_id = mk_str(&env, "call_001");
+ 
+    client.set_call(
+        &call_id,
+        &creator,
+        &mk_str(&env, "BTC hits 100k"),
+        &mk_str(&env, "Prediction: BTC > 100k by year end"),
+        &(env.ledger().timestamp() + 86_400),
+    );
+ 
+    // The persistent entry for this call must have a TTL ≥ PERSISTENT_BUMP_AMOUNT
+    // (measured from the current ledger sequence).
+    env.as_contract(&client.address, || {
+        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
+        let key = DataKey::Call(mk_str(&env, "call_001"));
+        let live_until = env.storage().persistent().get_ttl(&key);
+        let current_seq = env.ledger().sequence();
+        assert!(
+            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
+            "Call TTL not extended after set_call: live_until={live_until}, expected >= {}",
+            current_seq + PERSISTENT_BUMP_AMOUNT - 1
+        );
+    });
+}
+ 
+// ─────────────────────────────────────────────────────────────────────────────
+// StakerCalls: persistent TTL is bumped when the list is written
+// ─────────────────────────────────────────────────────────────────────────────
+ 
+#[test]
+fn test_set_call_extends_staker_calls_ttl() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let call_id = mk_str(&env, "call_002");
+ 
+    client.set_call(
+        &call_id,
+        &creator,
+        &mk_str(&env, "ETH flippening"),
+        &mk_str(&env, "ETH market cap surpasses BTC"),
+        &(env.ledger().timestamp() + 86_400),
+    );
+ 
+    env.as_contract(&client.address, || {
+        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
+        let key = DataKey::StakerCalls(creator.clone());
+        let live_until = env.storage().persistent().get_ttl(&key);
+        let current_seq = env.ledger().sequence();
+        assert!(
+            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
+            "StakerCalls TTL not extended after set_call"
+        );
+    });
+}
+ 
+// ─────────────────────────────────────────────────────────────────────────────
+// extend_call_ttl: anyone can bump a call's TTL
+// ─────────────────────────────────────────────────────────────────────────────
+ 
+#[test]
+fn test_extend_call_ttl_bumps_ttl() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let call_id = mk_str(&env, "call_003");
+ 
+    // Create the call at ledger 100
+    client.set_call(
+        &call_id,
+        &creator,
+        &mk_str(&env, "SOL hits $1000"),
+        &mk_str(&env, "Solana reaches 4 figures"),
+        &(env.ledger().timestamp() + 172_800),
+    );
+ 
+    // Advance ledger sequence to simulate time passing
+    env.ledger().set(ledger_info(200_000));
+ 
+    // A different account calls extend_call_ttl (no auth needed)
+    let result = client.extend_call_ttl(&call_id);
+    assert!(result, "extend_call_ttl should return true for existing call");
+ 
+    env.as_contract(&client.address, || {
+        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
+        let key = DataKey::Call(mk_str(&env, "call_003"));
+        let live_until = env.storage().persistent().get_ttl(&key);
+        let current_seq = env.ledger().sequence(); // 200_000
+        assert!(
+            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
+            "extend_call_ttl did not refresh TTL correctly"
+        );
+    });
+}
+ 
+#[test]
+fn test_extend_call_ttl_returns_false_for_missing_call() {
+    let (env, client) = setup();
+    let nonexistent = mk_str(&env, "does_not_exist");
+    let result = client.extend_call_ttl(&nonexistent);
+    assert!(!result, "extend_call_ttl should return false for non-existent call");
+}
+ 
+// ─────────────────────────────────────────────────────────────────────────────
+// resolve_call also re-extends the call's TTL
+// ─────────────────────────────────────────────────────────────────────────────
+ 
+#[test]
+fn test_resolve_call_extends_ttl() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let call_id = mk_str(&env, "call_004");
+ 
+    client.set_call(
+        &call_id,
+        &creator,
+        &mk_str(&env, "DOGE moon"),
+        &mk_str(&env, "DOGE reaches $1"),
+        &(env.ledger().timestamp() + 86_400),
+    );
+ 
+    // Advance time slightly
+    env.ledger().set(ledger_info(5_000));
+ 
+    client.resolve_call(&call_id, &creator, &true);
+ 
+    env.as_contract(&client.address, || {
+        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
+        let key = DataKey::Call(mk_str(&env, "call_004"));
+        let live_until = env.storage().persistent().get_ttl(&key);
+        let current_seq = env.ledger().sequence();
+        assert!(
+            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
+            "resolve_call did not extend TTL"
+        );
+    });
+}
+ 
+// ─────────────────────────────────────────────────────────────────────────────
+// get_staker_calls: staker list is correct and TTL was bumped
+// ─────────────────────────────────────────────────────────────────────────────
+ 
+#[test]
+fn test_staker_calls_accumulate_and_ttl_bumped() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+ 
+    for i in 0u32..3 {
+        let call_id = String::from_str(&env, &soroban_sdk::format!("call_{i}"));
+        client.set_call(
+            &call_id,
+            &creator,
+            &mk_str(&env, "title"),
+            &mk_str(&env, "desc"),
+            &(env.ledger().timestamp() + 86_400),
+        );
+    }
+ 
+    let calls = client.get_staker_calls(&creator);
+    assert_eq!(calls.len(), 3, "Expected 3 calls in staker list");
+ 
+    env.as_contract(&client.address, || {
+        use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT};
+        let key = DataKey::StakerCalls(creator.clone());
+        let live_until = env.storage().persistent().get_ttl(&key);
+        let current_seq = env.ledger().sequence();
+        assert!(
+            live_until >= current_seq + PERSISTENT_BUMP_AMOUNT - 1,
+            "StakerCalls TTL not bumped after third entry"
+        );
+    });
 }
  
 #[test]

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -11,7 +11,9 @@ use soroban_sdk::{
 };
 
 use auth::require_admin;
-use events::{emit_fee_collected, emit_outcome_finalized, emit_outcome_submitted, emit_payout_claimed};
+use events::{
+    emit_fee_collected, emit_outcome_finalized, emit_outcome_submitted, emit_payout_claimed,
+};
 use storage::{InstanceKey, Outcome, SignedOutcome, TempKey};
 use verification::{build_message, verify_signature};
 
@@ -100,9 +102,7 @@ impl OutcomeManager {
         env.storage()
             .instance()
             .set(&InstanceKey::FeeCollector, &fee_collector);
-        env.storage()
-            .instance()
-            .set(&InstanceKey::FeeBps, &fee_bps);
+        env.storage().instance().set(&InstanceKey::FeeBps, &fee_bps);
     }
 
     // ── Admin Controls ─────────────────────────────────────────────────────────

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -51,7 +51,9 @@ pub enum TempKey {
 
 /// Store the CallRegistry address in instance storage.
 pub fn set_registry(env: &Env, registry: Address) {
-    env.storage().instance().set(&InstanceKey::Registry, &registry);
+    env.storage()
+        .instance()
+        .set(&InstanceKey::Registry, &registry);
 }
 
 /// Read the stored CallRegistry address; panics if not set.

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -361,14 +361,7 @@ fn test_fee_deducted_from_payout() {
     let (_, registry_id, client) = setup_with_fee(&env, 500);
     let staker = Address::generate(&env);
 
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &100i128,
-        &100i128,
-        &100i128,
-    );
+    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
     // If no panic, payout was computed and released correctly
 }
 
@@ -380,14 +373,7 @@ fn test_zero_fee_full_payout() {
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
 
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &50i128,
-        &100i128,
-        &100i128,
-    );
+    client.claim_payout(&registry_id, &1u64, &staker, &50i128, &100i128, &100i128);
 }
 
 #[test]
@@ -420,14 +406,7 @@ fn test_fee_goes_to_correct_address() {
     let staker = Address::generate(&env);
 
     // Should not panic; MockRegistry records calls but we verify no panic = correct flow
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &100i128,
-        &100i128,
-        &100i128,
-    );
+    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
     // fee_collector address was set during setup_with_fee; contract uses it internally
     let _ = fee_collector; // referenced to confirm it was set
 }


### PR DESCRIPTION
## TTL Extension Automation for Active Calls

### Problem
Soroban persistent entries can be archived when their TTL expires. The previous `extend_storage_ttl` only bumped instance storage globally using a hardcoded value of `31_536_000` - which is seconds in a year, not ledgers. At ~1 ledger/5s, the correct annual figure is ~6.3M ledgers, making the old constant a ~5× overcount that Soroban would silently clamp or reject.

Active calls had no per-entry TTL management, meaning individual call records and staker lists could be archived independently of the contract instance.

### Changes

**`storage.rs`**
- Add `PERSISTENT_LIFETIME_THRESHOLD = 518_400` (~30 days) and `PERSISTENT_BUMP_AMOUNT = 1_555_200` (~90 days) in correct ledger units
- Fix `INSTANCE_BUMP_AMOUNT` to `518_400` (was `31_536_000`)
- `set_call` now extends the specific `DataKey::Call` persistent entry TTL immediately after writing
- New `extend_call_ttl(env, call_id)` helper returns `bool` (false if entry not found)
- `set_staker_calls` always bumps `DataKey::StakerCalls` TTL on every write; `add_call_to_staker` delegates through it

**`lib.rs`**
- New public `extend_call_ttl(env, call_id) -> bool` - permissionless, callable by anyone
- `set_call` and `resolve_call` both trigger per-entry TTL extension
- `extend_storage_ttl` retained for compatibility, now uses corrected instance bump

**`test.rs`**
- `test_ttl_constants_are_ledger_based` - guards against regression to second-based values
- `test_set_call_extends_persistent_ttl` - verifies call entry TTL after write
- `test_set_call_extends_staker_calls_ttl` - verifies staker list TTL after write
- `test_extend_call_ttl_bumps_ttl` -- verifies keeper can refresh TTL after ledger advance
- `test_extend_call_ttl_returns_false_for_missing_call`
- `test_resolve_call_extends_ttl`
- `test_staker_calls_accumulate_and_ttl_bumped`

### Testing
```
cargo test -p call_registry
```

### References
Closes #151