### PR TITLE
feat(frontend): add live CountdownTimer to CallCard components

### DIFF
--- a/packages/frontend/src/components/CallCard.tsx
+++ b/packages/frontend/src/components/CallCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import StakeBar from "./StakeBar";
+import CountdownTimer from "./CountdownTimer";
 import { useState, useEffect } from "react";
 
 interface CallCardProps {
@@ -16,25 +17,6 @@ export default function CallCard({ call }: CallCardProps) {
       .then((data) => setOdds(data))
       .catch(() => setOdds({ yes: 2.0, no: 2.0 }));
   }, [call.id]);
-
-  // Calculate time remaining
-  const calculateTimeRemaining = () => {
-    if (!call.endTime) return "Unknown";
-    
-    const now = new Date().getTime();
-    const end = new Date(call.endTime).getTime();
-    const diff = end - now;
-
-    if (diff <= 0) return "Ended";
-
-    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-    const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-
-    if (days > 0) return `${days}d ${hours}h`;
-    if (hours > 0) return `${hours}h ${minutes}m`;
-    return `${minutes}m`;
-  };
 
   // Determine status
   const getStatus = () => {
@@ -64,7 +46,9 @@ export default function CallCard({ call }: CallCardProps) {
         </div>
         <div className="text-right">
           <div className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1">Ends In</div>
-          <div className="text-sm font-mono font-medium text-orange-500 bg-orange-50 px-2 py-1 rounded-lg border border-orange-100 italic">{calculateTimeRemaining()}</div>
+          <div className="bg-gray-50 px-2 py-1 rounded-lg border border-gray-100">
+            <CountdownTimer endTime={call.endTime} />
+          </div>
         </div>
       </div>
 

--- a/packages/frontend/src/components/CountdownTimer.tsx
+++ b/packages/frontend/src/components/CountdownTimer.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface CountdownTimerProps {
+  endTime: string | Date | null | undefined;
+}
+
+interface TimeState {
+  label: string;
+  colorClass: string;
+}
+
+function computeTimeState(endTime: string | Date | null | undefined): TimeState {
+  if (!endTime) return { label: "Unknown", colorClass: "text-gray-400" };
+
+  const end = new Date(endTime).getTime();
+  const now = Date.now();
+  const diff = end - now;
+
+  if (diff <= 0) return { label: "Ended", colorClass: "text-gray-400" };
+
+  const ONE_HOUR = 1000 * 60 * 60;
+  const ONE_DAY = ONE_HOUR * 24;
+
+  if (diff > ONE_DAY) {
+    const date = new Date(endTime);
+    const label = date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    return { label: `Ends ${label}`, colorClass: "text-green-600" };
+  }
+
+  const hours = Math.floor(diff / ONE_HOUR);
+  const minutes = Math.floor((diff % ONE_HOUR) / (1000 * 60));
+  const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  parts.push(`${seconds}s`);
+
+  const label = `Ends in ${parts.join(" ")}`;
+  const colorClass = diff < ONE_HOUR ? "text-red-500" : "text-yellow-500";
+
+  return { label, colorClass };
+}
+
+export default function CountdownTimer({ endTime }: CountdownTimerProps) {
+  const [timeState, setTimeState] = useState<TimeState>(() => computeTimeState(endTime));
+
+  useEffect(() => {
+    setTimeState(computeTimeState(endTime));
+
+    const interval = setInterval(() => {
+      setTimeState(computeTimeState(endTime));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [endTime]);
+
+  return (
+    <span className={`text-sm font-mono font-medium ${timeState.colorClass}`}>
+      {timeState.label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new `CountdownTimer` component (`packages/frontend/src/components/CountdownTimer.tsx`) that ticks every second via `setInterval` and cleans up on unmount (no memory leaks).
- Displays **"Ends in Xh Ym Zs"** for calls ending within 24 h, **"Ends Jan 15"** for calls beyond 24 h, and **"Ended"** (grey) for expired calls.
- Colour coding: green (>24 h), yellow (1–24 h), red (<1 h), grey (ended).
- Removes the now-redundant static `calculateTimeRemaining` helper from `CallCard.tsx` and wires in the new component.

Closes #219

## Test plan

- [ ] Verify card with `endTime` < 1 h shows red "Ends in Xm Ys" and ticks down each second.
- [ ] Verify card with `endTime` between 1–24 h shows yellow "Ends in Xh Ym Zs".
- [ ] Verify card with `endTime` > 24 h shows green "Ends Jan 15" (static date label).
- [ ] Verify card with past `endTime` shows grey "Ended".
- [ ] Unmount the component and confirm no lingering interval (no console warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)