### PR TITLE
feat(call_registry): implement contract storage usage monitoring

### DIFF
--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -196,3 +196,11 @@ pub fn emit_void_refund_claimed(env: &Env, call_id: u64, staker: &Address, amoun
         (call_id, staker.clone(), amount),
     );
 }
+
+/// Emitted when instance entry count exceeds the warning threshold.
+pub fn emit_storage_warning(env: &Env, entry_count: u32, estimated_bytes: u32) {
+    env.events().publish(
+        ("call_registry", "storage_warning"),
+        (entry_count, estimated_bytes),
+    );
+}

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -83,6 +83,8 @@ impl CallRegistry {
         env.storage()
             .instance()
             .set(&Symbol::new(&env, "version"), &CONTRACT_VERSION);
+        // Track the 'version' instance key (Config key tracked inside set_config)
+        inc_instance_entry_count(&env, 1);
         extend_storage_ttl(&env);
 
         env.events()
@@ -642,6 +644,21 @@ impl CallRegistry {
     /// Get contract-wide aggregated statistics.
     pub fn get_global_stats(env: Env) -> GlobalStats {
         storage::get_global_stats(&env)
+    }
+
+    /// Return the number of entries currently tracked in instance storage.
+    pub fn get_instance_entry_count(env: Env) -> u32 {
+        storage::get_instance_entry_count(&env)
+    }
+
+    /// Return a storage utilisation snapshot.
+    /// Emits `StorageWarning` if instance entries exceed the threshold.
+    pub fn get_storage_stats(env: Env) -> StorageStats {
+        let stats = storage::get_storage_stats(&env);
+        if stats.instance_entry_count >= INSTANCE_ENTRY_WARNING_THRESHOLD {
+            events::emit_storage_warning(&env, stats.instance_entry_count, stats.estimated_instance_bytes);
+        }
+        stats
     }
 
     /// Return the current contract version.

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::types::{Call, ContractConfig, GlobalStats, CreatorStats};
+use crate::types::{Call, ContractConfig, GlobalStats, CreatorStats, StorageStats};
 use soroban_sdk::{contracttype, Address, Env};
 
 // ~120 days in ledgers (5s per ledger): 120 * 24 * 3600 / 5 = 2_073_600
@@ -22,11 +22,16 @@ pub enum DataKey {
     UpStakerCount(u64),
     DownStakerCount(u64),
     VoidRefundClaimed(u64, Address),
+    InstanceEntryCount,
 }
 
 /// Store contract configuration
 pub fn set_config(env: &Env, config: &ContractConfig) {
+    let is_new = !env.storage().instance().has(&DataKey::Config);
     env.storage().instance().set(&DataKey::Config, config);
+    if is_new {
+        inc_instance_entry_count(env, 1);
+    }
 }
 
 /// Retrieve contract configuration
@@ -43,6 +48,10 @@ pub fn next_call_id(env: &Env) -> u64 {
         .unwrap_or(0);
 
     let next_id = counter + 1;
+    if counter == 0 {
+        // First write of CallCounter key
+        inc_instance_entry_count(env, 1);
+    }
     env.storage()
         .instance()
         .set(&DataKey::CallCounter, &next_id);
@@ -131,9 +140,13 @@ pub fn get_global_stats(env: &Env) -> GlobalStats {
 }
 
 pub fn record_call_created(env: &Env) {
+    let is_new = !env.storage().instance().has(&DataKey::GlobalStats);
     let mut stats = get_global_stats(env);
     stats.total_calls += 1;
     env.storage().instance().set(&DataKey::GlobalStats, &stats);
+    if is_new {
+        inc_instance_entry_count(env, 1);
+    }
 }
 
 pub fn record_stake(env: &Env, staker: &Address, amount: i128) {
@@ -249,9 +262,12 @@ pub fn set_creator_stats(env: &Env, creator: &Address, stats: &CreatorStats) {
 
 /// Mark that a staker has claimed their void refund for a call
 pub fn set_void_refund_claimed(env: &Env, call_id: u64, staker: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::VoidRefundClaimed(call_id, staker.clone()), &true);
+    let key = DataKey::VoidRefundClaimed(call_id, staker.clone());
+    let is_new = !env.storage().instance().has(&key);
+    env.storage().instance().set(&key, &true);
+    if is_new {
+        inc_instance_entry_count(env, 1);
+    }
 }
 
 /// Check whether a staker has already claimed their void refund
@@ -259,4 +275,36 @@ pub fn is_void_refund_claimed(env: &Env, call_id: u64, staker: &Address) -> bool
     env.storage()
         .instance()
         .has(&DataKey::VoidRefundClaimed(call_id, staker.clone()))
+}
+
+// ── Instance entry counter ────────────────────────────────────────────────────
+
+/// Increment the instance entry counter by `delta` (call when adding new instance keys).
+pub fn inc_instance_entry_count(env: &Env, delta: u32) {
+    let current: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::InstanceEntryCount)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKey::InstanceEntryCount, &(current + delta));
+}
+
+/// Return the number of tracked instance storage entries.
+pub fn get_instance_entry_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::InstanceEntryCount)
+        .unwrap_or(0)
+}
+
+/// Return a storage utilisation snapshot.
+pub fn get_storage_stats(env: &Env) -> StorageStats {
+    let instance_entry_count = get_instance_entry_count(env);
+    StorageStats {
+        call_count: get_call_counter(env),
+        instance_entry_count,
+        estimated_instance_bytes: instance_entry_count * 128,
+    }
 }

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -1982,5 +1982,88 @@ mod call_registry {
         assert_eq!(stats.total_resolved, 3);
         assert_eq!(stats.total_correct, 2);
     }
+
+    // ── Storage Stats ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_storage_stats_after_initialize() {
+        let (_env, client, _admin, _om) = setup();
+        let stats = client.get_storage_stats();
+        // After initialize: Config + version = 2 instance entries
+        assert_eq!(stats.call_count, 0);
+        assert_eq!(stats.instance_entry_count, 2);
+        assert_eq!(stats.estimated_instance_bytes, 2 * 128);
+    }
+
+    #[test]
+    fn test_get_instance_entry_count_after_initialize() {
+        let (_env, client, _admin, _om) = setup();
+        assert_eq!(client.get_instance_entry_count(), 2);
+    }
+
+    #[test]
+    fn test_storage_stats_call_count_increments_after_create() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+
+        let creator = Address::generate(&env);
+        let stake_token = env.register_contract(None, MockToken);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
+
+        create_call_with_default_condition(
+            &client, &creator, &stake_token, &100_000_000_i128,
+            &2000u64, &token_address, &pair_id, &ipfs_cid,
+        );
+        create_call_with_default_condition(
+            &client, &creator, &stake_token, &100_000_000_i128,
+            &3000u64, &token_address, &pair_id, &ipfs_cid,
+        );
+
+        let stats = client.get_storage_stats();
+        assert_eq!(stats.call_count, 2);
+        // Config + version + CallCounter + GlobalStats = 4
+        assert_eq!(stats.instance_entry_count, 4);
+        assert_eq!(stats.estimated_instance_bytes, 4 * 128);
+    }
+
+    #[test]
+    fn test_storage_stats_instance_entry_count_increases_with_void_refund() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, stake_token) = make_call(&env, &client, &creator);
+
+        mint(&env, &stake_token, &staker, 100_000_000_i128);
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        let before = client.get_instance_entry_count();
+        client.void_call(&call.id);
+        client.claim_void_refund(&staker, &call.id);
+        let after = client.get_instance_entry_count();
+
+        // One new VoidRefundClaimed entry added
+        assert_eq!(after, before + 1);
+    }
+
+    #[test]
+    fn test_storage_stats_no_warning_below_threshold() {
+        let (env, client, _admin, _om) = setup();
+        // Well below 500 entries — get_storage_stats should not emit storage_warning
+        let stats = client.get_storage_stats();
+        assert!(stats.instance_entry_count < 500);
+
+        let events = env.events().all();
+        let has_warning = events.iter().any(|e| {
+            e.1 == soroban_sdk::vec![
+                &env,
+                "call_registry".into_val(&env),
+                "storage_warning".into_val(&env),
+            ]
+        });
+        assert!(!has_warning);
+    }
 }
 

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -129,3 +129,18 @@ pub struct CreatorStats {
     pub total_resolved: u32,
     pub total_correct: u32,
 }
+
+/// Instance storage is capped at 64 KB. Warn when entry count exceeds this.
+pub const INSTANCE_ENTRY_WARNING_THRESHOLD: u32 = 500;
+
+/// Storage utilisation snapshot returned by `get_storage_stats`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageStats {
+    /// Total calls ever created (mirrors CallCounter).
+    pub call_count: u64,
+    /// Number of entries currently tracked in instance storage.
+    pub instance_entry_count: u32,
+    /// Rough byte estimate for instance storage (entry_count × 128 bytes).
+    pub estimated_instance_bytes: u32,
+}


### PR DESCRIPTION
## Summary

Implements #163 — instance storage utilisation monitoring for `call_registry`.

## Changes

**`types.rs`**
- Added `StorageStats` struct (`call_count`, `instance_entry_count`, `estimated_instance_bytes`)
- Added `INSTANCE_ENTRY_WARNING_THRESHOLD = 500`

**`storage.rs`**
- Added `InstanceEntryCount` `DataKey` variant
- Tracks new instance entries in `set_config`, `next_call_id`, `record_call_created`, `set_void_refund_claimed`
- Added `inc_instance_entry_count`, `get_instance_entry_count`, `get_storage_stats` helpers

**`events.rs`**
- Added `emit_storage_warning(env, entry_count, estimated_bytes)` → topic `("call_registry", "storage_warning")`

**`lib.rs`**
- `initialize` increments counter for the `version` instance key
- Added `get_instance_entry_count(env) -> u32` view function
- Added `get_storage_stats(env) -> StorageStats` view function — emits `StorageWarning` when entries ≥ 500

**`test.rs`**
- `test_get_storage_stats_after_initialize` — entry_count = 2 (Config + version)
- `test_get_instance_entry_count_after_initialize`
- `test_storage_stats_call_count_increments_after_create` — entry_count = 4 after 2 calls
- `test_storage_stats_instance_entry_count_increases_with_void_refund`
- `test_storage_stats_no_warning_below_threshold`

## Acceptance Criteria

- [x] `get_storage_stats(env) -> StorageStats` returning `call_count`, `estimated_instance_bytes`
- [x] Track number of entries in instance storage
- [x] `get_instance_entry_count(env) -> u32` helper
- [x] Emit `StorageWarning` event when instance entries exceed 500
- [x] Tests: stats accurate after creating calls and staking

Closes #163