### PR TITLE
Harden backend CORS and security headers

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,6 +50,7 @@
     "class-validator": "^0.14.3",
     "cron": "^4.4.0",
     "dotenv": "^17.2.3",
+    "helmet": "^8.1.0",
     "pg": "^8.17.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
@@ -57,8 +58,7 @@
     "socket.io-client": "^4.8.3",
     "swagger-ui-express": "^5.0.1",
     "tweetnacl": "^1.0.3",
-    "typeorm": "^0.3.28"
-    ,
+    "typeorm": "^0.3.28",
     "bullmq": "^5.61.0",
     "ioredis": "^5.7.0"
   },
@@ -89,8 +89,7 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
-  }
-  ,
+  },
   "jest": {
     "moduleFileExtensions": [
       "js",

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -3,6 +3,7 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { AppModule } from './app.module';
+import { configureHttpSecurity } from './security/http-security';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -10,11 +11,7 @@ async function bootstrap() {
   // Attach the Socket.io WebSocket adapter — required for the EventsGateway
   app.useWebSocketAdapter(new IoAdapter(app));
 
-  // Enable CORS
-  app.enableCors({
-    origin: process.env.FRONTEND_URL || 'http://localhost:3000',
-    credentials: true,
-  });
+  configureHttpSecurity(app);
 
   // Global validation pipe
   app.useGlobalPipes(

--- a/packages/backend/src/security/http-security.ts
+++ b/packages/backend/src/security/http-security.ts
@@ -1,0 +1,111 @@
+import { INestApplication } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import helmet from 'helmet';
+import { randomUUID } from 'node:crypto';
+
+const DEFAULT_ALLOWED_ORIGINS = [
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+];
+
+export const secureCookieDefaults = {
+  httpOnly: true,
+  secure: true,
+  sameSite: 'lax' as const,
+};
+
+function normalizeOrigins(value?: string): string[] {
+  if (!value?.trim()) {
+    return DEFAULT_ALLOWED_ORIGINS;
+  }
+
+  const origins = value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return origins.length > 0 ? origins : DEFAULT_ALLOWED_ORIGINS;
+}
+
+function getRequestId(request: Request): string {
+  const existing = request.headers['x-request-id'];
+
+  if (Array.isArray(existing) && existing.length > 0) {
+    return existing[0];
+  }
+
+  if (typeof existing === 'string' && existing.trim().length > 0) {
+    return existing.trim();
+  }
+
+  return randomUUID();
+}
+
+export function getAllowedOrigins(): string[] {
+  return normalizeOrigins(
+    process.env.ALLOWED_ORIGINS || process.env.FRONTEND_URL,
+  );
+}
+
+export function configureHttpSecurity(
+  app: INestApplication,
+  allowedOrigins = getAllowedOrigins(),
+) {
+  const secureApp = app as INestApplication & {
+    disable(setting: string): INestApplication;
+  };
+
+  secureApp.disable('x-powered-by');
+
+  secureApp.use((request: Request, response: Response, next: NextFunction) => {
+    const requestId = getRequestId(request);
+    response.setHeader('X-Request-ID', requestId);
+    response.locals.requestId = requestId;
+    next();
+  });
+
+  secureApp.use((request: Request, response: Response, next: NextFunction) => {
+    const originalCookie = response.cookie.bind(response);
+
+    response.cookie = ((name, value, options = {}) =>
+      originalCookie(name, value, {
+        ...secureCookieDefaults,
+        ...options,
+      })) as typeof response.cookie;
+
+    next();
+  });
+
+  secureApp.use(
+    helmet({
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          defaultSrc: ["'self'"],
+          baseUri: ["'self'"],
+          frameAncestors: ["'none'"],
+          objectSrc: ["'none'"],
+          scriptSrc: ["'self'", "'unsafe-inline'"],
+          styleSrc: ["'self'", "'unsafe-inline'", 'https:'],
+          imgSrc: ["'self'", 'data:', 'https:'],
+          fontSrc: ["'self'", 'data:', 'https:'],
+          connectSrc: ["'self'", 'https:', 'wss:'],
+        },
+      },
+      frameguard: {
+        action: 'deny',
+      },
+      noSniff: true,
+      hsts: {
+        maxAge: 31536000,
+        includeSubDomains: true,
+        preload: true,
+      },
+    }),
+  );
+
+  secureApp.enableCors({
+    origin: allowedOrigins,
+    credentials: true,
+  });
+}

--- a/packages/backend/test/security.e2e-spec.ts
+++ b/packages/backend/test/security.e2e-spec.ts
@@ -1,0 +1,97 @@
+import { Controller, Get, Module, Res } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Response } from 'express';
+import request from 'supertest';
+import { configureHttpSecurity } from '../src/security/http-security';
+
+@Controller('security')
+class SecurityTestController {
+  @Get('headers')
+  getHeaders() {
+    return { ok: true };
+  }
+
+  @Get('cookie')
+  setCookie(@Res({ passthrough: true }) response: Response) {
+    response.cookie('session', 'abc123');
+    return { ok: true };
+  }
+}
+
+@Module({
+  controllers: [SecurityTestController],
+})
+class SecurityTestModule {}
+
+describe('HTTP security hardening', () => {
+  let app: Awaited<ReturnType<typeof createTestApp>>;
+  let previousAllowedOrigins: string | undefined;
+  let previousNodeEnv: string | undefined;
+
+  async function createTestApp() {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [SecurityTestModule],
+    }).compile();
+
+    const application = moduleFixture.createNestApplication();
+    configureHttpSecurity(application, [
+      'http://allowed.test',
+      'http://second.test',
+    ]);
+    await application.init();
+
+    return application;
+  }
+
+  beforeAll(async () => {
+    previousAllowedOrigins = process.env.ALLOWED_ORIGINS;
+    previousNodeEnv = process.env.NODE_ENV;
+    process.env.ALLOWED_ORIGINS = 'http://allowed.test,http://second.test';
+    process.env.NODE_ENV = 'production';
+    app = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    process.env.ALLOWED_ORIGINS = previousAllowedOrigins;
+    process.env.NODE_ENV = previousNodeEnv;
+  });
+
+  it('applies the expected security and CORS headers', async () => {
+    const requestId = 'test-request-id-123';
+
+    const response = await request(app.getHttpServer())
+      .get('/security/headers')
+      .set('Origin', 'http://allowed.test')
+      .set('X-Request-ID', requestId)
+      .expect(200);
+
+    expect(response.headers['access-control-allow-origin']).toBe(
+      'http://allowed.test',
+    );
+    expect(response.headers['x-request-id']).toBe(requestId);
+    expect(response.headers['strict-transport-security']).toContain('max-age=');
+    expect(response.headers['x-frame-options']).toBe('DENY');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['x-powered-by']).toBeUndefined();
+  });
+
+  it('applies secure cookie defaults when a response sets cookies', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/security/cookie')
+      .expect(200);
+
+    const cookieHeader = response.headers['set-cookie'];
+    expect(cookieHeader).toBeDefined();
+    expect(Array.isArray(cookieHeader)).toBe(true);
+
+    if (!Array.isArray(cookieHeader)) {
+      throw new Error('Expected a set-cookie header array');
+    }
+
+    const [cookie] = cookieHeader;
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('SameSite=Lax');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
+      helmet:
+        specifier: ^8.1.0
+        version: 8.2.0
       ioredis:
         specifier: ^5.7.0
         version: 5.11.0
@@ -6035,6 +6038,11 @@ packages:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
     dependencies:
       '@types/hast': 3.0.4
+    dev: false
+
+  /helmet@8.2.0:
+    resolution: {integrity: sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==}
+    engines: {node: '>=18.0.0'}
     dev: false
 
   /html-escaper@2.0.2:


### PR DESCRIPTION
## Summary
- Configure CORS from `ALLOWED_ORIGINS`
- Add Helmet hardening with CSP, X-Frame-Options, X-Content-Type-Options, and HSTS
- Add per-response `X-Request-ID`
- Disable `X-Powered-By`
- Enforce secure cookie defaults (`httpOnly`, `secure`, `sameSite=lax`)
- Add e2e coverage for headers and cookie flags

## Verification
- `node packages/backend/node_modules/jest/bin/jest.js --config packages/backend/test/jest-e2e.json --runInBand packages/backend/test/security.e2e-spec.ts`
closes #206 