### PR TITLE
Add max submission delay to outcome manager

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run Cargo Test
         run: |
           cd packages/contracts
-          cargo test
+          CARGO_HTTP_MULTIPLEXING=false cargo test
 
       - name: Install Stellar CLI
         run: |
@@ -59,7 +59,7 @@ jobs:
       - name: Build Contracts with Stellar CLI
         run: |
           cd packages/contracts
-          stellar contract build
+          CARGO_HTTP_MULTIPLEXING=false stellar contract build
 
       - name: Report Contract Sizes
         run: |

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -49,3 +49,11 @@ pub fn emit_batch_payout_started(env: &Env, call_id: u64, staker_count: u32) {
         (call_id, staker_count),
     );
 }
+
+/// Emitted when admin changes
+pub fn emit_admin_params_changed(env: &Env, new_delay: u64) {
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("params")),
+        (new_delay,),
+    );
+}

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -6,12 +6,23 @@ mod storage;
 mod test;
 mod verification;
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, IntoVal, Map, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
+
+#[derive(Clone)]
+#[contracttype]
+struct Call {
+    id: u64,
+    creator: Address,
+    stake_token: Address,
+    stake_amount: i128,
+    end_ts: u64,
+    // We don't need the rest of the fields
+}
 
 use auth::require_admin;
 use events::{
     emit_batch_payout_started, emit_fee_collected, emit_outcome_finalized, emit_outcome_submitted,
-    emit_payout_claimed,
+    emit_payout_claimed, emit_admin_params_changed,
 };
 use storage::{InstanceKey, Outcome, SignedOutcome, TempKey};
 use verification::{build_message, verify_signature};
@@ -102,6 +113,7 @@ impl OutcomeManager {
             .instance()
             .set(&InstanceKey::FeeCollector, &fee_collector);
         env.storage().instance().set(&InstanceKey::FeeBps, &fee_bps);
+        env.storage().instance().set(&InstanceKey::MaxSubmissionDelay, &86400u64);
     }
 
     // ── Admin Controls ─────────────────────────────────────────────────────────
@@ -141,6 +153,14 @@ impl OutcomeManager {
         env.storage()
             .instance()
             .set(&InstanceKey::Admin, &new_admin);
+    }
+
+    pub fn set_max_submission_delay(env: Env, new_delay: u64) {
+        require_admin(&env);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::MaxSubmissionDelay, &new_delay);
+        emit_admin_params_changed(&env, new_delay);
     }
 
     // ── Oracle Submission ──────────────────────────────────────────────────────
@@ -185,7 +205,16 @@ impl OutcomeManager {
             panic!("invalid outcome: must be 1 (UP) or 2 (DOWN)");
         }
 
-        // 5. Build canonical message and verify ed25519 signature
+        // 5. Fetch call from registry to get end_ts
+        let call: Call = env.invoke_contract(&registry, &Symbol::new(&env, "get_call"), (signed.call_id,).into_val(&env));
+
+        // 6. Check submission timestamp is within window
+        let max_delay: u64 = env.storage().instance().get(&InstanceKey::MaxSubmissionDelay).unwrap_or(86400);
+        if signed.timestamp > call.end_ts + max_delay {
+            panic!("submission outside valid window");
+        }
+
+        // 7. Build canonical message and verify ed25519 signature
         let message = build_message(
             &env,
             signed.call_id,
@@ -195,15 +224,15 @@ impl OutcomeManager {
         );
         verify_signature(&env, &signed.oracle_pubkey, &signed.signature, &message);
 
-        // 6. Hash outcome candidate for vote counting
+        // 8. Hash outcome candidate for vote counting
         let outcome_hash: BytesN<32> = env.crypto().sha256(&message).into();
 
-        // 7. Record oracle's vote (prevents duplicates)
+        // 9. Record oracle's vote (prevents duplicates)
         env.storage()
             .temporary()
             .set(&submission_key, &outcome_hash);
 
-        // 8. Tally votes for this outcome candidate
+        // 10. Tally votes for this outcome candidate
         let vote_key = TempKey::VoteCount(outcome_hash.clone(), signed.call_id);
         let votes: u32 = env.storage().temporary().get(&vote_key).unwrap_or(0);
         let votes = votes + 1;
@@ -211,7 +240,7 @@ impl OutcomeManager {
 
         emit_outcome_submitted(&env, signed.call_id, &signed.oracle_pubkey, signed.outcome);
 
-        // 9. Finalize if quorum reached
+        // 11. Finalize if quorum reached
         let quorum: u32 = env.storage().instance().get(&InstanceKey::Quorum).unwrap();
         if votes >= quorum {
             Self::finalize(

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -40,6 +40,7 @@ pub enum InstanceKey {
     FeeBps,
     /// Stored CallRegistry address; set via set_registry() to avoid caller-supplied forgery
     Registry,
+    MaxSubmissionDelay,
 }
 
 #[contracttype]

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -14,11 +14,30 @@ use crate::{OutcomeManager, OutcomeManagerClient};
 #[contract]
 pub struct MockRegistry;
 
+#[contracttype]
+#[derive(Clone)]
+struct MockCall {
+    id: u64,
+    creator: Address,
+    stake_token: Address,
+    stake_amount: i128,
+    end_ts: u64,
+}
+
 #[contractimpl]
 impl MockRegistry {
     pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
     pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
     pub fn mark_settled(_env: Env, _call_id: u64) {}
+    pub fn get_call(env: Env, call_id: u64) -> MockCall {
+        MockCall {
+            id: call_id,
+            creator: Address::generate(&env),
+            stake_token: Address::generate(&env),
+            stake_amount: 100i128,
+            end_ts: 10000u64, // Call ends at 10000, so max delay 86400 allows up to 96400
+        }
+    }
 }
 
 /// Generate a deterministic Ed25519 keypair for testing.
@@ -562,4 +581,92 @@ fn test_batch_claim_duplicate_within_same_batch_panics() {
     stakes.push_back(50_i128);
 
     client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
+}
+
+// ─── Submission Window Tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_submit_within_window_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    let call_id = 42u64;
+    let outcome_val = 1u32;
+    let price = 150_000_000i128;
+    let ts = 20000u64; // end_ts is 10000, 20000 ≤ 10000+86400 = 96400 ✅
+
+    let sig = sign_outcome(&env, &oracle_secret, call_id, outcome_val, price, ts);
+    client.submit_outcome(
+        &registry_id,
+        &SignedOutcome {
+            call_id,
+            outcome: outcome_val,
+            price,
+            timestamp: ts,
+            oracle_pubkey,
+            signature: sig,
+        },
+    );
+
+    let final_outcome = client.get_outcome(&call_id);
+    assert_eq!(final_outcome.outcome, outcome_val);
+}
+
+#[test]
+#[should_panic(expected = "submission outside valid window")]
+fn test_submit_outside_window_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    let call_id = 42u64;
+    let outcome_val = 1u32;
+    let price = 150_000_000i128;
+    let ts = 100000u64; // end_ts is 10000, 100000 > 10000+86400 = 96400 ❌
+
+    let sig = sign_outcome(&env, &oracle_secret, call_id, outcome_val, price, ts);
+    client.submit_outcome(
+        &registry_id,
+        &SignedOutcome {
+            call_id,
+            outcome: outcome_val,
+            price,
+            timestamp: ts,
+            oracle_pubkey,
+            signature: sig,
+        },
+    );
+}
+
+#[test]
+fn test_set_max_submission_delay_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    // Update delay to 200000
+    client.set_max_submission_delay(&200000u64);
+
+    // Now submit a timestamp that would have failed before but now passes (10000 + 200000 = 210000)
+    let call_id = 42u64;
+    let outcome_val = 1u32;
+    let price = 150_000_000i128;
+    let ts = 100000u64; // Now ≤ 210000 ✅
+
+    let sig = sign_outcome(&env, &oracle_secret, call_id, outcome_val, price, ts);
+    client.submit_outcome(
+        &registry_id,
+        &SignedOutcome {
+            call_id,
+            outcome: outcome_val,
+            price,
+            timestamp: ts,
+            oracle_pubkey,
+            signature: sig,
+        },
+    );
+
+    let final_outcome = client.get_outcome(&call_id);
+    assert_eq!(final_outcome.outcome, outcome_val);
 }


### PR DESCRIPTION
This PR adds support for max submission delay to outcome manager contract.

Changes:
- Add max_submission_delay config parameter (default 86400 seconds)
- Add check in submit_outcome that signed.timestamp is within call.end_ts + max_submission_delay
- Add set_max_submission_delay admin function
- Emit AdminParamsChanged event
- Add tests

Closes #162