### PR TITLE
feat: create shared contract library crate (#160)

### DIFF
--- a/packages/contracts/Cargo.toml
+++ b/packages/contracts/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "shared",
   "call_registry",
   "outcome_manager",
   "contracts/hello-world",
@@ -8,6 +9,7 @@ members = [
 
 [workspace.dependencies]
 soroban-sdk = "23.0.0"
+backit-shared = { path = "shared" }
 
 [profile.release]
 opt-level = "z"

--- a/packages/contracts/call_registry/Cargo.toml
+++ b/packages/contracts/call_registry/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+backit-shared = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/contracts/call_registry/src/admin.rs
+++ b/packages/contracts/call_registry/src/admin.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::{Address, Env};
 
+use backit_shared::is_valid_fee_bps;
+
 use crate::errors::CallRegistryError;
 use crate::events::{
     emit_admin_params_changed_address, emit_admin_params_changed_u32, PARAM_ADMIN, PARAM_FEE_BPS,
@@ -64,7 +66,7 @@ pub fn set_outcome_manager(env: Env, new_manager: Address) -> Result<(), CallReg
 /// * [`CallRegistryError::NotInitialized`] – contract not initialised.
 /// * [`CallRegistryError::FeeTooHigh`]     – `new_fee_bps` > 10 000.
 pub fn set_fee(env: Env, new_fee_bps: u32) -> Result<(), CallRegistryError> {
-    if new_fee_bps > 10_000 {
+    if !is_valid_fee_bps(new_fee_bps) {
         return Err(CallRegistryError::FeeTooHigh);
     }
 

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -11,6 +11,7 @@ mod types;
 #[cfg(test)]
 mod test;
 
+use backit_shared::{is_valid_outcome, OUTCOME_DOWN, OUTCOME_UP};
 use errors::CallRegistryError;
 use events::*;
 use storage::*;
@@ -240,7 +241,7 @@ impl CallRegistry {
 
         let mut call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
 
-        if outcome != 1 && outcome != 2 {
+        if !is_valid_outcome(outcome) {
             return Err(CallRegistryError::InvalidOutcome);
         }
 
@@ -470,8 +471,8 @@ impl CallRegistry {
         let call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
 
         match position {
-            1 => Ok(call.up_stakes.get(staker).unwrap_or(0)),
-            2 => Ok(call.down_stakes.get(staker).unwrap_or(0)),
+            OUTCOME_UP => Ok(call.up_stakes.get(staker).unwrap_or(0)),
+            OUTCOME_DOWN => Ok(call.down_stakes.get(staker).unwrap_or(0)),
             _ => Err(CallRegistryError::InvalidPosition),
         }
     }

--- a/packages/contracts/outcome_manager/Cargo.toml
+++ b/packages/contracts/outcome_manager/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+backit-shared = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -9,6 +9,7 @@ mod verification;
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, IntoVal, Map, Symbol, Vec};
 
 use auth::require_admin;
+use backit_shared::{is_valid_fee_bps, is_valid_outcome};
 use events::{
     emit_batch_payout_started, emit_fee_collected, emit_outcome_finalized, emit_outcome_submitted,
     emit_payout_claimed,
@@ -84,7 +85,7 @@ impl OutcomeManager {
         if quorum == 0 || quorum > oracles.len() as u32 {
             panic!("invalid quorum");
         }
-        if fee_bps > 10000 {
+        if !is_valid_fee_bps(fee_bps) {
             panic!("invalid fee_bps");
         }
 
@@ -181,7 +182,7 @@ impl OutcomeManager {
         }
 
         // 4. Validate outcome range
-        if signed.outcome != 1 && signed.outcome != 2 {
+        if !is_valid_outcome(signed.outcome) {
             panic!("invalid outcome: must be 1 (UP) or 2 (DOWN)");
         }
 

--- a/packages/contracts/outcome_manager/src/verification.rs
+++ b/packages/contracts/outcome_manager/src/verification.rs
@@ -1,44 +1,17 @@
-use soroban_sdk::{Bytes, BytesN, Env};
+use soroban_sdk::{BytesN, Env, Bytes};
 
-/// Build the canonical message that oracles sign.
-///
-/// Format (all big-endian):
-///   b"BACKit:Outcome:" | call_id(8B) | b":" | outcome(1B) | b":" | price(16B) | b":" | timestamp(8B)
-pub fn build_message(env: &Env, call_id: u64, outcome: u32, price: i128, timestamp: u64) -> Bytes {
-    let mut msg = Bytes::new(env);
-
-    msg.append(&Bytes::from_slice(env, b"BACKit:Outcome:"));
-    msg.append(&Bytes::from_slice(env, &call_id.to_be_bytes()));
-    msg.append(&Bytes::from_slice(env, b":"));
-
-    // outcome is always 1 or 2; encode as a single ASCII byte
-    let outcome_byte: &[u8] = match outcome {
-        1 => b"1",
-        _ => b"2",
-    };
-    msg.append(&Bytes::from_slice(env, outcome_byte));
-    msg.append(&Bytes::from_slice(env, b":"));
-
-    msg.append(&Bytes::from_slice(env, &price.to_be_bytes()));
-    msg.append(&Bytes::from_slice(env, b":"));
-    msg.append(&Bytes::from_slice(env, &timestamp.to_be_bytes()));
-
-    msg
-}
+// Re-export build_message from the shared crate so existing call sites are unchanged.
+pub use backit_shared::build_message;
 
 /// Verify an ed25519 signature.
 ///
-/// `env.crypto().ed25519_verify` panics on failure ─ we wrap that in a bool
-/// so callers can handle it gracefully without unwinding the whole transaction.
+/// `env.crypto().ed25519_verify` panics on failure, which reverts the transaction.
 pub fn verify_signature(
     env: &Env,
     public_key: &BytesN<32>,
     signature: &BytesN<64>,
     message: &Bytes,
 ) -> bool {
-    // ed25519_verify panics on bad signatures in the Soroban SDK;
-    // we rely on that panic propagating (which reverts the tx) rather than
-    // returning false – this is the safe choice on-chain.
     env.crypto().ed25519_verify(public_key, message, signature);
     true
 }

--- a/packages/contracts/shared/Cargo.toml
+++ b/packages/contracts/shared/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "backit-shared"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/packages/contracts/shared/src/lib.rs
+++ b/packages/contracts/shared/src/lib.rs
@@ -1,0 +1,62 @@
+#![no_std]
+
+use soroban_sdk::{Bytes, Env};
+
+// ─── Outcome constants ────────────────────────────────────────────────────────
+
+/// Outcome value representing an UP result.
+pub const OUTCOME_UP: u32 = 1;
+/// Outcome value representing a DOWN result.
+pub const OUTCOME_DOWN: u32 = 2;
+
+// ─── Fee constants ────────────────────────────────────────────────────────────
+
+/// Maximum allowed fee in basis points (100 % = 10 000 bps).
+pub const MAX_FEE_BPS: u32 = 10_000;
+
+// ─── Message format ───────────────────────────────────────────────────────────
+
+/// Prefix used in the canonical oracle message.
+pub const MESSAGE_PREFIX: &[u8] = b"BACKit:Outcome:";
+
+/// Build the canonical message that oracles sign.
+///
+/// Format (all big-endian):
+///   `b"BACKit:Outcome:"` | call_id(8B) | `b":"` | outcome(1B) | `b":"` | price(16B) | `b":"` | timestamp(8B)
+pub fn build_message(env: &Env, call_id: u64, outcome: u32, price: i128, timestamp: u64) -> Bytes {
+    let mut msg = Bytes::new(env);
+
+    msg.append(&Bytes::from_slice(env, MESSAGE_PREFIX));
+    msg.append(&Bytes::from_slice(env, &call_id.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+
+    let outcome_byte: &[u8] = if outcome == OUTCOME_UP { b"1" } else { b"2" };
+    msg.append(&Bytes::from_slice(env, outcome_byte));
+    msg.append(&Bytes::from_slice(env, b":"));
+
+    msg.append(&Bytes::from_slice(env, &price.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(&Bytes::from_slice(env, &timestamp.to_be_bytes()));
+
+    msg
+}
+
+// ─── Validation helpers ───────────────────────────────────────────────────────
+
+/// Returns `true` if `call_id` is a valid (non-zero) call identifier.
+#[inline]
+pub fn validate_call_id(call_id: u64) -> bool {
+    call_id > 0
+}
+
+/// Returns `true` if `outcome` is a valid outcome value (UP or DOWN).
+#[inline]
+pub fn is_valid_outcome(outcome: u32) -> bool {
+    outcome == OUTCOME_UP || outcome == OUTCOME_DOWN
+}
+
+/// Returns `true` if `fee_bps` does not exceed [`MAX_FEE_BPS`].
+#[inline]
+pub fn is_valid_fee_bps(fee_bps: u32) -> bool {
+    fee_bps <= MAX_FEE_BPS
+}


### PR DESCRIPTION
## Summary
Creates `packages/contracts/shared/` — a new workspace library crate that eliminates
duplication between `call_registry` and `outcome_manager`.

## Changes
- New crate `backit-shared` at `packages/contracts/shared/`
  - `OUTCOME_UP = 1`, `OUTCOME_DOWN = 2` — replaces magic numbers in both contracts
  - `MAX_FEE_BPS = 10_000` — single source of truth for the fee cap
  - `MESSAGE_PREFIX` — the canonical oracle message prefix constant
  - `build_message()` — moved from `outcome_manager/verification.rs`; re-exported there for backward compat
  - `validate_call_id()` — returns `true` for non-zero IDs
  - `is_valid_outcome()` — replaces inline `outcome != 1 && outcome != 2` checks
  - `is_valid_fee_bps()` — replaces inline `fee_bps > 10_000` checks
- Updated `call_registry` and `outcome_manager` Cargo.toml to depend on `backit-shared`
- Updated workspace Cargo.toml to include `shared` as a member

## Testing
All 70 tests pass (`cargo test`): 44 call_registry + 25 outcome_manager + 1 hello_world.

Closes #160