### PR TITLE
feat(frontend): implement share market to social media (#236)

### DIFF
--- a/packages/frontend/src/app/calls/[id]/page.tsx
+++ b/packages/frontend/src/app/calls/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import CallDetail from "@/components/CallDetail";
 import { CallDetailData } from "@/types";
+import { useMetaTags } from "@/hooks/useMetaTags";
 
 // Health check function (checks if our mock API is responsive)
 async function checkApiHealth(): Promise<boolean> {
@@ -30,6 +31,16 @@ export default function CallDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [apiStatus, setApiStatus] = useState<'checking' | 'online' | 'offline'>('checking');
+
+  // Set meta tags when call data is available
+  useMetaTags({
+    title: call?.title || `Market #${id}`,
+    description:
+      call?.condition ||
+      "Trade your conviction on Stellar prediction markets. Put your staking power where your mouth is.",
+    url: `${typeof window !== "undefined" ? window.location.origin : ""}/calls/${id}`,
+    image: "/og-default.png",
+  });
 
   useEffect(() => {
     async function fetchCall() {

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -9,6 +9,27 @@ const inter = Inter({ subsets: ["latin"] });
 export const metadata = {
   title: "BACKit - Stellar Prediction Markets",
   description: "Decentralized prediction markets on Stellar",
+  openGraph: {
+    title: "BACKit - Stellar Prediction Markets",
+    description: "Decentralized prediction markets on Stellar",
+    type: "website",
+    url: "https://backit.io",
+    siteName: "BACKit",
+    images: [
+      {
+        url: "https://backit.io/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "BACKit - Prediction Markets",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "BACKit - Stellar Prediction Markets",
+    description: "Decentralized prediction markets on Stellar",
+    images: ["https://backit.io/og-image.png"],
+  },
 };
 
 export default function RootLayout({

--- a/packages/frontend/src/components/CallCard.tsx
+++ b/packages/frontend/src/components/CallCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import StakeBar from "./StakeBar";
+import ShareButton from "./ShareButton";
 import { useState, useEffect } from "react";
 
 interface CallCardProps {
@@ -112,9 +113,17 @@ export default function CallCard({ call }: CallCardProps) {
             </div>
           </div>
         </div>
-        <div className="text-right">
-          <div className="text-[10px] font-bold text-gray-400 uppercase">Participants</div>
-          <div className="text-sm font-bold text-gray-700">{call.participants || 0}</div>
+        <div className="flex items-center gap-4">
+          <div className="text-right">
+            <div className="text-[10px] font-bold text-gray-400 uppercase">Participants</div>
+            <div className="text-sm font-bold text-gray-700">{call.participants || 0}</div>
+          </div>
+          <ShareButton
+            callId={call.id}
+            marketTitle={call.condition}
+            currentOdds={odds || undefined}
+            compact
+          />
         </div>
       </div>
     </div>

--- a/packages/frontend/src/components/CallDetailHeader.tsx
+++ b/packages/frontend/src/components/CallDetailHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CallDetailData } from "@/types";
+import ShareButton from "./ShareButton";
 
 interface Props {
   call: CallDetailData;
@@ -66,25 +67,34 @@ export default function CallDetailHeader({ call, timeLeft, odds }: Props) {
       </div>
       
       {/* Creator info */}
-      <div className="mt-10 pt-6 border-t border-slate-700/50 flex flex-wrap items-center gap-6 text-sm">
-        <div className="flex items-center gap-2">
-            <div className="w-8 h-8 rounded-full bg-slate-700 flex items-center justify-center font-black text-xs text-slate-300">
-               {call.creatorAddress.slice(0, 1)}
-            </div>
-            <div>
-                <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">Creator</p>
-                <p className="font-mono text-slate-300 font-bold">{call.creatorAddress.slice(0, 6)}...{call.creatorAddress.slice(-4)}</p>
-            </div>
-        </div>
-        
-        <div className="h-4 w-px bg-slate-700 mx-2" />
+      <div className="mt-10 pt-6 border-t border-slate-700/50 flex flex-wrap items-center justify-between gap-6 text-sm">
+        <div className="flex items-center gap-6">
+          <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-slate-700 flex items-center justify-center font-black text-xs text-slate-300">
+                 {call.creatorAddress.slice(0, 1)}
+              </div>
+              <div>
+                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">Creator</p>
+                  <p className="font-mono text-slate-300 font-bold">{call.creatorAddress.slice(0, 6)}...{call.creatorAddress.slice(-4)}</p>
+              </div>
+          </div>
+          
+          <div className="h-4 w-px bg-slate-700" />
 
-        <div>
-            <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">Contract Address</p>
-            <p className="font-mono text-indigo-400 font-bold">C...{call.tokenAddress.slice(-6)}</p>
+          <div>
+              <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">Contract Address</p>
+              <p className="font-mono text-indigo-400 font-bold">C...{call.tokenAddress.slice(-6)}</p>
+          </div>
         </div>
 
-        <span className="ml-auto bg-indigo-500/10 text-indigo-400 text-[10px] font-black px-3 py-1 rounded-full border border-indigo-500/20 uppercase tracking-widest">Protocol Participantv1.0</span>
+        <div className="flex items-center gap-4">
+          <span className="bg-indigo-500/10 text-indigo-400 text-[10px] font-black px-3 py-1 rounded-full border border-indigo-500/20 uppercase tracking-widest">Protocol Participantv1.0</span>
+          <ShareButton
+            callId={call.id}
+            marketTitle={call.title}
+            currentOdds={odds || undefined}
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/ShareButton.tsx
+++ b/packages/frontend/src/components/ShareButton.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { Share2, Twitter, Send, Copy, Check } from "lucide-react";
+
+interface ShareButtonProps {
+  callId: number;
+  marketTitle: string;
+  currentOdds?: { yes: number; no: number };
+  compact?: boolean;
+}
+
+export default function ShareButton({
+  callId,
+  marketTitle,
+  currentOdds,
+  compact = false,
+}: ShareButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
+  const marketUrl = `${baseUrl}/calls/${callId}`;
+  const utmUrl = `${marketUrl}?utm_source=share&utm_medium=social&utm_campaign=market_share`;
+
+  // Track share event for analytics
+  const trackShareEvent = (platform: string) => {
+    if (typeof window !== "undefined" && window.gtag) {
+      window.gtag("event", "market_shared", {
+        market_id: callId,
+        market_title: marketTitle,
+        platform: platform,
+      });
+    }
+  };
+
+  const handleTwitterShare = () => {
+    trackShareEvent("twitter");
+    const text = `🎯 Predicting: ${marketTitle}\n\nYES: ${
+      currentOdds?.yes.toFixed(2) || "2.0"
+    }x | NO: ${
+      currentOdds?.no.toFixed(2) || "2.0"
+    }x\n\nJoin the prediction on BACKit:\n${utmUrl}`;
+
+    const encodedText = encodeURIComponent(text);
+    window.open(
+      `https://twitter.com/intent/tweet?text=${encodedText}`,
+      "_blank",
+      "width=550,height=420"
+    );
+    setIsOpen(false);
+  };
+
+  const handleTelegramShare = () => {
+    trackShareEvent("telegram");
+    const message = `🎯 <b>${marketTitle}</b>\n\n💰 <b>Odds</b>\nYES: ${
+      currentOdds?.yes.toFixed(2) || "2.0"
+    }x\nNO: ${
+      currentOdds?.no.toFixed(2) || "2.0"
+    }x\n\nPredictable. Profitable. On Stellar. 🚀\n\n${utmUrl}`;
+
+    const encodedMessage = encodeURIComponent(message);
+    window.open(
+      `https://t.me/share/url?url=${encodeURIComponent(
+        utmUrl
+      )}&text=${encodedMessage}`,
+      "_blank",
+      "width=550,height=420"
+    );
+    setIsOpen(false);
+  };
+
+  const handleCopyLink = async () => {
+    trackShareEvent("copy_link");
+    try {
+      await navigator.clipboard.writeText(marketUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy link:", err);
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative inline-block">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`${
+          compact
+            ? "p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition"
+            : "flex items-center gap-2 px-3 py-2 bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 transition font-medium text-sm"
+        }`}
+        title="Share market"
+      >
+        <Share2 size={compact ? 18 : 16} />
+        {!compact && "Share"}
+      </button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 z-50">
+          <button
+            onClick={handleTwitterShare}
+            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition border-b border-gray-100 text-left"
+          >
+            <Twitter size={18} className="text-blue-400" />
+            <span className="font-medium text-gray-900">Share on Twitter/X</span>
+          </button>
+
+          <button
+            onClick={handleTelegramShare}
+            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition border-b border-gray-100 text-left"
+          >
+            <Send size={18} className="text-blue-500" />
+            <span className="font-medium text-gray-900">Share on Telegram</span>
+          </button>
+
+          <button
+            onClick={handleCopyLink}
+            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition text-left"
+          >
+            {copied ? (
+              <>
+                <Check size={18} className="text-green-500" />
+                <span className="font-medium text-green-600">Copied!</span>
+              </>
+            ) : (
+              <>
+                <Copy size={18} className="text-gray-500" />
+                <span className="font-medium text-gray-900">Copy Link</span>
+              </>
+            )}
+          </button>
+        </div>
+      )}
+
+      {/* Tooltip for Copy feedback */}
+      {copied && (
+        <div className="absolute -top-8 right-0 bg-green-500 text-white px-3 py-1 rounded-lg text-sm whitespace-nowrap">
+          Copied!
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useMetaTags.ts
+++ b/packages/frontend/src/hooks/useMetaTags.ts
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+
+interface MetaTagsProps {
+  title: string;
+  description: string;
+  url: string;
+  image?: string;
+}
+
+export function useMetaTags({
+  title,
+  description,
+  url,
+  image = "/og-default.png",
+}: MetaTagsProps) {
+  useEffect(() => {
+    // Update document title
+    document.title = title;
+
+    // Update or create meta tags
+    const updateMetaTag = (
+      name: string,
+      content: string,
+      property?: boolean
+    ) => {
+      let tag = property
+        ? document.querySelector(`meta[property="${name}"]`)
+        : document.querySelector(`meta[name="${name}"]`);
+
+      if (!tag) {
+        tag = document.createElement("meta");
+        if (property) {
+          tag.setAttribute("property", name);
+        } else {
+          tag.setAttribute("name", name);
+        }
+        document.head.appendChild(tag);
+      }
+      tag.setAttribute("content", content);
+    };
+
+    // Standard meta tags
+    updateMetaTag("description", description);
+
+    // Open Graph tags
+    updateMetaTag("og:title", title, true);
+    updateMetaTag("og:description", description, true);
+    updateMetaTag("og:url", url, true);
+    updateMetaTag("og:image", image, true);
+    updateMetaTag("og:type", "website", true);
+    updateMetaTag("og:site_name", "BACKit", true);
+
+    // Twitter Card tags
+    updateMetaTag("twitter:card", "summary_large_image");
+    updateMetaTag("twitter:title", title);
+    updateMetaTag("twitter:description", description);
+    updateMetaTag("twitter:image", image);
+
+    // Canonical link
+    let canonical = document.querySelector("link[rel='canonical']");
+    if (!canonical) {
+      canonical = document.createElement("link");
+      canonical.setAttribute("rel", "canonical");
+      document.head.appendChild(canonical);
+    }
+    canonical.setAttribute("href", url);
+  }, [title, description, url, image]);
+}

--- a/packages/frontend/src/lib/metadata.ts
+++ b/packages/frontend/src/lib/metadata.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { CallDetailData } from "@/types";
 
 interface SeoProps {
   title: string;
@@ -31,6 +32,40 @@ export function buildMetadata({ title, description, url, image }: SeoProps): Met
       title: `${title} | ${siteName}`,
       description,
       images: [image ?? defaultImage],
+    },
+  };
+}
+
+/**
+ * Generates metadata for a specific call/market
+ */
+export function buildCallMetadata(call: CallDetailData, callId: number): Metadata {
+  const siteName = "BACKit";
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://backit.app";
+  const callUrl = `${baseUrl}/calls/${callId}`;
+  const defaultImage = "/og-default.png";
+  
+  const title = call.title || `Market #${callId}`;
+  const description = 
+    call.condition || 
+    `Trade your conviction on this prediction market. YES: ${call.stakes?.yes || 0} USDC vs NO: ${call.stakes?.no || 0} USDC`;
+  
+  return {
+    title: `${title} | ${siteName}`,
+    description,
+    openGraph: {
+      title: `${title} | ${siteName}`,
+      description,
+      url: callUrl,
+      siteName,
+      images: [{ url: defaultImage, width: 1200, height: 630 }],
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${title} | ${siteName}`,
+      description,
+      images: [defaultImage],
     },
   };
 }


### PR DESCRIPTION
- Add ShareButton component with Twitter/X, Telegram, and copy link options
- Integrate ShareButton into CallCard for easy sharing from market feed
- Integrate ShareButton into CallDetailHeader for detail page sharing
- Add Open Graph meta tags to layout for rich link previews
- Implement dynamic meta tags for call detail pages
- Add useMetaTags hook for runtime meta tag management
- Track share events for analytics (Twitter, Telegram, Copy)
- Include market title and current odds in social shares with UTM parameters
- Display copy feedback tooltip for link copy action

Closes #236