### PR TITLE
feat(call_registry): add contract-level global statistics

### DIFF
--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -130,6 +130,7 @@ impl CallRegistry {
         };
 
         set_call(&env, &call);
+        record_call_created(&env);
         extend_storage_ttl(&env);
 
         emit_call_created(
@@ -216,6 +217,7 @@ impl CallRegistry {
 
         set_call(&env, &call);
         add_staker_call(&env, &staker, call_id);
+        record_stake(&env, &staker, amount);
         extend_storage_ttl(&env);
 
         emit_stake_added(&env, call_id, &staker, amount, position);
@@ -479,5 +481,10 @@ impl CallRegistry {
     /// Get total number of calls created.
     pub fn get_call_count(env: Env) -> u64 {
         get_call_counter(&env)
+    }
+
+    /// Get contract-wide aggregated statistics.
+    pub fn get_global_stats(env: Env) -> GlobalStats {
+        storage::get_global_stats(&env)
     }
 }

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::types::{Call, ContractConfig};
+use crate::types::{Call, ContractConfig, GlobalStats};
 use soroban_sdk::{contracttype, Address, Env};
 
 // ~120 days in ledgers (5s per ledger): 120 * 24 * 3600 / 5 = 2_073_600
@@ -13,6 +13,8 @@ const INSTANCE_BUMP_AMOUNT: u32 = 120_960; // ~7 days
 pub enum DataKey {
     Config,
     CallCounter,
+    GlobalStats,
+    GlobalStakerSeen(Address),
     Call(u64),
     StakerCalls(Address),
 }
@@ -110,6 +112,36 @@ pub fn get_staker_calls(env: &Env, staker: &Address) -> soroban_sdk::Vec<u64> {
         );
     }
     result
+}
+
+pub fn get_global_stats(env: &Env) -> GlobalStats {
+    env.storage()
+        .instance()
+        .get(&DataKey::GlobalStats)
+        .unwrap_or(GlobalStats {
+            total_calls: 0,
+            total_stake_volume: 0,
+            total_unique_stakers: 0,
+        })
+}
+
+pub fn record_call_created(env: &Env) {
+    let mut stats = get_global_stats(env);
+    stats.total_calls += 1;
+    env.storage().instance().set(&DataKey::GlobalStats, &stats);
+}
+
+pub fn record_stake(env: &Env, staker: &Address, amount: i128) {
+    let mut stats = get_global_stats(env);
+    stats.total_stake_volume += amount;
+
+    let seen_key = DataKey::GlobalStakerSeen(staker.clone());
+    if !env.storage().persistent().has(&seen_key) {
+        env.storage().persistent().set(&seen_key, &true);
+        stats.total_unique_stakers += 1;
+    }
+
+    env.storage().instance().set(&DataKey::GlobalStats, &stats);
 }
 
 /// Get current call counter

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -365,6 +365,60 @@ mod call_registry {
         assert_eq!(staker_calls.get(0).unwrap().id, call.id);
     }
 
+    // ── global stats ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_global_stats_increment() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+
+        let creator = Address::generate(&env);
+        let staker1 = Address::generate(&env);
+        let staker2 = Address::generate(&env);
+        let stake_token = env.register_contract(None, MockToken);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        let stats = client.get_global_stats();
+        assert_eq!(stats.total_calls, 0);
+        assert_eq!(stats.total_stake_volume, 0);
+        assert_eq!(stats.total_unique_stakers, 0);
+
+        let call1 = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+        let call2 = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &ipfs_cid,
+        );
+
+        let stats = client.get_global_stats();
+        assert_eq!(stats.total_calls, 2);
+
+        env.budget().reset_unlimited();
+        client.stake_on_call(&staker1, &call1.id, &50_000_000_i128, &1);
+        client.stake_on_call(&staker1, &call1.id, &20_000_000_i128, &1);
+        client.stake_on_call(&staker2, &call2.id, &30_000_000_i128, &2);
+
+        let stats = client.get_global_stats();
+        assert_eq!(stats.total_stake_volume, 100_000_000);
+        assert_eq!(stats.total_unique_stakers, 2);
+    }
+
     // ── create_call ───────────────────────────────────────────────────────────
 
     #[test]

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -94,6 +94,15 @@ pub struct ContractConfig {
     pub fee_bps: u32,
 }
 
+/// Contract-wide aggregated statistics for dashboards.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlobalStats {
+    pub total_calls: u64,
+    pub total_stake_volume: i128,
+    pub total_unique_stakers: u64,
+}
+
 /// Statistics for a call
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Closes #161

---

## Summary

- Add `GlobalStats` (`total_calls`, `total_stake_volume`, `total_unique_stakers`) stored in instance storage for dashboard metrics that cannot be derived efficiently from events alone.
- Increment `total_calls` on `create_call` and `total_stake_volume` on `stake_on_call`.
- Track unique stakers with a counter plus per-address `GlobalStakerSeen` flags (no unbounded staker list).
- Expose `get_global_stats(env) -> GlobalStats` view function.

## Test plan

- [x] `cargo test -p call-registry` (45 tests, including `test_global_stats_increment`)
- [x] `cargo test` in `packages/contracts` (full workspace)
- [x] `cargo fmt --check` on contracts
- [x] Soroban Contracts CI (`contracts.yml`) — runs on PR path filter for `packages/contracts/**`


