### PR TITLE
feat(analytics): implement Portfolio TVL aggregation with USDC conver…

### DIFF
--- a/packages/backend/src/analytics/analytics.controller.ts
+++ b/packages/backend/src/analytics/analytics.controller.ts
@@ -117,6 +117,8 @@ export class AnalyticsController {
    * for the given wallet address.
    */
   @Get(':userAddress/tvl')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60000) // 1 minute
   @ApiOperation({
     summary: 'Get Total Value Locked',
     description:

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -4,9 +4,15 @@ import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
 import { Call } from './entities/call.entity';
 import { Stake } from './entities/stake.entity';
+import { TokensModule } from '../token/tokens.module';
+import { OracleModule } from '../oracle/oracle.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Call, Stake])],
+  imports: [
+    TypeOrmModule.forFeature([Call, Stake]),
+    TokensModule,
+    OracleModule,
+  ],
   controllers: [AnalyticsController],
   providers: [AnalyticsService],
   exports: [AnalyticsService],

--- a/packages/backend/src/analytics/analytics.service.spec.ts
+++ b/packages/backend/src/analytics/analytics.service.spec.ts
@@ -5,14 +5,26 @@ import { Stake } from './entities/stake.entity';
 import { Call } from './entities/call.entity';
 import { DataSource } from 'typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { TokensService } from '../token/tokens.service';
+import { CoinGeckoService } from '../oracle/coinGeko.service';
 
 const mockQb = {
   innerJoin: jest.fn().mockReturnThis(),
+  innerJoinAndSelect: jest.fn().mockReturnThis(),
+  leftJoin: jest.fn().mockReturnThis(),
+  leftJoinAndSelect: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
   select: jest.fn().mockReturnThis(),
   addSelect: jest.fn().mockReturnThis(),
+  groupBy: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
   getRawOne: jest.fn(),
+  getRawMany: jest.fn(),
+  getMany: jest.fn(),
+  getManyAndCount: jest.fn(),
 };
 
 const mockStakeLedgerRepository = {
@@ -31,6 +43,14 @@ const mockCacheManager = {
   get: jest.fn(),
   set: jest.fn(),
   del: jest.fn(),
+};
+
+const mockTokensService = {
+  getAll: jest.fn(),
+};
+
+const mockCoinGeckoService = {
+  getPrices: jest.fn(),
 };
 
 describe('AnalyticsService – getTotalValueLocked', () => {
@@ -60,6 +80,14 @@ describe('AnalyticsService – getTotalValueLocked', () => {
           provide: CACHE_MANAGER,
           useValue: mockCacheManager,
         },
+        {
+          provide: TokensService,
+          useValue: mockTokensService,
+        },
+        {
+          provide: CoinGeckoService,
+          useValue: mockCoinGeckoService,
+        },
       ],
     }).compile();
 
@@ -67,51 +95,61 @@ describe('AnalyticsService – getTotalValueLocked', () => {
   });
 
   it('returns correct TVL and count when pending stakes exist', async () => {
-    mockQb.getRawOne.mockResolvedValue({
-      totalValueLocked: '1250.75',
-      pendingStakesCount: '8',
-    });
+    mockQb.getMany.mockResolvedValue([
+      {
+        amount: '100',
+        position: 'YES',
+        call: {
+          id: 'call-1',
+          stakeToken: 'USDC-ADDR',
+          totalYesStake: '200',
+          totalNoStake: '100',
+        }
+      },
+      {
+        amount: '50',
+        position: 'NO',
+        call: {
+          id: 'call-2',
+          stakeToken: 'XLM-ADDR',
+          totalYesStake: '50',
+          totalNoStake: '50',
+        }
+      }
+    ]);
+
+    mockTokensService.getAll.mockResolvedValue([
+      { assetIssuer: 'USDC-ADDR', assetCode: 'USDC' },
+      { assetIssuer: 'XLM-ADDR', assetCode: 'XLM' },
+    ]);
+
+    const mockPrices = new Map<string, number>();
+    mockPrices.set('USDC', 1);
+    mockPrices.set('XLM', 0.1);
+    mockCoinGeckoService.getPrices.mockResolvedValue(mockPrices);
 
     const result = await service.getTotalValueLocked('GBXXX');
 
-    expect(result).toEqual({
-      userAddress: 'GBXXX',
-      totalValueLocked: 1250.75,
-      pendingStakesCount: 8,
-    });
+    expect(result.userAddress).toEqual('GBXXX');
+    expect(result.pendingStakesCount).toBe(2);
+    expect(result.totalValueLocked).toBe(105); // 100*1 + 50*0.1 = 105
 
-    // Assert the query was scoped correctly
-    expect(mockQb.where).toHaveBeenCalledWith(
-      'stake.userAddress = :userAddress',
-      { userAddress: 'GBXXX' },
-    );
-    expect(mockQb.andWhere).toHaveBeenCalledWith('call.outcome = :outcome', {
-      outcome: 'PENDING',
-    });
+    expect(result.breakdown).toHaveLength(2);
+    expect(result.breakdown[0].tokenSymbol).toBe('USDC');
+    expect(result.breakdown[0].potentialWin).toBe(150); // (100 / 200) * 300 * 1
+    expect(result.breakdown[1].tokenSymbol).toBe('XLM');
+    expect(result.breakdown[1].potentialWin).toBe(10); // (50 / 50) * 100 * 0.1
   });
 
   it('returns zeros when the user has no pending stakes', async () => {
-    // DB returns COALESCE default — still a string from getRawOne
-    mockQb.getRawOne.mockResolvedValue({
-      totalValueLocked: '0',
-      pendingStakesCount: '0',
-    });
+    mockQb.getMany.mockResolvedValue([]);
 
     const result = await service.getTotalValueLocked('GBYYY');
 
     expect(result.totalValueLocked).toBe(0);
     expect(result.pendingStakesCount).toBe(0);
     expect(result.userAddress).toBe('GBYYY');
-  });
-
-  it('handles null getRawOne result gracefully', async () => {
-    // Edge case: getRawOne can return undefined if the driver returns nothing
-    mockQb.getRawOne.mockResolvedValue(undefined);
-
-    const result = await service.getTotalValueLocked('GBZZZ');
-
-    expect(result.totalValueLocked).toBe(0);
-    expect(result.pendingStakesCount).toBe(0);
+    expect(result.breakdown).toEqual([]);
   });
 });
 
@@ -140,6 +178,14 @@ describe('AnalyticsService - calculateReputationScore', () => {
         {
           provide: CACHE_MANAGER,
           useValue: mockCacheManager,
+        },
+        {
+          provide: TokensService,
+          useValue: mockTokensService,
+        },
+        {
+          provide: CoinGeckoService,
+          useValue: mockCoinGeckoService,
         },
       ],
     }).compile();

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -1,5 +1,7 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { TotalValueLockedResponseDto } from './dto/tvl.dto';
+import { TokensService } from '../token/tokens.service';
+import { CoinGeckoService } from '../oracle/coinGeko.service';
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
@@ -33,6 +35,8 @@ export class AnalyticsService {
 
     private readonly dataSource: DataSource,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    private readonly tokensService: TokensService,
+    private readonly coinGeckoService: CoinGeckoService,
   ) {}
 
   /**
@@ -529,28 +533,83 @@ export class AnalyticsService {
   /**
    * Aggregates a user's active Portfolio "Total Value Locked".
    *
-   * Loops over every StakeLedger row where:
+   * Loops over every Stake row where:
    *   - userAddress matches the caller
-   *   - the parent Call still has outcome === 'PENDING'  (i.e. unresolved)
+   *   - the parent Call has status OPEN or SETTLING
    *
-   * Returns the XLM sum of those amounts and a count of matching rows.
+   * Returns the USDC sum of those amounts, a count, and a breakdown.
    */
   async getTotalValueLocked(
     userAddress: string,
   ): Promise<TotalValueLockedResponseDto> {
-    const result = await this.stakeLedgerRepository
+    const stakes = await this.stakeLedgerRepository
       .createQueryBuilder('stake')
-      .innerJoin('stake.call', 'call')
+      .innerJoinAndSelect('stake.call', 'call')
       .where('stake.userAddress = :userAddress', { userAddress })
-      .andWhere('call.outcome = :outcome', { outcome: 'PENDING' })
-      .select('COALESCE(SUM(stake.amount), 0)', 'totalValueLocked')
-      .addSelect('COUNT(stake.id)', 'pendingStakesCount')
-      .getRawOne<{ totalValueLocked: string; pendingStakesCount: string }>();
+      .andWhere('call.status IN (:...statuses)', { statuses: ['OPEN', 'SETTLING'] })
+      .getMany();
+
+    if (!stakes.length) {
+      return {
+        userAddress,
+        totalValueLocked: 0,
+        pendingStakesCount: 0,
+        breakdown: [],
+      };
+    }
+
+    // Get all active tokens to map addresses to symbols
+    const tokens = await this.tokensService.getAll();
+    const tokenMap = new Map(tokens.map(t => [t.assetIssuer || t.assetCode, t.assetCode]));
+
+    // Identify unique symbols needed for price lookup
+    const symbolsToFetch = new Set<string>();
+    stakes.forEach(stake => {
+      const stakeToken = stake.call.stakeToken;
+      const symbol = stakeToken ? tokenMap.get(stakeToken) || 'XLM' : 'XLM'; // fallback
+      symbolsToFetch.add(symbol);
+    });
+
+    // Fetch prices in USD
+    const prices = await this.coinGeckoService.getPrices(Array.from(symbolsToFetch));
+
+    let totalLocked = 0;
+    const breakdown = stakes.map(stake => {
+      const call = stake.call;
+      const stakeToken = call.stakeToken;
+      const tokenSymbol = stakeToken ? tokenMap.get(stakeToken) || 'XLM' : 'XLM';
+      const usdPrice = prices.get(tokenSymbol) || 0; // Default to 0 if price missing
+
+      const amount = Number(stake.amount);
+      const usdValue = amount * usdPrice;
+      totalLocked += usdValue;
+
+      // Calculate potential win
+      const totalYes = Number(call.totalYesStake || 0);
+      const totalNo = Number(call.totalNoStake || 0);
+      const poolSize = stake.position === 'YES' ? totalYes : totalNo;
+      const totalPool = totalYes + totalNo;
+
+      let potentialWin = 0;
+      if (poolSize > 0) {
+        potentialWin = (amount / poolSize) * totalPool;
+      }
+      const potentialWinUsd = potentialWin * usdPrice;
+
+      return {
+        callId: call.id,
+        amount: Number(usdValue.toFixed(2)),
+        position: stake.position,
+        tokenSymbol,
+        potentialWin: Number(potentialWinUsd.toFixed(2)),
+      };
+    });
 
     return {
       userAddress,
-      totalValueLocked: parseFloat(result?.totalValueLocked ?? '0'),
-      pendingStakesCount: parseInt(result?.pendingStakesCount ?? '0', 10),
+      totalValueLocked: Number(totalLocked.toFixed(2)),
+      pendingStakesCount: stakes.length,
+      breakdown,
     };
   }
 }

--- a/packages/backend/src/analytics/dto/tvl.dto.ts
+++ b/packages/backend/src/analytics/dto/tvl.dto.ts
@@ -18,4 +18,16 @@ export class TotalValueLockedResponseDto {
     example: 8,
   })
   pendingStakesCount: number;
+
+  @ApiProperty({
+    description: 'Breakdown of active stakes',
+    example: [{ callId: '123', amount: 100, position: 'YES', tokenSymbol: 'USDC', potentialWin: 150 }]
+  })
+  breakdown: {
+    callId: string;
+    amount: number;
+    position: 'YES' | 'NO';
+    tokenSymbol: string;
+    potentialWin: number;
+  }[];
 }

--- a/packages/backend/src/analytics/entities/call.entity.ts
+++ b/packages/backend/src/analytics/entities/call.entity.ts
@@ -50,4 +50,10 @@ export class Call {
 
   @Column({ type: 'decimal', precision: 20, scale: 7, default: 0 })
   totalNoStake: number;
+
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  stakeToken?: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  status?: string;
 }

--- a/packages/backend/src/oracle/oracle.module.ts
+++ b/packages/backend/src/oracle/oracle.module.ts
@@ -46,6 +46,6 @@ import { OracleHealthController } from './oracle-health.controller';
       },
     },
   ],
-  exports: [OracleService, PriceDeviationService, OracleHealthService],
+  exports: [OracleService, PriceDeviationService, OracleHealthService, CoinGeckoService],
 })
 export class OracleModule {}


### PR DESCRIPTION
…sion

- Add GET /users/:address/tvl returning totalLocked, breakdown per stake
- Filter stakes where call.status IN ('OPEN', 'SETTLING') only
- Map stakeToken addresses to symbols via TokensService
- Fetch real-time USD prices via CoinGeckoService for USDC conversion
- Compute potentialWin using pari-mutuel formula per position
- Add 1-minute cache TTL on TVL endpoint via CacheInterceptor
- Add status and stakeToken columns to analytics Call entity
- Export CoinGeckoService from OracleModule
- Import TokensModule and OracleModule into AnalyticsModule
- Update TotalValueLockedResponseDto with breakdown array
- Update unit tests with multi-token portfolio scenarios

close #198