### PR TITLE
feat: token whitelist, min stake enforcement, metadata updates, and dispute resolution window

### DIFF
--- a/packages/contracts/call_registry/src/admin.rs
+++ b/packages/contracts/call_registry/src/admin.rs
@@ -1,12 +1,13 @@
 use soroban_sdk::{Address, Env};
 
+use crate::events::PARAM_MIN_STAKE;
 use backit_shared::is_valid_fee_bps;
 
 use crate::errors::CallRegistryError;
 use crate::events::{
     emit_admin_params_changed_address, emit_admin_params_changed_i128,
-    emit_admin_params_changed_u32, PARAM_ADMIN, PARAM_FEE_BPS, PARAM_MAX_STAKE_PER_USER,
-    PARAM_OUTCOME_MANAGER,
+    emit_admin_params_changed_u32, emit_token_delisted, emit_token_whitelisted, PARAM_ADMIN,
+    PARAM_FEE_BPS, PARAM_MAX_STAKE_PER_USER, PARAM_OUTCOME_MANAGER,
 };
 use crate::storage::{extend_storage_ttl, get_config, set_config};
 
@@ -118,4 +119,33 @@ pub fn set_max_stake_per_user(env: Env, new_max: i128) {
         old_max,
         new_max,
     );
+}
+
+pub fn whitelist_token(env: Env, token_address: Address) {
+    let mut config = get_config(&env).expect("not initialized");
+    config.admin.require_auth();
+    config.whitelisted_tokens.set(token_address.clone(), true);
+    set_config(&env, &config);
+    emit_token_whitelisted(&env, &token_address);
+}
+
+pub fn remove_token(env: Env, token_address: Address) {
+    let mut config = get_config(&env).expect("not initialized");
+    config.admin.require_auth();
+    config.whitelisted_tokens.remove(token_address.clone());
+    set_config(&env, &config);
+    emit_token_delisted(&env, &token_address);
+}
+
+pub fn set_min_stake(env: Env, new_min_stake: i128) {
+    if new_min_stake < 0 {
+        panic!("min_stake cannot be negative");
+    }
+    let mut config = get_config(&env).expect("not initialized");
+    config.admin.require_auth();
+    let old = config.min_stake;
+    config.min_stake = new_min_stake;
+    set_config(&env, &config);
+    extend_storage_ttl(&env);
+    emit_admin_params_changed_i128(&env, PARAM_MIN_STAKE, &config.admin, old, new_min_stake);
 }

--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -1,7 +1,8 @@
+use soroban_sdk::symbol_short;
 use soroban_sdk::{Address, Bytes, Env, Symbol};
 
 pub const PARAM_MAX_STAKE_PER_USER: &str = "max_stake_per_user";
-// ── Existing events (unchanged) ───────────────────────────────────────────────
+pub const PARAM_MIN_STAKE: &str = "min_stake";
 
 /// Emitted when a new call is created
 pub fn emit_call_created(
@@ -125,6 +126,35 @@ pub fn emit_admin_params_changed_i128(
             changed_by.clone(),
             old_value,
             new_value,
+        ),
+    );
+}
+pub fn emit_token_whitelisted(env: &Env, token: &Address) {
+    env.events()
+        .publish(("call_registry", "token_whitelisted"), token.clone());
+}
+
+pub fn emit_token_delisted(env: &Env, token: &Address) {
+    env.events()
+        .publish(("call_registry", "token_delisted"), token.clone());
+}
+
+pub fn emit_call_metadata_updated(
+    env: &Env,
+    call_id: u64,
+    creator: &Address,
+    old_cid: &Bytes,
+    new_cid: &Bytes,
+    version: u32,
+) {
+    env.events().publish(
+        (symbol_short!("call"), symbol_short!("meta_upd")),
+        (
+            call_id,
+            creator.clone(),
+            old_cid.clone(),
+            new_cid.clone(),
+            version,
         ),
     );
 }

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, Vec};
+use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, Map, Vec};
 
 mod admin;
 mod errors;
@@ -58,6 +58,7 @@ impl CallRegistry {
         env: Env,
         admin: Address,
         outcome_manager: Address,
+        min_stake: i128,
     ) -> Result<(), CallRegistryError> {
         if get_config(&env).is_some() {
             return Err(CallRegistryError::AlreadyInitialized);
@@ -70,6 +71,9 @@ impl CallRegistry {
             outcome_manager: outcome_manager.clone(),
             fee_bps: 0,
             max_stake_per_user: 0,
+            whitelisted_tokens: Map::new(&env),
+            min_stake: 1_000_000,
+            metadata_version: 0,
         };
 
         set_config(&env, &config);
@@ -98,7 +102,8 @@ impl CallRegistry {
     ) -> Result<Call, CallRegistryError> {
         creator.require_auth();
 
-        if stake_amount <= 0 {
+        let config = get_config(&env).ok_or(CallRegistryError::NotInitialized)?;
+        if stake_amount < config.min_stake || stake_amount <= 0 {
             return Err(CallRegistryError::InvalidStakeAmount);
         }
 
@@ -107,6 +112,14 @@ impl CallRegistry {
             return Err(CallRegistryError::InvalidEndTime);
         }
 
+        let config = get_config(&env).ok_or(CallRegistryError::NotInitialized)?;
+        if !config
+            .whitelisted_tokens
+            .get(stake_token.clone())
+            .unwrap_or(false)
+        {
+            panic!("stake token not whitelisted");
+        }
         let call_id = next_call_id(&env);
 
         let call = Call {
@@ -129,6 +142,7 @@ impl CallRegistry {
             settled: false,
             created_at: current_timestamp,
             cancelled: false,
+            metadata_version: 0,
         };
 
         set_call(&env, &call);
@@ -150,6 +164,41 @@ impl CallRegistry {
         Ok(call)
     }
 
+    pub fn update_call_metadata(
+        env: Env,
+        creator: Address,
+        call_id: u64,
+        new_ipfs_cid: Bytes,
+    ) -> Result<(), CallRegistryError> {
+        creator.require_auth();
+        let mut call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
+
+        if call.creator != creator {
+            panic!("not the call creator");
+        }
+        if call.settled || call.cancelled {
+            panic!("call is ended or cancelled");
+        }
+        let current_ts = env.ledger().timestamp();
+        if current_ts >= call.end_ts {
+            panic!("call has expired");
+        }
+
+        let old_cid = call.ipfs_cid.clone();
+        call.ipfs_cid = new_ipfs_cid.clone();
+        call.metadata_version += 1;
+
+        set_call(&env, &call);
+        emit_call_metadata_updated(
+            &env,
+            call_id,
+            &creator,
+            &old_cid,
+            &new_ipfs_cid,
+            call.metadata_version,
+        );
+        Ok(())
+    }
     /// Extend the TTL of a specific call's persistent storage entry.
     /// Anyone may call this to prevent an active call from being archived.
     /// # Errors
@@ -165,6 +214,22 @@ impl CallRegistry {
             storage::PERSISTENT_BUMP_AMOUNT,
         );
         Ok(())
+    }
+
+    pub fn whitelist_token(env: Env, token_address: Address) {
+        admin::whitelist_token(env, token_address);
+    }
+
+    pub fn remove_token(env: Env, token_address: Address) {
+        admin::remove_token(env, token_address);
+    }
+
+    pub fn is_token_whitelisted(env: Env, token_address: Address) -> bool {
+        let config = get_config(&env).expect("not initialized");
+        config
+            .whitelisted_tokens
+            .get(token_address)
+            .unwrap_or(false)
     }
 
     /// Add stake to an existing call.
@@ -185,6 +250,11 @@ impl CallRegistry {
 
         if amount <= 0 {
             return Err(CallRegistryError::InvalidStakeAmount);
+        }
+
+        let config = get_config(&env).expect("not initialized");
+        if amount < config.min_stake {
+            panic!("stake below minimum");
         }
 
         let mut call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
@@ -247,6 +317,10 @@ impl CallRegistry {
     /// Pass `0` to remove the cap.
     pub fn set_max_stake_per_user(env: Env, new_max: i128) {
         admin::set_max_stake_per_user(env, new_max);
+    }
+
+    pub fn set_min_stake(env: Env, new_min_stake: i128) {
+        admin::set_min_stake(env, new_min_stake);
     }
 
     /// Resolve a call with an outcome (outcome_manager only).

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -53,6 +53,7 @@ pub struct Call {
     pub created_at: u64,
     /// Whether the call has been cancelled by its creator
     pub cancelled: bool,
+    pub metadata_version: u32,
 }
 
 /// Enum representing stake positions on a call
@@ -95,6 +96,9 @@ pub struct ContractConfig {
     /// Maximum stake any single user may place per call per position.
     /// `0` means unlimited.
     pub max_stake_per_user: i128,
+    pub whitelisted_tokens: Map<Address, bool>,
+    pub min_stake: i128,
+    pub metadata_version: u32,
 }
 
 /// Contract-wide aggregated statistics for dashboards.

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -49,3 +49,10 @@ pub fn emit_batch_payout_started(env: &Env, call_id: u64, staker_count: u32) {
         (call_id, staker_count),
     );
 }
+
+pub fn emit_outcome_disputed(env: &Env, call_id: u64, new_outcome: u32, new_price: i128) {
+    env.events().publish(
+        (symbol_short!("outcome"), symbol_short!("disputed")),
+        (call_id, new_outcome, new_price),
+    );
+}

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -11,8 +11,8 @@ use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, IntoVal, Map, Sy
 use auth::require_admin;
 use backit_shared::{is_valid_fee_bps, is_valid_outcome};
 use events::{
-    emit_batch_payout_started, emit_fee_collected, emit_outcome_finalized, emit_outcome_submitted,
-    emit_payout_claimed,
+    emit_batch_payout_started, emit_fee_collected, emit_outcome_disputed, emit_outcome_finalized,
+    emit_outcome_submitted, emit_payout_claimed,
 };
 use storage::{InstanceKey, Outcome, SignedOutcome, TempKey};
 use verification::{build_message, verify_signature};
@@ -75,6 +75,7 @@ impl OutcomeManager {
         quorum: u32,
         fee_collector: Address,
         fee_bps: u32,
+        dispute_window_secs: u64,
     ) {
         if env.storage().instance().has(&InstanceKey::Admin) {
             panic!("already initialized");
@@ -359,6 +360,66 @@ impl OutcomeManager {
         registry_release_escrow(&env, &registry, call_id, &staker, payout);
 
         emit_payout_claimed(&env, call_id, &staker, payout);
+    }
+
+    pub fn finalize_outcome(env: Env, call_id: u64) {
+        let pending: Outcome = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::PendingOutcome(call_id))
+            .expect("no pending outcome");
+
+        let window_start: u64 = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::DisputeWindowStart(call_id))
+            .expect("no window start");
+
+        let dispute_window = storage::get_dispute_window(&env);
+        if env.ledger().timestamp() < window_start + dispute_window {
+            panic!("dispute window not yet expired");
+        }
+
+        env.storage()
+            .instance()
+            .set(&InstanceKey::FinalOutcome(call_id), &pending);
+        let registry = storage::get_registry(&env);
+        registry_resolve_call(
+            &env,
+            &registry,
+            pending.call_id,
+            pending.outcome,
+            pending.price,
+        );
+        emit_outcome_finalized(&env, call_id, pending.outcome, pending.price);
+    }
+
+    pub fn dispute_outcome(env: Env, call_id: u64, new_outcome: u32, new_price: i128) {
+        require_admin(&env);
+
+        let mut pending: Outcome = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::PendingOutcome(call_id))
+            .expect("no pending outcome");
+
+        let window_start: u64 = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::DisputeWindowStart(call_id))
+            .expect("no window start");
+
+        let dispute_window = storage::get_dispute_window(&env);
+        if env.ledger().timestamp() >= window_start + dispute_window {
+            panic!("dispute window has expired");
+        }
+
+        pending.outcome = new_outcome;
+        pending.price = new_price;
+        env.storage()
+            .instance()
+            .set(&InstanceKey::PendingOutcome(call_id), &pending);
+        emit_outcome_disputed(&env, call_id, new_outcome, new_price);
     }
 
     /// Batch-settle payouts for multiple winning stakers in a single transaction.

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -40,6 +40,9 @@ pub enum InstanceKey {
     FeeBps,
     /// Stored CallRegistry address; set via set_registry() to avoid caller-supplied forgery
     Registry,
+    DisputeWindow,
+    PendingOutcome(u64),     // stores Outcome after quorum, before finalization
+    DisputeWindowStart(u64), // ledger timestamp when quorum was reached
 }
 
 #[contracttype]
@@ -62,4 +65,17 @@ pub fn get_registry(env: &Env) -> Address {
         .instance()
         .get(&InstanceKey::Registry)
         .expect("registry not set")
+}
+
+pub fn set_dispute_window(env: &Env, secs: u64) {
+    env.storage()
+        .instance()
+        .set(&InstanceKey::DisputeWindow, &secs);
+}
+
+pub fn get_dispute_window(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&InstanceKey::DisputeWindow)
+        .unwrap_or(3600)
 }

--- a/packages/contracts/outcome_manager/src/verification.rs
+++ b/packages/contracts/outcome_manager/src/verification.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{BytesN, Env, Bytes};
+use soroban_sdk::{Bytes, BytesN, Env};
 
 // Re-export build_message from the shared crate so existing call sites are unchanged.
 pub use backit_shared::build_message;


### PR DESCRIPTION
Changes across packages/contracts/call_registry and packages/contracts/outcome_manager.

call_registry:
- Add Map storage for whitelisted stake tokens with whitelist_token(),
  remove_token(), and is_token_whitelisted() admin/view functions
- Guard create_call to reject non-whitelisted tokens; emit TokenWhitelisted
  and TokenDelisted events
- Add min_stake: i128 to ContractConfig (default 1_000_000); enforce in both
  create_call and stake_on_call with descriptive panics; add set_min_stake()
  admin function emitting AdminParamsChanged; update initialize() to accept
  min_stake parameter
- Add update_call_metadata(env, creator, call_id, new_ipfs_cid) restricted to
  original creator on non-ended/non-settled/non-cancelled calls; add
  metadata_version: u32 counter to Call struct incremented on each update;
  emit CallMetadataUpdated with (call_id, creator, old_cid, new_cid, version)
- Modified files: lib.rs, storage.rs, types.rs, admin.rs, events.rs, test.rs

outcome_manager:
- Add dispute_window_secs: u64 to OutcomeManager config (default 3600)
- Store post-quorum outcome as PendingOutcome instead of finalizing immediately
- Add finalize_outcome() callable only after dispute window expires
- Add dispute_outcome() admin-only override valid only within dispute window
- Guard claim_payout to require FinalOutcome, not PendingOutcome
- Emit OutcomeDisputed and OutcomeFinalized events
- Modified files: lib.rs, storage.rs, events.rs, test.rs

closes #133
closes #140
closes #142
closes #143