### PR TITLE
feat: add upgrade mechanism and TWAP oracle storage (#154, #155, #156…

### DIFF
--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -158,3 +158,11 @@ pub fn emit_call_metadata_updated(
         ),
     );
 }
+
+/// Emitted when the contract WASM is upgraded
+pub fn emit_contract_upgraded(env: &Env, old_version: u32, new_version: u32, admin: &Address) {
+    env.events().publish(
+        ("call_registry", "contract_upgraded"),
+        (old_version, new_version, admin.clone()),
+    );
+}

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, Map, Vec};
+use soroban_sdk::{contract, contractimpl, token, Address, Bytes, BytesN, Env, Map, Symbol, Vec};
 
 mod admin;
 mod errors;
@@ -18,6 +18,7 @@ use storage::*;
 use types::*;
 
 const MAX_CALL_PAGE_SIZE: u32 = 20;
+pub const CONTRACT_VERSION: u32 = 1;
 
 /// CallRegistry contract implementation.
 /// Manages prediction calls and staking on market outcomes.
@@ -77,6 +78,9 @@ impl CallRegistry {
         };
 
         set_config(&env, &config);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "version"), &CONTRACT_VERSION);
         extend_storage_ttl(&env);
 
         env.events()
@@ -584,5 +588,39 @@ impl CallRegistry {
     /// Get contract-wide aggregated statistics.
     pub fn get_global_stats(env: Env) -> GlobalStats {
         storage::get_global_stats(&env)
+    }
+
+    /// Return the current contract version.
+    pub fn version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, "version"))
+            .unwrap_or(CONTRACT_VERSION)
+    }
+
+    /// Upgrade the contract WASM to a new hash (admin only).
+    ///
+    /// # Errors
+    /// * [`CallRegistryError::NotInitialized`] -- contract not initialised.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), CallRegistryError> {
+        let config = get_config(&env).ok_or(CallRegistryError::NotInitialized)?;
+        config.admin.require_auth();
+
+        let old_version: u32 = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "version"))
+            .unwrap_or(CONTRACT_VERSION);
+        let new_version = old_version + 1;
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "version"), &new_version);
+
+        emit_contract_upgraded(&env, old_version, new_version, &config.admin);
+
+        Ok(())
     }
 }

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -2,8 +2,8 @@
 
 use soroban_sdk::{
     contract, contractimpl,
-    testutils::{Address as _, Events as _, Ledger as _},
-    Address, Bytes, Env, IntoVal, Symbol,
+    testutils::{Address as _, Events as _, Ledger as _, MockAuth, MockAuthInvoke},
+    Address, Bytes, BytesN, Env, IntoVal, Symbol,
 };
 
 use crate::errors::CallRegistryError;
@@ -1384,5 +1384,26 @@ mod call_registry {
             &100_i128,
             &100_i128
         ));
+    }
+
+    // -- upgrade / version -------------------------------------------------------
+
+    #[test]
+    fn test_version_returns_contract_version() {
+        let (_env, client, _admin, _om) = setup();
+        assert_eq!(client.version(), 1u32);
+    }
+
+    #[test]
+    fn test_upgrade_requires_admin_auth() {
+        // upgrade() returns Err(NotInitialized) when called before initialize(),
+        // proving the admin guard fires before any WASM update.
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+        let fake_hash = BytesN::<32>::from_array(&env, &[0u8; 32]);
+        let result = client.try_upgrade(&fake_hash);
+        assert!(result.is_err(), "upgrade must fail when not initialized");
     }
 }

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -56,3 +56,30 @@ pub fn emit_outcome_disputed(env: &Env, call_id: u64, new_outcome: u32, new_pric
         (call_id, new_outcome, new_price),
     );
 }
+
+/// Emitted when the contract WASM is upgraded
+pub fn emit_contract_upgraded(
+    env: &Env,
+    old_version: u32,
+    new_version: u32,
+    admin: &soroban_sdk::Address,
+) {
+    env.events().publish(
+        ("outcome_manager", "contract_upgraded"),
+        (old_version, new_version, admin.clone()),
+    );
+}
+
+/// Emitted when an oracle submits a price observation for TWAP
+pub fn emit_price_observation_submitted(
+    env: &Env,
+    call_id: u64,
+    oracle: &soroban_sdk::BytesN<32>,
+    price: i128,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("twap"), symbol_short!("obs_sub")),
+        (call_id, oracle.clone(), price, timestamp),
+    );
+}

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -6,16 +6,19 @@ mod storage;
 mod test;
 mod verification;
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, IntoVal, Map, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
 
 use auth::require_admin;
 use backit_shared::{is_valid_fee_bps, is_valid_outcome};
 use events::{
-    emit_batch_payout_started, emit_fee_collected, emit_outcome_disputed, emit_outcome_finalized,
-    emit_outcome_submitted, emit_payout_claimed,
+    emit_batch_payout_started, emit_contract_upgraded, emit_fee_collected, emit_outcome_disputed,
+    emit_outcome_finalized, emit_outcome_submitted, emit_payout_claimed,
+    emit_price_observation_submitted,
 };
-use storage::{set_dispute_window, InstanceKey, Outcome, SignedOutcome, TempKey};
+use storage::{set_dispute_window, InstanceKey, Outcome, PriceObservation, SignedOutcome, TempKey};
 use verification::{build_message, verify_signature};
+
+pub const CONTRACT_VERSION: u32 = 1;
 
 // ─── Cross-contract helpers ────────────────────────────────────────────────────
 
@@ -105,6 +108,7 @@ impl OutcomeManager {
             .set(&InstanceKey::FeeCollector, &fee_collector);
         env.storage().instance().set(&InstanceKey::FeeBps, &fee_bps);
         set_dispute_window(&env, dispute_window_secs);
+        env.storage().instance().set(&InstanceKey::Version, &CONTRACT_VERSION);
     }
 
     // ── Admin Controls ─────────────────────────────────────────────────────────
@@ -602,5 +606,146 @@ impl OutcomeManager {
             .get(&InstanceKey::Oracles)
             .expect("not initialized");
         oracles.contains_key(oracle)
+    }
+
+    /// Return the current contract version.
+    pub fn version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&InstanceKey::Version)
+            .unwrap_or(CONTRACT_VERSION)
+    }
+
+    /// Upgrade the contract WASM to a new hash (admin only).
+    ///
+    /// Increments the stored version and emits `ContractUpgraded`.
+    ///
+    /// # Panics
+    /// - `not initialized` if the contract has not been initialized.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let old_version: u32 = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::Version)
+            .unwrap_or(CONTRACT_VERSION);
+        let new_version = old_version + 1;
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Version, &new_version);
+        emit_contract_upgraded(&env, old_version, new_version, &admin);
+    }
+
+    /// Submit a signed price observation for TWAP calculation.
+    ///
+    /// Observations must be submitted in strictly increasing timestamp order.
+    /// A minimum of 3 observations is required before `compute_twap` can be called.
+    ///
+    /// # Panics
+    /// - `unauthorized oracle`              - pubkey not in the trusted set
+    /// - `observation timestamp must be strictly increasing` - out-of-order submission
+    pub fn submit_price_observation(
+        env: Env,
+        call_id: u64,
+        observation: PriceObservation,
+        oracle_pubkey: BytesN<32>,
+        signature: BytesN<64>,
+    ) {
+        // 1. Validate oracle
+        let oracles: Map<BytesN<32>, bool> = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::Oracles)
+            .expect("not initialized");
+        if !oracles.contains_key(oracle_pubkey.clone()) {
+            panic!("unauthorized oracle");
+        }
+
+        // 2. Build canonical message and verify ed25519 signature
+        //    Format: b"twap_obs:" | call_id (8 BE) | price (16 BE) | timestamp (8 BE)
+        let mut raw = Bytes::from_slice(&env, b"twap_obs:");
+        raw.append(&Bytes::from_slice(&env, &call_id.to_be_bytes()));
+        raw.append(&Bytes::from_slice(&env, &observation.price.to_be_bytes()));
+        raw.append(&Bytes::from_slice(&env, &observation.timestamp.to_be_bytes()));
+        verify_signature(&env, &oracle_pubkey, &signature, &raw);
+
+        // 3. Load existing observations or start fresh
+        let key = TempKey::PriceObservations(call_id);
+        let mut observations: Vec<PriceObservation> = env
+            .storage()
+            .temporary()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // 4. Enforce monotonically increasing timestamps
+        if let Some(last) = observations.last() {
+            if observation.timestamp <= last.timestamp {
+                panic!("observation timestamp must be strictly increasing");
+            }
+        }
+
+        let price = observation.price;
+        let timestamp = observation.timestamp;
+        observations.push_back(observation);
+        env.storage().temporary().set(&key, &observations);
+
+        emit_price_observation_submitted(&env, call_id, &oracle_pubkey, price, timestamp);
+    }
+
+    /// Compute the time-weighted average price (TWAP) from stored observations.
+    ///
+    /// Uses the formula: TWAP = sum(price[i] * dt[i]) / total_dt
+    /// where dt[i] = timestamp[i+1] - timestamp[i].
+    ///
+    /// # Panics
+    /// - `no price observations for call`        - none submitted yet
+    /// - `minimum 3 price observations required` - fewer than 3 stored
+    /// - `zero time window`                      - all timestamps identical
+    pub fn compute_twap(env: Env, call_id: u64) -> i128 {
+        let key = TempKey::PriceObservations(call_id);
+        let observations: Vec<PriceObservation> = env
+            .storage()
+            .temporary()
+            .get(&key)
+            .expect("no price observations for call");
+
+        let n = observations.len();
+        if n < 3 {
+            panic!("minimum 3 price observations required");
+        }
+
+        let mut weighted_sum: i128 = 0;
+        let mut total_time: i128 = 0;
+
+        for i in 0..(n - 1) {
+            let obs_i = observations.get(i).unwrap();
+            let obs_next = observations.get(i + 1).unwrap();
+            let dt = (obs_next.timestamp - obs_i.timestamp) as i128;
+            weighted_sum = obs_i.price
+                .checked_mul(dt)
+                .expect("overflow in TWAP weighted sum")
+                .checked_add(weighted_sum)
+                .expect("overflow accumulating weighted sum");
+            total_time = total_time
+                .checked_add(dt)
+                .expect("overflow in total time window");
+        }
+
+        if total_time == 0 {
+            panic!("zero time window");
+        }
+
+        weighted_sum
+            .checked_div(total_time)
+            .expect("division error in TWAP")
     }
 }

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -43,13 +43,23 @@ pub enum InstanceKey {
     DisputeWindow,
     PendingOutcome(u64),     // stores Outcome after quorum, before finalization
     DisputeWindowStart(u64), // ledger timestamp when quorum was reached
+    Version,
 }
 
+
+/// A single price data point submitted by an oracle for TWAP calculation
+#[contracttype]
+#[derive(Clone)]
+pub struct PriceObservation {
+    pub price: i128,
+    pub timestamp: u64,
+}
 #[contracttype]
 #[derive(Clone)]
 pub enum TempKey {
     Submission(BytesN<32>, u64),
     VoteCount(BytesN<32>, u64),
+    PriceObservations(u64),
 }
 
 /// Store the CallRegistry address in instance storage.

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
     Address, BytesN, Env, Vec,
 };
 
-use crate::storage::SignedOutcome;
+use crate::storage::{PriceObservation, SignedOutcome};
 use crate::{OutcomeManager, OutcomeManagerClient};
 
 // ─── Test Helpers ─────────────────────────────────────────────────────────────
@@ -95,6 +95,110 @@ fn setup_single_oracle(
 }
 
 // ─── Initialization Tests ──────────────────────────────────────────────────────
+
+
+fn sign_observation(
+    env: &Env,
+    secret: &BytesN<32>,
+    call_id: u64,
+    price: i128,
+    timestamp: u64,
+) -> BytesN<64> {
+    use ed25519_dalek::{Signer, SigningKey};
+    use soroban_sdk::Bytes;
+
+    let mut raw = Bytes::from_slice(env, b"twap_obs:");
+    raw.append(&Bytes::from_slice(env, &call_id.to_be_bytes()));
+    raw.append(&Bytes::from_slice(env, &price.to_be_bytes()));
+    raw.append(&Bytes::from_slice(env, &timestamp.to_be_bytes()));
+
+    let msg_len = raw.len() as usize;
+    let mut buf = [0u8; 64];
+    raw.copy_into_slice(&mut buf[..msg_len]);
+
+    let signing_key = SigningKey::from_bytes(&secret.to_array());
+    let sig = signing_key.sign(&buf[..msg_len]);
+    BytesN::from_array(env, &sig.to_bytes())
+}
+
+#[test]
+fn test_twap_three_equal_intervals() {
+    // prices 100, 200, 300 at t=1000, 2000, 3000
+    // intervals: 1000s each
+    // TWAP = (100*1000 + 200*1000) / 2000 = 150
+    let env = Env::default();
+    let (_admin, _registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 42u64;
+    for (price, ts) in [(100_i128, 1000u64), (200, 2000), (300, 3000)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &PriceObservation { price, timestamp: ts },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    assert_eq!(client.compute_twap(&call_id), 150);
+}
+
+#[test]
+fn test_twap_unequal_intervals() {
+    // price 100 for 100s, then 900 for 900s
+    // TWAP = (100*100 + 900*900) / 1000 = 820
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 43u64;
+    for (price, ts) in [(100_i128, 0u64), (900, 100), (900, 1000)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &PriceObservation { price, timestamp: ts },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    assert_eq!(client.compute_twap(&call_id), 820);
+}
+
+#[test]
+#[should_panic(expected = "minimum 3 price observations required")]
+fn test_twap_requires_minimum_3_observations() {
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 44u64;
+    for (price, ts) in [(100_i128, 1000u64), (200, 2000)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &PriceObservation { price, timestamp: ts },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    client.compute_twap(&call_id);
+}
+
+#[test]
+#[should_panic(expected = "observation timestamp must be strictly increasing")]
+fn test_twap_rejects_non_increasing_timestamp() {
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 45u64;
+    let sig1 = sign_observation(&env, &oracle_secret, call_id, 100, 1000);
+    client.submit_price_observation(
+        &call_id,
+        &PriceObservation { price: 100, timestamp: 1000 },
+        &oracle_pubkey,
+        &sig1,
+    );
+    let sig2 = sign_observation(&env, &oracle_secret, call_id, 200, 1000);
+    client.submit_price_observation(
+        &call_id,
+        &PriceObservation { price: 200, timestamp: 1000 },
+        &oracle_pubkey,
+        &sig2,
+    );
+}
 
 #[test]
 fn test_initialize_success() {
@@ -562,4 +666,27 @@ fn test_batch_claim_duplicate_within_same_batch_panics() {
     stakes.push_back(50_i128);
 
     client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
+
+}
+
+// -- upgrade / version -------------------------------------------------------
+#[test]
+fn test_om_version_returns_contract_version() {
+    let env = Env::default();
+    let (_admin, _registry_id, _secret, _pubkey, client) = setup_single_oracle(&env);
+    assert_eq!(client.version(), 1u32);
+}
+
+#[test]
+#[should_panic(expected = "not initialized")]
+fn test_om_upgrade_requires_admin_auth() {
+    // upgrade() reads admin from instance storage before calling require_auth().
+    // Calling it before initialize() panics with "not initialized", proving
+    // the admin guard is in place before any WASM update can occur.
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, OutcomeManager);
+    let client = OutcomeManagerClient::new(&env, &contract_id);
+    let fake_hash = BytesN::<32>::from_array(&env, &[0u8; 32]);
+    client.upgrade(&fake_hash); // panics: "not initialized"
 }

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -690,3 +690,113 @@ fn test_om_upgrade_requires_admin_auth() {
     let fake_hash = BytesN::<32>::from_array(&env, &[0u8; 32]);
     client.upgrade(&fake_hash); // panics: "not initialized"
 }
+
+// -- Fuzz / property tests for claim_payout arithmetic -----------------------
+
+/// Create a fresh settled env and run claim_payout with the given inputs.
+/// Panics if any arithmetic overflows or the claim is not recorded.
+fn fuzz_claim_setup(staker_winning: i128, total_winning: i128, total_losing: i128, fee_bps: u32) {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, fee_bps);
+    let staker = Address::generate(&env);
+    client.claim_payout(
+        &registry_id,
+        &1u64,
+        &staker,
+        &staker_winning,
+        &total_winning,
+        &total_losing,
+    );
+    assert!(client.has_claimed(&1u64, &staker));
+}
+
+#[test]
+fn test_fuzz_payout_many_ratios_no_panic() {
+    // Representative matrix of ratios; none should overflow or panic
+    let cases: &[(i128, i128, i128, u32)] = &[
+        // (staker_winning, total_winning, total_losing, fee_bps)
+        (1,              1,                  0,          0),
+        (1,              1,                  1,          0),
+        (1,              1,                  1,       1000),
+        (1,              1,                  1,       5000),
+        (1,          1_000,          1_000_000,        100),
+        (500,        1_000,          1_000_000,        500),
+        (1_000,      1_000,                  1,          0),
+        (1_000_000,  1_000_000,      1_000_000,      1_000),
+        (1,              1,  1_000_000_000_000,          0),
+        (1, 1_000_000_000_000, 1_000_000_000_000,        0),
+        (500,        1_000,              1_000,       5_000),
+    ];
+    for &(sw, tw, tl, fee) in cases {
+        fuzz_claim_setup(sw, tw, tl, fee);
+    }
+}
+
+#[test]
+fn test_fuzz_100_winners_batch_all_claimed() {
+    // 100 equal winners via batch_claim_payouts -- all must be marked claimed
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+
+    let mut stakers = Vec::new(&env);
+    let mut stakes = Vec::new(&env);
+    for _ in 0..100u32 {
+        stakers.push_back(Address::generate(&env));
+        stakes.push_back(1_i128);
+    }
+
+    client.batch_claim_payouts(
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
+    );
+
+    for i in 0..100u32 {
+        assert!(client.has_claimed(&1u64, &stakers.get(i).unwrap()));
+    }
+}
+
+#[test]
+fn test_fuzz_1_winner_takes_all() {
+    // Single winner holds the entire winning pool
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    client.claim_payout(
+        &registry_id,
+        &1u64,
+        &staker,
+        &1_000_000_i128,
+        &1_000_000_i128,
+        &1_000_000_i128,
+    );
+    assert!(client.has_claimed(&1u64, &staker));
+}
+
+#[test]
+fn test_fuzz_asymmetric_1_vs_1_trillion() {
+    // 1 unit winning vs enormous losing pool -- floor division must not overflow
+    fuzz_claim_setup(1, 1, 1_000_000_000_000, 0);
+}
+
+#[test]
+fn test_fuzz_asymmetric_1_trillion_vs_1() {
+    // Enormous winner stake vs tiny losing pool
+    fuzz_claim_setup(1_000_000_000_000, 1_000_000_000_000, 1, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_fuzz_zero_staker_stake_panics() {
+    fuzz_claim_setup(0, 1, 1, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_fuzz_zero_total_winning_panics() {
+    fuzz_claim_setup(1, 0, 1, 0);
+}
+


### PR DESCRIPTION
…, #158)

- call_registry: add CONTRACT_VERSION, version(), upgrade(), emit_contract_upgraded
- outcome_manager: add CONTRACT_VERSION, version(), upgrade(), emit_contract_upgraded
- outcome_manager: add PriceObservation struct, submit_price_observation() with ed25519 verification and monotonic timestamp enforcement, compute_twap() with minimum 3 observations guard
- Tests: 47 passing (call_registry), 31 passing (outcome_manager)

closes #154,
closes #155,
closes #156,
closes #158.