### PR TITLE
Add branded custom error pages

### DIFF
--- a/packages/frontend/src/app/calls/[id]/not-found.tsx
+++ b/packages/frontend/src/app/calls/[id]/not-found.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+export default function CallNotFoundPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  return (
+    <div className="min-h-screen bg-[#080b14] text-white flex items-center justify-center px-6 py-16">
+      <div className="w-full max-w-4xl rounded-[32px] border border-white/10 bg-white/5 backdrop-blur-xl shadow-[0_40px_120px_rgba(34,197,94,0.18)] overflow-hidden">
+        <div className="grid gap-8 lg:grid-cols-[1.4fr_1fr] bg-[#0e1320] p-10 sm:p-14">
+          <div className="space-y-6">
+            <p className="text-sm uppercase tracking-[0.35em] text-sky-300">Market not found</p>
+            <h1 className="text-5xl font-black tracking-tight text-white sm:text-6xl">
+              No market matches <span className="text-[#22c55e]">{params.id}</span>.
+            </h1>
+            <p className="max-w-xl text-lg leading-8 text-slate-300">
+              The call you are trying to access may have been removed or never existed.
+              Check the id or return to the market feed to discover active calls.
+            </p>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-[#22c55e] px-6 py-3 text-sm font-semibold text-black transition hover:bg-[#16a34a]"
+              >
+                Browse Markets
+              </Link>
+              <a
+                href="https://github.com/degenspot/BACKit-onStellar/issues/new"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:border-[#22c55e] hover:text-[#22c55e]"
+              >
+                Report Issue
+              </a>
+            </div>
+          </div>
+
+          <div className="relative rounded-[28px] border border-white/10 bg-[#111924] p-8">
+            <div className="absolute -top-8 left-8 h-20 w-20 rounded-full bg-gradient-to-br from-[#2563eb] to-[#0ea5e9] opacity-80 blur-3xl" />
+            <div className="relative z-10 flex h-full flex-col items-center justify-center gap-6">
+              <div className="h-24 w-24 rounded-3xl bg-[#0f172a] border border-white/10 flex items-center justify-center">
+                <span className="text-6xl">📉</span>
+              </div>
+              <p className="text-sm text-slate-400">This call id doesn’t resolve to an active prediction market.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/error.tsx
+++ b/packages/frontend/src/app/error.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  console.error("Route error:", error);
+
+  return (
+    <div className="min-h-screen bg-[#080b14] text-white flex items-center justify-center px-6 py-16">
+      <div className="w-full max-w-4xl rounded-[32px] border border-white/10 bg-white/5 backdrop-blur-xl shadow-[0_40px_120px_rgba(34,197,94,0.18)] overflow-hidden">
+        <div className="bg-[#0f172a] p-10 sm:p-14">
+          <p className="text-sm uppercase tracking-[0.35em] text-emerald-300">Something went wrong</p>
+          <h1 className="mt-6 text-5xl font-black tracking-tight text-white sm:text-6xl">
+            Unexpected error.
+          </h1>
+          <p className="mt-4 max-w-2xl text-lg leading-8 text-slate-300">
+            We hit a snag while loading the page. Refresh the route or report the issue if it keeps happening.
+          </p>
+
+          <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={() => reset()}
+              className="inline-flex items-center justify-center rounded-full bg-[#22c55e] px-6 py-3 text-sm font-semibold text-black transition hover:bg-[#16a34a]"
+            >
+              Try Again
+            </button>
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:border-[#22c55e] hover:text-[#22c55e]"
+            >
+              Go Home
+            </Link>
+            <a
+              href="https://github.com/degenspot/BACKit-onStellar/issues/new"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-transparent px-6 py-3 text-sm font-semibold text-slate-200 transition hover:border-[#22c55e] hover:text-[#22c55e]"
+            >
+              Report Issue
+            </a>
+          </div>
+
+          <div className="mt-10 rounded-3xl border border-white/10 bg-[#111924] p-6 text-slate-300">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Error details
+            </p>
+            <pre className="mt-4 max-h-40 overflow-auto whitespace-pre-wrap text-sm leading-6 text-slate-200">
+              {error.message}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/not-found.tsx
+++ b/packages/frontend/src/app/not-found.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+
+export default function NotFoundPage() {
+  return (
+    <div className="min-h-screen bg-[#080b14] text-white flex items-center justify-center px-6 py-16">
+      <div className="w-full max-w-5xl rounded-[32px] border border-white/10 bg-white/5 backdrop-blur-xl shadow-[0_40px_120px_rgba(34,197,94,0.18)] overflow-hidden">
+        <div className="grid gap-8 lg:grid-cols-[1.5fr_1fr] bg-[#0e1320] p-10 lg:p-14">
+          <div className="space-y-8">
+            <div className="space-y-3">
+              <p className="text-sm uppercase tracking-[0.35em] text-emerald-300">404 · Page not found</p>
+              <h1 className="text-5xl font-black tracking-tight text-white sm:text-6xl">
+                This market is off the grid.
+              </h1>
+              <p className="max-w-xl text-lg leading-8 text-slate-300">
+                The page you are looking for doesn’t exist anymore, or the link is incorrect.
+                Head back to the feed and keep exploring the next on-chain opportunity.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-[#22c55e] px-6 py-3 text-sm font-semibold text-black transition hover:bg-[#16a34a]"
+              >
+                Go Home
+              </Link>
+              <a
+                href="https://github.com/degenspot/BACKit-onStellar/issues/new"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:border-[#22c55e] hover:text-[#22c55e]"
+              >
+                Report Issue
+              </a>
+            </div>
+          </div>
+
+          <div className="relative rounded-[28px] border border-white/10 bg-[#101827] p-8 shadow-2xl">
+            <div className="absolute -top-8 right-6 h-20 w-20 rounded-full bg-gradient-to-br from-[#22c55e] to-[#3b82f6] opacity-80 blur-3xl" />
+            <div className="relative z-10 flex h-full flex-col items-center justify-center gap-6 text-center">
+              <div className="flex h-24 w-24 items-center justify-center rounded-3xl bg-[#111924] border border-white/10">
+                <svg className="h-14 w-14 text-[#22c55e]" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M32 8C19.85 8 10 17.85 10 30C10 42.15 19.85 52 32 52C44.15 52 54 42.15 54 30C54 17.85 44.15 8 32 8Z" stroke="currentColor" strokeWidth="3" />
+                  <path d="M32 18V34" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                  <path d="M32 42H32.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                </svg>
+              </div>
+              <div className="space-y-3">
+                <p className="text-sm uppercase tracking-[0.35em] text-sky-300">Backed by Stellar</p>
+                <h2 className="text-3xl font-semibold text-white">We couldn’t find this route.</h2>
+                <p className="text-sm leading-6 text-slate-400">
+                  Need help? Report the issue so we can fix navigation gaps and keep the app strong.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/profile/[address]/not-found.tsx
+++ b/packages/frontend/src/app/profile/[address]/not-found.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+
+export default function ProfileNotFoundPage({
+  params,
+}: {
+  params: { address: string };
+}) {
+  return (
+    <div className="min-h-screen bg-[#080b14] text-white flex items-center justify-center px-6 py-16">
+      <div className="w-full max-w-4xl rounded-[32px] border border-white/10 bg-white/5 backdrop-blur-xl shadow-[0_40px_120px_rgba(34,197,94,0.18)] overflow-hidden">
+        <div className="grid gap-8 lg:grid-cols-[1.4fr_1fr] bg-[#0e1320] p-10 sm:p-14">
+          <div className="space-y-6">
+            <p className="text-sm uppercase tracking-[0.35em] text-sky-300">User not found</p>
+            <h1 className="text-5xl font-black tracking-tight text-white sm:text-6xl">
+              No profile for <span className="text-[#22c55e]">{params.address}</span>.
+            </h1>
+            <p className="max-w-xl text-lg leading-8 text-slate-300">
+              The address you searched for doesn’t have a public profile yet. Try another account or return to explore top creators.
+            </p>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-[#22c55e] px-6 py-3 text-sm font-semibold text-black transition hover:bg-[#16a34a]"
+              >
+                Explore Feed
+              </Link>
+              <a
+                href="https://github.com/degenspot/BACKit-onStellar/issues/new"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:border-[#22c55e] hover:text-[#22c55e]"
+              >
+                Report Issue
+              </a>
+            </div>
+          </div>
+
+          <div className="relative rounded-[28px] border border-white/10 bg-[#111924] p-8">
+            <div className="absolute -top-8 left-8 h-20 w-20 rounded-full bg-gradient-to-br from-[#8b5cf6] to-[#6366f1] opacity-80 blur-3xl" />
+            <div className="relative z-10 flex h-full flex-col items-center justify-center gap-6">
+              <div className="h-24 w-24 rounded-3xl bg-[#0f172a] border border-white/10 flex items-center justify-center">
+                <span className="text-6xl">👤</span>
+              </div>
+              <p className="text-sm text-slate-400">Profiles are generated when users interact with markets.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #238

---

Description
Added branded custom error handling for the frontend:

[not-found.tsx](https://stunning-space-yodel-465xq75j54x34j7.github.dev/) — site-wide 404 page with illustration, home button, and issue report link
[error.tsx](https://stunning-space-yodel-465xq75j54x34j7.github.dev/) — React error boundary page with Try Again, home fallback, and console logging
[not-found.tsx](https://stunning-space-yodel-465xq75j54x34j7.github.dev/) — market-specific “Market Not Found” page
[not-found.tsx](https://stunning-space-yodel-465xq75j54x34j7.github.dev/) — user-specific “User Not Found” page