### PR TITLE
feat(frontend): implement animated pool visualization on CallCard (#235)

### DIFF
--- a/packages/frontend/src/components/CallCard.tsx
+++ b/packages/frontend/src/components/CallCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import StakeBar from "./StakeBar";
+import StakeDistributionBar from "./StakeDistributionBar";
 import { useState, useEffect } from "react";
 
 interface CallCardProps {
@@ -86,13 +86,14 @@ export default function CallCard({ call }: CallCardProps) {
         </div>
       </div>
 
-      {/* Progress bar */}
+      {/* Animated Pool Distribution */}
       <div className="mb-5">
-        <div className="flex justify-between text-[10px] font-bold text-gray-400 uppercase mb-2">
-          <span>Staking Distribution</span>
-          <span>Pool: {((call.stakes?.yes || 0) + (call.stakes?.no || 0)).toLocaleString()} USDC</span>
-        </div>
-        <StakeBar yes={call.stakes?.yes || 0} no={call.stakes?.no || 0} />
+        <p className="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-2">Pool Distribution</p>
+        <StakeDistributionBar
+          yes={call.stakes?.yes || 0}
+          no={call.stakes?.no || 0}
+          variant="sm"
+        />
       </div>
 
       {/* Creator info */}

--- a/packages/frontend/src/components/CallDetail.tsx
+++ b/packages/frontend/src/components/CallDetail.tsx
@@ -3,7 +3,7 @@
 import ReactMarkdown from "react-markdown";
 import { useEffect, useState } from "react";
 import CallDetailHeader from "./CallDetailHeader";
-import StakeBar from "./StakeBar";
+import StakeDistributionBar from "./StakeDistributionBar";
 import ActivityLog from "./ActivityLog";
 import StakingInterface from "./StakingInterface";
 import StakingDrawer from "./StakingDrawer";
@@ -118,13 +118,11 @@ export default function CallDetail({ call }: { call: CallDetailData }) {
               <h4 className="font-bold text-gray-900 uppercase tracking-widest text-xs">Market Liquidity</h4>
               <span className="bg-gray-100 text-gray-600 text-[10px] font-bold px-2 py-1 rounded-md">LIVE POOL</span>
             </div>
-            <StakeBar yes={call.stakes.yes} no={call.stakes.no} />
-            <div className="mt-6 flex justify-between items-end">
-              <div>
-                <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1">Total Vaulted</p>
-                <p className="text-2xl font-black text-gray-900">{(call.stakes.yes + call.stakes.no).toLocaleString()} <span className="text-gray-400 text-sm">USDC</span></p>
-              </div>
-            </div>
+            <StakeDistributionBar
+              yes={call.stakes.yes}
+              no={call.stakes.no}
+              variant="lg"
+            />
           </div>
         </div>
 

--- a/packages/frontend/src/components/StakeDistributionBar.tsx
+++ b/packages/frontend/src/components/StakeDistributionBar.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface StakeDistributionBarProps {
+  /** Raw YES stake amount (any unit — USDC, XLM, etc.) */
+  yes: number;
+  /** Raw NO stake amount */
+  no: number;
+  /** Token label shown next to the total pool size (default "USDC") */
+  currency?: string;
+  /**
+   * visual size variant:
+   *  - "sm"  — compact bar used in CallCard
+   *  - "lg"  — taller bar with bigger labels used in the market detail page
+   */
+  variant?: "sm" | "lg";
+}
+
+/**
+ * StakeDistributionBar
+ *
+ * Shows the YES / NO stake split as an animated progress bar.
+ *
+ * Edge-cases handled:
+ *  • Empty pool (yes === 0 && no === 0) → 50 / 50 grey bar
+ *  • Single-sided (one side is 0) → 100 % one colour
+ *  • Animates width from 0 on mount and whenever yes/no values change
+ */
+export default function StakeDistributionBar({
+  yes,
+  no,
+  currency = "USDC",
+  variant = "sm",
+}: StakeDistributionBarProps) {
+  const total = yes + no;
+  const isEmpty = total === 0;
+
+  // Target percentages
+  const targetYesPct = isEmpty ? 50 : (yes / total) * 100;
+  const targetNoPct = isEmpty ? 50 : (no / total) * 100;
+
+  // Animated width state — starts at 50/50 and transitions to real values
+  const [yesPct, setYesPct] = useState(50);
+  const [noPct, setNoPct] = useState(50);
+  const rafRef = useRef<number | null>(null);
+  const prevYes = useRef(yes);
+  const prevNo = useRef(no);
+
+  useEffect(() => {
+    // Cancel any in-flight animation
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+
+    const start = performance.now();
+    const duration = 700; // ms
+
+    const fromYes = yesPct;
+    const fromNo = noPct;
+    const toYes = targetYesPct;
+    const toNo = targetNoPct;
+
+    function easeOutCubic(t: number) {
+      return 1 - Math.pow(1 - t, 3);
+    }
+
+    function step(now: number) {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = easeOutCubic(progress);
+
+      const currentYes = fromYes + (toYes - fromYes) * eased;
+      const currentNo = fromNo + (toNo - fromNo) * eased;
+
+      setYesPct(currentYes);
+      setNoPct(currentNo);
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(step);
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(step);
+    prevYes.current = yes;
+    prevNo.current = no;
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [yes, no]);
+
+  // ── Derived display values ──────────────────────────────────────────────
+  const displayYesPct = Math.round(targetYesPct);
+  const displayNoPct = Math.round(targetNoPct);
+  const totalFormatted = total.toLocaleString();
+
+  // ── Style variants ───────────────────────────────────────────────────────
+  const barHeight = variant === "lg" ? "h-5" : "h-3";
+  const labelSize = variant === "lg" ? "text-sm" : "text-[11px]";
+  const poolSize = variant === "lg" ? "text-xs" : "text-[10px]";
+
+  // ── Colour logic ─────────────────────────────────────────────────────────
+  // Empty pool → grey; otherwise green / red
+  const yesColour = isEmpty
+    ? "bg-gray-300"
+    : "bg-gradient-to-r from-emerald-400 to-green-500";
+  const noColour = isEmpty
+    ? "bg-gray-300"
+    : "bg-gradient-to-r from-red-400 to-rose-500";
+
+  // Glow pulse only when pool has real liquidity
+  const yesGlow =
+    !isEmpty && yes > 0
+      ? "shadow-[inset_0_0_6px_rgba(52,211,153,0.4)]"
+      : "";
+  const noGlow =
+    !isEmpty && no > 0
+      ? "shadow-[inset_0_0_6px_rgba(251,113,133,0.4)]"
+      : "";
+
+  return (
+    <div
+      className="w-full select-none"
+      aria-label={`Stake distribution: ${displayYesPct}% YES, ${displayNoPct}% NO`}
+    >
+      {/* ── Percentage labels ─────────────────────────────────────────── */}
+      <div className={`flex justify-between font-bold mb-1.5 ${labelSize}`}>
+        <span
+          className={isEmpty ? "text-gray-400" : "text-emerald-600"}
+          aria-label={`${displayYesPct}% UP`}
+        >
+          {isEmpty ? "—" : `${displayYesPct}%`}{" "}
+          <span className={isEmpty ? "text-gray-400" : "text-emerald-500"}>
+            UP
+          </span>
+        </span>
+        <span
+          className={isEmpty ? "text-gray-400" : "text-rose-500"}
+          aria-label={`${displayNoPct}% DOWN`}
+        >
+          <span className={isEmpty ? "text-gray-400" : "text-rose-400"}>
+            DOWN
+          </span>{" "}
+          {isEmpty ? "—" : `${displayNoPct}%`}
+        </span>
+      </div>
+
+      {/* ── Animated bar ─────────────────────────────────────────────── */}
+      <div
+        className={`flex w-full ${barHeight} rounded-full overflow-hidden bg-gray-100`}
+        role="progressbar"
+        aria-valuenow={displayYesPct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        {/* YES segment */}
+        <div
+          className={`${yesColour} ${yesGlow} rounded-l-full transition-none`}
+          style={{ width: `${yesPct}%` }}
+        />
+        {/* NO segment */}
+        <div
+          className={`${noColour} ${noGlow} rounded-r-full flex-1`}
+          style={{ width: `${noPct}%` }}
+        />
+      </div>
+
+      {/* ── Pool total ───────────────────────────────────────────────── */}
+      <div
+        className={`mt-1.5 text-center ${poolSize} font-semibold ${
+          isEmpty ? "text-gray-400" : "text-gray-500"
+        }`}
+      >
+        {isEmpty ? (
+          "No liquidity yet"
+        ) : (
+          <>
+            Total pool:{" "}
+            <span className="text-gray-700 font-bold">
+              {totalFormatted} {currency}
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #235

Adds a `StakeDistributionBar` component that visualises the YES/NO
stake split as a smooth animated progress bar, integrated into both `CallCard`
and the market detail page.

## New Component — `StakeDistributionBar`

**File:** `packages/frontend/src/components/StakeDistributionBar.tsx`

| Feature | Detail |
|---|---|
| Animation | `requestAnimationFrame` loop with easeOutCubic curve, 700 ms duration. Runs on mount and re-runs whenever `yes`/`no` values change. |
| Colours | Green gradient (`from-emerald-400 to-green-500`) for YES; Red gradient (`from-red-400 to-rose-500`) for NO |
| Labels | `65% UP | 35% DOWN` displayed above the bar |
| Pool total | `Total pool: 1,200 USDC` rendered below the bar |
| Empty pool | 50/50 grey bar + "No liquidity yet" label |
| Single-sided | 100% one colour — no division-by-zero issues |
| Variants | `sm` (compact, for CallCard) and `lg` (taller, for market detail) |
| Accessibility | `role="progressbar"`, `aria-valuenow/min/max`, descriptive `aria-label` |

## Integration

- **`CallCard.tsx`** — replaces the old static `StakeBar` with `<StakeDistributionBar variant="sm" />` inside the "Pool Distribution" section.
- **`CallDetail.tsx`** — replaces `StakeBar` + the separate "Total Vaulted" block inside the "Market Liquidity" card with `<StakeDistributionBar variant="lg" />` which renders the total itself.

## Testing

1. Open `/feed` — each CallCard shows the animated bar on load
2. Open any call detail page — the Market Liquidity card shows the larger bar
3. Test edge cases via mock data with `yes: 0, no: 0` (grey bar) and `yes: 500, no: 0` (100% green)
