### PR TITLE
feat(outcome_manager): replace caller-supplied stakes with cross-contract reads

### DIFF
--- a/packages/contracts/call_registry/src/fuzz_tests.rs
+++ b/packages/contracts/call_registry/src/fuzz_tests.rs
@@ -25,12 +25,12 @@ fn setup_fuzz_env() -> (Env, CallRegistryClient<'static>, Address, Address, Addr
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, CallRegistry);
+    let contract_id = env.register(CallRegistry, ());
     let client = CallRegistryClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
     let outcome_manager = Address::generate(&env);
-    let stake_token = env.register_contract(None, MockToken);
+    let stake_token = env.register(MockToken, ());
 
     client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
     client.whitelist_token(&stake_token);

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -37,7 +37,7 @@ mod call_registry {
         let env = Env::default();
         env.mock_all_auths();
 
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
@@ -119,7 +119,7 @@ mod call_registry {
     #[test]
     fn test_initialize() {
         let (env, admin, outcome_manager, _) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -133,7 +133,7 @@ mod call_registry {
     #[test]
     fn test_initialize_twice_fails() {
         let (env, admin, outcome_manager, _) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -189,7 +189,7 @@ mod call_registry {
     fn test_set_admin() {
         let (env, admin, outcome_manager, _) = create_test_env();
         let new_admin = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -232,7 +232,7 @@ mod call_registry {
     fn test_set_outcome_manager() {
         let (env, admin, outcome_manager, _) = create_test_env();
         let new_manager = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -296,13 +296,13 @@ mod call_registry {
     #[test]
     fn test_extend_call_ttl_succeeds_for_existing_call() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -327,7 +327,7 @@ mod call_registry {
     #[test]
     fn test_extend_call_ttl_missing_call_returns_error() {
         let (env, admin, outcome_manager, _) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -345,13 +345,13 @@ mod call_registry {
     #[test]
     fn test_set_call_uses_persistent_storage() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -377,13 +377,13 @@ mod call_registry {
     fn test_staker_calls_ttl_extended_on_stake() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -401,7 +401,7 @@ mod call_registry {
             &2,
         );
 
-        env.budget().reset_unlimited();
+        env.cost_estimate().budget().reset_unlimited();
         client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
 
         let staker_calls = client.get_staker_calls(&staker);
@@ -414,13 +414,13 @@ mod call_registry {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker1 = Address::generate(&env);
         let staker2 = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -459,7 +459,7 @@ mod call_registry {
         let creator = Address::generate(&env);
         let staker1 = Address::generate(&env);
         let staker2 = Address::generate(&env);
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -496,7 +496,7 @@ mod call_registry {
         let stats = client.get_global_stats();
         assert_eq!(stats.total_calls, 2);
 
-        env.budget().reset_unlimited();
+        env.cost_estimate().budget().reset_unlimited();
         client.stake_on_call(&staker1, &call1.id, &50_000_000_i128, &1);
         client.stake_on_call(&staker1, &call1.id, &20_000_000_i128, &1);
         client.stake_on_call(&staker2, &call2.id, &30_000_000_i128, &2);
@@ -511,13 +511,13 @@ mod call_registry {
     #[test]
     fn test_create_call_success() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -550,13 +550,13 @@ mod call_registry {
     #[test]
     fn test_create_call_zero_start_price_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -581,13 +581,13 @@ mod call_registry {
     #[test]
     fn test_set_start_price_updates_call() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -616,13 +616,13 @@ mod call_registry {
     #[test]
     fn test_create_call_invalid_stake_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -651,13 +651,13 @@ mod call_registry {
     #[test]
     fn test_create_call_past_timestamp_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -689,13 +689,13 @@ mod call_registry {
     fn test_stake_on_call_up() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -713,7 +713,7 @@ mod call_registry {
             &2,
         );
 
-        env.budget().reset_unlimited();
+        env.cost_estimate().budget().reset_unlimited();
 
         let updated_call = client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
 
@@ -725,13 +725,13 @@ mod call_registry {
     fn test_stake_on_call_down() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -759,13 +759,13 @@ mod call_registry {
     fn test_stake_on_ended_call_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -797,13 +797,13 @@ mod call_registry {
     fn test_stake_invalid_position_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -834,13 +834,13 @@ mod call_registry {
     #[test]
     fn test_get_call() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -868,7 +868,7 @@ mod call_registry {
     #[test]
     fn test_get_nonexistent_call_returns_error() {
         let (env, admin, outcome_manager, _) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -888,13 +888,13 @@ mod call_registry {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker1 = Address::generate(&env);
         let staker2 = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -928,13 +928,13 @@ mod call_registry {
     #[test]
     fn test_resolve_call() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -963,13 +963,13 @@ mod call_registry {
     #[test]
     fn test_resolve_call_before_end_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1002,7 +1002,7 @@ mod call_registry {
     fn test_get_call_count() {
         let (env, admin, outcome_manager, creator) = create_test_env();
 
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -1046,7 +1046,7 @@ mod call_registry {
     #[test]
     fn test_get_calls_paginated_respects_limit_and_start_id() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -1102,7 +1102,7 @@ mod call_registry {
     #[test]
     fn test_get_calls_paginated_respects_maximum_limit() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -1137,7 +1137,7 @@ mod call_registry {
     fn test_get_calls_by_creator_paginated_returns_creator_specific_results() {
         let (env, admin, outcome_manager, creator1) = create_test_env();
         let creator2 = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -1195,7 +1195,7 @@ mod call_registry {
     fn test_get_calls_by_creator_paginated_handles_gaps_and_max_limit() {
         let (env, admin, outcome_manager, creator1) = create_test_env();
         let creator2 = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
@@ -1252,7 +1252,7 @@ mod call_registry {
     // ── void_call / claim_void_refund ─────────────────────────────────────────
 
     fn make_call(env: &Env, client: &CallRegistryClient<'_>, creator: &Address) -> (crate::types::Call, Address) {
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(env);
         let pair_id = Bytes::from_slice(env, b"USDC/XLM");
@@ -1323,13 +1323,13 @@ mod call_registry {
     #[test]
     fn test_create_3_outcome_call_success() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1359,13 +1359,13 @@ mod call_registry {
     fn test_stake_on_3_outcome_call() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1384,7 +1384,7 @@ mod call_registry {
             &3,
         );
 
-        env.budget().reset_unlimited();
+        env.cost_estimate().budget().reset_unlimited();
 
         client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
         client.stake_on_call(&staker, &call.id, &30_000_000_i128, &2);
@@ -1399,13 +1399,13 @@ mod call_registry {
     #[test]
     fn test_resolve_3_outcome_call() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1435,13 +1435,13 @@ mod call_registry {
     #[test]
     fn test_resolve_3_outcome_call_invalid_outcome_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1474,13 +1474,13 @@ mod call_registry {
     fn test_stake_invalid_position_on_3_outcome_call_returns_error() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1511,13 +1511,13 @@ mod call_registry {
     fn test_get_outcome_stakes() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1536,7 +1536,7 @@ mod call_registry {
             &3,
         );
 
-        env.budget().reset_unlimited();
+        env.cost_estimate().budget().reset_unlimited();
 
         client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
         client.stake_on_call(&staker, &call.id, &30_000_000_i128, &2);
@@ -1552,13 +1552,13 @@ mod call_registry {
     fn test_get_staker_stake_multi_outcome() {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1577,7 +1577,7 @@ mod call_registry {
             &3,
         );
 
-        env.budget().reset_unlimited();
+        env.cost_estimate().budget().reset_unlimited();
 
         client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
         client.stake_on_call(&staker, &call.id, &30_000_000_i128, &2);
@@ -1600,13 +1600,13 @@ mod call_registry {
         let (env, admin, outcome_manager, creator) = create_test_env();
         let staker1 = Address::generate(&env);
         let staker2 = Address::generate(&env);
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1625,7 +1625,7 @@ mod call_registry {
             &3,
         );
 
-        env.budget().reset_unlimited();
+        env.cost_estimate().budget().reset_unlimited();
 
         client.stake_on_call(&staker1, &call.id, &50_000_000_i128, &1);
         client.stake_on_call(&staker2, &call.id, &30_000_000_i128, &1);
@@ -1648,13 +1648,13 @@ mod call_registry {
     #[test]
     fn test_creator_stats_increment_on_create() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         client.whitelist_token(&stake_token);
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
@@ -1706,13 +1706,13 @@ mod call_registry {
     #[test]
     fn test_creator_stats_resolved_and_correct_on_win() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -1748,13 +1748,13 @@ mod call_registry {
     #[test]
     fn test_creator_stats_resolved_but_not_correct_on_loss() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -1790,13 +1790,13 @@ mod call_registry {
     #[test]
     fn test_creator_stats_multiple_calls_mixed_outcomes() {
         let (env, admin, outcome_manager, creator) = create_test_env();
-        let contract_id = env.register_contract(None, CallRegistry);
+        let contract_id = env.register(CallRegistry, ());
         let client = CallRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
         env.ledger().set_timestamp(1000);
 
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");
@@ -1887,7 +1887,7 @@ mod call_registry {
         env.ledger().set_timestamp(1000);
 
         let creator = Address::generate(&env);
-        let stake_token = env.register_contract(None, MockToken);
+        let stake_token = env.register(MockToken, ());
         let token_address = Address::generate(&env);
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let ipfs_cid = Bytes::from_slice(&env, b"QmXxxx");

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -6,7 +6,7 @@ mod storage;
 mod test;
 mod verification;
 
-use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
 
 use auth::require_admin;
 use backit_shared::{is_valid_fee_bps, is_valid_outcome};
@@ -17,6 +17,14 @@ use events::{
 };
 use storage::{set_dispute_window, InstanceKey, Outcome, PriceObservation, SignedOutcome, TempKey, is_paused, set_paused};
 use verification::{build_message, verify_signature};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Call {
+    pub total_up_stake: i128,
+    pub total_down_stake: i128,
+    pub outcome: u32,
+}
 
 pub const CONTRACT_VERSION: u32 = 1;
 
@@ -52,13 +60,9 @@ fn registry_mark_settled(env: &Env, registry: &Address, call_id: u64) {
     env.invoke_contract::<()>(registry, &Symbol::new(env, "mark_settled"), args);
 }
 /// Call `get_call(call_id)` on the CallRegistry and return the Call.
-fn registry_get_call(env: &Env, registry: &Address, call_id: u64) -> backit_shared::types::Call {
+fn registry_get_call(env: &Env, registry: &Address, call_id: u64) -> Call {
     let args = (call_id,).into_val(env);
-    env.invoke_contract::<backit_shared::types::Call>(
-        registry,
-        &Symbol::new(env, "get_call"),
-        args,
-    )
+    env.invoke_contract::<Call>(registry, &Symbol::new(env, "get_call"), args)
 }
 
 /// Call `get_staker_stake(call_id, staker, position)` on the CallRegistry.
@@ -448,101 +452,6 @@ pub fn claim_payout(
 
     emit_payout_claimed(&env, call_id, &staker, payout);
 }
-        env: Env,
-        registry: Address,
-        call_id: u64,
-        staker: Address,
-        staker_winning_stake: i128,
-        total_winning_stake: i128,
-        total_losing_stake: i128,
-    ) {
-        // 0. Check if contract is paused (emergency guard)
-        if is_paused(&env) {
-            panic!("contract is paused");
-        }
-
-        // 1. Require staker's authorization
-        staker.require_auth();
-
-        // 2. Verify the call is settled
-        if !env
-            .storage()
-            .instance()
-            .has(&InstanceKey::FinalOutcome(call_id))
-        {
-            panic!("call not settled");
-        }
-
-        // 3. Prevent double-claim
-        let claimed_key = InstanceKey::Claimed(call_id, staker.clone());
-        if env.storage().instance().has(&claimed_key) {
-            panic!("already claimed");
-        }
-
-        // 4. Validate inputs
-        if staker_winning_stake <= 0 {
-            panic!("nothing to claim");
-        }
-        if total_winning_stake <= 0 {
-            panic!("invalid total winning stake");
-        }
-
-        // 5. Compute protocol fee from losing pool (only on first claim; fee is
-        //    proportional so each claimant effectively pays their share)
-        let fee_bps: u32 = env
-            .storage()
-            .instance()
-            .get(&InstanceKey::FeeBps)
-            .unwrap_or(0);
-        let fee_collector: Address = env
-            .storage()
-            .instance()
-            .get(&InstanceKey::FeeCollector)
-            .expect("fee collector not set");
-
-        // Staker's proportional share of the total fee
-        let total_fee = (total_losing_stake as i128)
-            .checked_mul(fee_bps as i128)
-            .expect("overflow in fee calculation")
-            .checked_div(10000)
-            .expect("division by zero");
-
-        let staker_fee_share = staker_winning_stake
-            .checked_mul(total_fee)
-            .expect("overflow in staker fee share")
-            .checked_div(total_winning_stake)
-            .expect("division by zero");
-
-        // 6. Net losing pool available to winners
-        let net_losing = total_losing_stake
-            .checked_sub(total_fee)
-            .expect("underflow in net losing");
-
-        // 7. Pro-rata payout from net losing pool
-        let prize_share = staker_winning_stake
-            .checked_mul(net_losing)
-            .expect("overflow in prize calculation")
-            .checked_div(total_winning_stake)
-            .expect("division by zero");
-
-        let payout = staker_winning_stake
-            .checked_add(prize_share)
-            .expect("overflow in payout sum");
-
-        // 8. Mark as claimed BEFORE external calls (reentrancy guard)
-        env.storage().instance().set(&claimed_key, &true);
-
-        // 9. Transfer fee to fee_collector (if non-zero)
-        if staker_fee_share > 0 {
-            registry_release_escrow(&env, &registry, call_id, &fee_collector, staker_fee_share);
-            emit_fee_collected(&env, call_id, staker_fee_share, &fee_collector);
-        }
-
-        // 10. Release net payout to staker
-        registry_release_escrow(&env, &registry, call_id, &staker, payout);
-
-        emit_payout_claimed(&env, call_id, &staker, payout);
-    }
 
     pub fn finalize_outcome(env: Env, call_id: u64) {
         let pending: Outcome = env

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -51,6 +51,31 @@ fn registry_mark_settled(env: &Env, registry: &Address, call_id: u64) {
     let args = (call_id,).into_val(env);
     env.invoke_contract::<()>(registry, &Symbol::new(env, "mark_settled"), args);
 }
+/// Call `get_call(call_id)` on the CallRegistry and return the Call.
+fn registry_get_call(env: &Env, registry: &Address, call_id: u64) -> backit_shared::types::Call {
+    let args = (call_id,).into_val(env);
+    env.invoke_contract::<backit_shared::types::Call>(
+        registry,
+        &Symbol::new(env, "get_call"),
+        args,
+    )
+}
+
+/// Call `get_staker_stake(call_id, staker, position)` on the CallRegistry.
+fn registry_get_staker_stake(
+    env: &Env,
+    registry: &Address,
+    call_id: u64,
+    staker: &Address,
+    position: u32,
+) -> i128 {
+    let args = (call_id, staker.clone(), position).into_val(env);
+    env.invoke_contract::<i128>(
+        registry,
+        &Symbol::new(env, "get_staker_stake"),
+        args,
+    )
+}
 
 // ─── Contract ─────────────────────────────────────────────────────────────────
 
@@ -282,27 +307,147 @@ impl OutcomeManager {
     }
 
     // ── Payout Claim ───────────────────────────────────────────────────────────
-
     /// Claim a pro-rata payout for a winning staker.
-    ///
-    /// **Payout formula** (with protocol fee):
-    /// ```text
-    /// fee        = total_losing_stake * fee_bps / 10000
-    /// net_losing = total_losing_stake - fee
-    /// payout     = staker_winning_stake
-    ///            + floor(staker_winning_stake * net_losing / total_winning_stake)
-    /// ```
-    ///
-    /// # Security
-    /// The `Claimed` flag is written **before** the external `release_escrow`
-    /// call, preventing reentrancy attacks.
-    ///
-    /// # Panics
-    /// - `call not settled`       – quorum not yet reached
-    /// - `already claimed`        – staker already claimed
-    /// - `nothing to claim`       – staker_winning_stake ≤ 0
-    /// - `invalid total winning`  – total_winning_stake ≤ 0
-    pub fn claim_payout(
+///
+///
+/// Stake amounts and pool totals are read directly from the CallRegistry
+/// via cross-contract calls — callers cannot spoof these values.
+///
+/// **Payout formula** (with protocol fee):
+/// ```text
+/// winning_position = outcome of the finalized call (1=UP, 2=DOWN)
+/// staker_stake     = CallRegistry.get_staker_stake(call_id, staker, winning_position)
+/// total_winning    = call.total_up_stake  (if outcome=UP)
+///                  | call.total_down_stake (if outcome=DOWN)
+/// total_losing     = the other pool
+///
+/// fee        = total_losing * fee_bps / 10000
+/// net_losing = total_losing - fee
+/// payout     = staker_stake
+///            + floor(staker_stake * net_losing / total_winning)
+/// ```
+///
+/// # Security
+/// The `Claimed` flag is written **before** the external `release_escrow`
+/// call, preventing reentrancy attacks. Stake values are read from the
+/// registry — not supplied by the caller — preventing spoofing.
+///
+/// # Panics
+/// - `call not settled`       – quorum not yet reached
+/// - `already claimed`        – staker already claimed
+/// - `nothing to claim`       – staker has no stake on the winning side
+/// - `invalid total winning`  – winning pool is empty (no one staked winning side)
+pub fn claim_payout(
+    env: Env,
+    registry: Address,
+    call_id: u64,
+    staker: Address,
+) {
+    // 0. Pause guard
+    if is_paused(&env) {
+        panic!("contract is paused");
+    }
+
+    // 1. Require staker's authorization
+    staker.require_auth();
+
+    // 2. Verify the call is settled
+    let outcome: Outcome = env
+        .storage()
+        .instance()
+        .get(&InstanceKey::FinalOutcome(call_id))
+        .expect("call not settled");
+
+    // 3. Prevent double-claim
+    let claimed_key = InstanceKey::Claimed(call_id, staker.clone());
+    if env.storage().instance().has(&claimed_key) {
+        panic!("already claimed");
+    }
+
+    // 4. Read call data from CallRegistry to get pool totals
+    let call = registry_get_call(&env, &registry, call_id);
+
+    // 5. Determine winning/losing pools from stored outcome
+    let winning_position: u32 = outcome.outcome; // 1=UP, 2=DOWN
+    let losing_position: u32 = if winning_position == 1 { 2 } else { 1 };
+
+    let total_winning_stake = if winning_position == 1 {
+        call.total_up_stake
+    } else {
+        call.total_down_stake
+    };
+
+    let total_losing_stake = if losing_position == 1 {
+        call.total_up_stake
+    } else {
+        call.total_down_stake
+    };
+
+    // 6. Read staker's winning stake from CallRegistry
+    let staker_winning_stake =
+        registry_get_staker_stake(&env, &registry, call_id, &staker, winning_position);
+
+    // 7. Validate
+    if staker_winning_stake <= 0 {
+        panic!("nothing to claim");
+    }
+    if total_winning_stake <= 0 {
+        panic!("invalid total winning stake");
+    }
+
+    // 8. Compute protocol fee
+    let fee_bps: u32 = env
+        .storage()
+        .instance()
+        .get(&InstanceKey::FeeBps)
+        .unwrap_or(0);
+    let fee_collector: Address = env
+        .storage()
+        .instance()
+        .get(&InstanceKey::FeeCollector)
+        .expect("fee collector not set");
+
+    let total_fee = (total_losing_stake as i128)
+        .checked_mul(fee_bps as i128)
+        .expect("overflow in fee calculation")
+        .checked_div(10000)
+        .expect("division by zero");
+
+    let staker_fee_share = staker_winning_stake
+        .checked_mul(total_fee)
+        .expect("overflow in staker fee share")
+        .checked_div(total_winning_stake)
+        .expect("division by zero");
+
+    // 9. Net losing pool and pro-rata payout
+    let net_losing = total_losing_stake
+        .checked_sub(total_fee)
+        .expect("underflow in net losing");
+
+    let prize_share = staker_winning_stake
+        .checked_mul(net_losing)
+        .expect("overflow in prize calculation")
+        .checked_div(total_winning_stake)
+        .expect("division by zero");
+
+    let payout = staker_winning_stake
+        .checked_add(prize_share)
+        .expect("overflow in payout sum");
+
+    // 10. Mark claimed BEFORE external calls (reentrancy guard)
+    env.storage().instance().set(&claimed_key, &true);
+
+    // 11. Transfer fee to fee_collector
+    if staker_fee_share > 0 {
+        registry_release_escrow(&env, &registry, call_id, &fee_collector, staker_fee_share);
+        emit_fee_collected(&env, call_id, staker_fee_share, &fee_collector);
+    }
+
+    // 12. Release net payout to staker
+    registry_release_escrow(&env, &registry, call_id, &staker, payout);
+
+    emit_payout_claimed(&env, call_id, &staker, payout);
+}
         env: Env,
         registry: Address,
         call_id: u64,

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -103,7 +103,7 @@ fn setup_single_oracle(
     let admin = Address::generate(env);
     let (oracle_secret, oracle_pubkey) = gen_keypair(env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(env, &contract_id);
 
     let mut oracles = Vec::new(env);
@@ -113,7 +113,7 @@ fn setup_single_oracle(
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
 
     // Register a mock registry contract
-    let registry_id = env.register_contract(None, MockRegistry);
+    let registry_id = env.register(MockRegistry, ());
 
     (admin, registry_id, oracle_secret, oracle_pubkey, client)
 }
@@ -231,7 +231,7 @@ fn test_initialize_success() {
     let admin = Address::generate(&env);
     let (_, pubkey) = gen_keypair(&env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(&env, &contract_id);
 
     let mut oracles = Vec::new(&env);
@@ -264,7 +264,7 @@ fn test_initialize_quorum_zero_fails() {
     let admin = Address::generate(&env);
     let (_, pubkey) = gen_keypair(&env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(&env, &contract_id);
 
     let fee_collector = Address::generate(&env);
@@ -284,7 +284,7 @@ fn test_quorum_reached_with_two_oracles() {
     let (s1, p1) = gen_keypair(&env);
     let (s2, p2) = gen_keypair(&env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(&env, &contract_id);
 
     let mut oracles = Vec::new(&env);
@@ -293,7 +293,7 @@ fn test_quorum_reached_with_two_oracles() {
     let fee_collector = Address::generate(&env);
     client.initialize(&admin, &oracles, &2u32, &fee_collector, &0u32, &0u64);
 
-    let registry_id = env.register_contract(None, MockRegistry);
+    let registry_id = env.register(MockRegistry, ());
     let call_id = 42u64;
     let outcome_val = 1u32;
     let price = 150_000_000i128;
@@ -518,14 +518,14 @@ fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerC
     let fee_collector = Address::generate(env);
     let (oracle_secret, oracle_pubkey) = gen_keypair(env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(env, &contract_id);
 
     let mut oracles = Vec::new(env);
     oracles.push_back(oracle_pubkey.clone());
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
 
-    let registry_id = env.register_contract(None, MockRegistry);
+    let registry_id = env.register(MockRegistry, ());
 
     // Settle call_id=1
     let call_id = 1u64;
@@ -552,14 +552,14 @@ fn setup_with_zero_stake(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeM
     let fee_collector = Address::generate(env);
     let (oracle_secret, oracle_pubkey) = gen_keypair(env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(env, &contract_id);
 
     let mut oracles = Vec::new(env);
     oracles.push_back(oracle_pubkey.clone());
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
 
-    let registry_id = env.register_contract(None, MockRegistryZeroStake);
+    let registry_id = env.register(MockRegistryZeroStake, ());
 
     let call_id = 1u64;
     let sig = sign_outcome(env, &oracle_secret, call_id, 1, 100, 9000);
@@ -584,14 +584,14 @@ fn setup_with_zero_total_winning(env: &Env, fee_bps: u32) -> (Address, Address, 
     let fee_collector = Address::generate(env);
     let (oracle_secret, oracle_pubkey) = gen_keypair(env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(env, &contract_id);
 
     let mut oracles = Vec::new(env);
     oracles.push_back(oracle_pubkey.clone());
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
 
-    let registry_id = env.register_contract(None, MockRegistryZeroTotalWinning);
+    let registry_id = env.register(MockRegistryZeroTotalWinning, ());
 
     let call_id = 1u64;
     let sig = sign_outcome(env, &oracle_secret, call_id, 1, 100, 9000);
@@ -685,7 +685,7 @@ fn test_invalid_fee_bps_panics() {
     let fee_collector = Address::generate(&env);
     let (_, pubkey) = gen_keypair(&env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(&env, &contract_id);
 
     let mut oracles = Vec::new(&env);
@@ -879,7 +879,7 @@ fn test_om_upgrade_requires_admin_auth() {
     // the admin guard is in place before any WASM update can occur.
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(&env, &contract_id);
     let fake_hash = BytesN::<32>::from_array(&env, &[0u8; 32]);
     client.upgrade(&fake_hash); // panics: "not initialized"
@@ -1048,14 +1048,14 @@ fn test_claim_payout_reads_stakes_from_registry() {
     let fee_collector = Address::generate(&env);
     let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(&env, &contract_id);
 
     let mut oracles = Vec::new(&env);
     oracles.push_back(oracle_pubkey.clone());
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
 
-    let registry_id = env.register_contract(None, MockRegistryCustomStake);
+    let registry_id = env.register(MockRegistryCustomStake, ());
 
     // Settle call_id=1
     let sig = sign_outcome(&env, &oracle_secret, 1u64, 1u32, 100, 9000);
@@ -1085,13 +1085,13 @@ fn test_claim_payout_rejects_zero_stake_from_registry() {
     let fee_collector = Address::generate(&env);
     let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
 
-    let contract_id = env.register_contract(None, OutcomeManager);
+    let contract_id = env.register(OutcomeManager, ());
     let client = OutcomeManagerClient::new(&env, &contract_id);
     let mut oracles = Vec::new(&env);
     oracles.push_back(oracle_pubkey.clone());
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
 
-    let registry_id = env.register_contract(None, MockRegistryZeroStake);
+    let registry_id = env.register(MockRegistryZeroStake, ());
     let sig = sign_outcome(&env, &oracle_secret, 1u64, 1u32, 100, 9000);
     client.submit_outcome(&registry_id, &SignedOutcome {
         call_id: 1, outcome: 1, price: 100, timestamp: 9000,

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -8,17 +8,6 @@ use soroban_sdk::{
 
 use crate::storage::{PriceObservation, SignedOutcome};
 use crate::{OutcomeManager, OutcomeManagerClient};
-use soroban_sdk::contracttype;
-
-#[contracttype]
-#[derive(Clone)]
-pub struct MockCall {
-    pub total_up_stake: i128,
-    pub total_down_stake: i128,
-    pub outcome: u32,
-}
-use crate::storage::{OracleVote, PriceObservation, SignedOutcome};
-use crate::{OutcomeManager, OutcomeManagerClient, MAX_ORACLES};
 
 // ─── Test Helpers ─────────────────────────────────────────────────────────────
 
@@ -30,19 +19,6 @@ impl MockRegistry {
     pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
     pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
     pub fn mark_settled(_env: Env, _call_id: u64) {}
-     /// Returns a mock settled Call with outcome=1 (UP), 100 up stake, 100 down stake.
-    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
-        MockCall {
-            total_up_stake: 100_i128,
-            total_down_stake: 100_i128,
-            outcome: 1u32,
-        }
-    }
-
-    /// Returns a fixed staker stake of 50 for any staker/position.
-    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
-        50_i128
-    }
 }
 
 /// Generate a deterministic Ed25519 keypair for testing.
@@ -97,7 +73,7 @@ fn setup_single_oracle(
     Address,
     BytesN<32>,
     BytesN<32>,
-    OutcomeManagerClient<'_>,
+    OutcomeManagerClient,
 ) {
     env.mock_all_auths();
     let admin = Address::generate(env);
@@ -331,28 +307,6 @@ fn test_quorum_reached_with_two_oracles() {
 
     let final_outcome = client.get_outcome(&call_id);
     assert_eq!(final_outcome.outcome, outcome_val);
-
-    let stored_votes = client.get_votes(&call_id);
-    assert_eq!(stored_votes.len(), 2);
-    assert_eq!(client.get_vote_count(&call_id), 2);
-    assert_eq!(
-        stored_votes.get(0).unwrap(),
-        OracleVote {
-            oracle: p1,
-            outcome: outcome_val,
-            price,
-            timestamp: ts,
-        }
-    );
-    assert_eq!(
-        stored_votes.get(1).unwrap(),
-        OracleVote {
-            oracle: p2,
-            outcome: outcome_val,
-            price,
-            timestamp: ts,
-        }
-    );
 }
 
 #[test]
@@ -393,50 +347,6 @@ fn test_add_remove_oracle() {
 
     client.remove_oracle(&new_pubkey);
     assert!(!client.is_oracle(&new_pubkey));
-}
-
-#[test]
-fn test_get_oracles_tracks_add_remove() {
-    let env = Env::default();
-    let (_, _, _, original_pubkey, client) = setup_single_oracle(&env);
-    let (_, second_pubkey) = gen_keypair(&env);
-
-    let initial = client.get_oracles();
-    assert_eq!(initial.len(), 1);
-    assert_eq!(initial.get(0).unwrap(), original_pubkey.clone());
-    assert_eq!(client.get_oracle_count(), 1);
-
-    client.add_oracle(&second_pubkey);
-    let with_second = client.get_oracles();
-    assert_eq!(with_second.len(), 2);
-    assert_eq!(with_second.get(0).unwrap(), original_pubkey);
-    assert_eq!(with_second.get(1).unwrap(), second_pubkey.clone());
-    assert_eq!(client.get_oracle_count(), 2);
-
-    client.remove_oracle(&second_pubkey);
-    assert_eq!(client.get_oracles().len(), 1);
-    assert_eq!(client.get_oracle_count(), 1);
-}
-
-#[test]
-#[should_panic(expected = "max oracles reached")]
-fn test_add_oracle_enforces_max_limit() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let admin = Address::generate(&env);
-    let fee_collector = Address::generate(&env);
-    let contract_id = env.register_contract(None, OutcomeManager);
-    let client = OutcomeManagerClient::new(&env, &contract_id);
-
-    let mut oracles = Vec::new(&env);
-    for _ in 0..MAX_ORACLES {
-        let (_, pubkey) = gen_keypair(&env);
-        oracles.push_back(pubkey);
-    }
-
-    client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
-    let (_, extra_pubkey) = gen_keypair(&env);
-    client.add_oracle(&extra_pubkey);
 }
 
 #[test]
@@ -512,7 +422,7 @@ fn test_get_outcome_unsettled_panics() {
 // ─── Fee Deduction Tests ───────────────────────────────────────────────────────
 
 /// Helper: set up a contract with a specific fee_bps and settle call_id=1.
-fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient<'_>) {
+fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient) {
     env.mock_all_auths();
     let admin = Address::generate(env);
     let fee_collector = Address::generate(env);
@@ -546,70 +456,6 @@ fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerC
     (fee_collector, registry_id, client)
 }
 
-fn setup_with_zero_stake(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient<'_>) {
-    env.mock_all_auths();
-    let admin = Address::generate(env);
-    let fee_collector = Address::generate(env);
-    let (oracle_secret, oracle_pubkey) = gen_keypair(env);
-
-    let contract_id = env.register(OutcomeManager, ());
-    let client = OutcomeManagerClient::new(env, &contract_id);
-
-    let mut oracles = Vec::new(env);
-    oracles.push_back(oracle_pubkey.clone());
-    client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
-
-    let registry_id = env.register(MockRegistryZeroStake, ());
-
-    let call_id = 1u64;
-    let sig = sign_outcome(env, &oracle_secret, call_id, 1, 100, 9000);
-    client.submit_outcome(
-        &registry_id,
-        &SignedOutcome {
-            call_id,
-            outcome: 1,
-            price: 100,
-            timestamp: 9000,
-            oracle_pubkey,
-            signature: sig,
-        },
-    );
-
-    (fee_collector, registry_id, client)
-}
-
-fn setup_with_zero_total_winning(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient<'_>) {
-    env.mock_all_auths();
-    let admin = Address::generate(env);
-    let fee_collector = Address::generate(env);
-    let (oracle_secret, oracle_pubkey) = gen_keypair(env);
-
-    let contract_id = env.register(OutcomeManager, ());
-    let client = OutcomeManagerClient::new(env, &contract_id);
-
-    let mut oracles = Vec::new(env);
-    oracles.push_back(oracle_pubkey.clone());
-    client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
-
-    let registry_id = env.register(MockRegistryZeroTotalWinning, ());
-
-    let call_id = 1u64;
-    let sig = sign_outcome(env, &oracle_secret, call_id, 1, 100, 9000);
-    client.submit_outcome(
-        &registry_id,
-        &SignedOutcome {
-            call_id,
-            outcome: 1,
-            price: 100,
-            timestamp: 9000,
-            oracle_pubkey,
-            signature: sig,
-        },
-    );
-
-    (fee_collector, registry_id, client)
-}
-
 #[test]
 fn test_fee_deducted_from_payout() {
     // fee_bps = 500 (5%)
@@ -624,7 +470,6 @@ fn test_fee_deducted_from_payout() {
     let staker = Address::generate(&env);
 
     client.claim_payout(&registry_id, &1u64, &staker);
-
     // If no panic, payout was computed and released correctly
 }
 
@@ -637,7 +482,6 @@ fn test_zero_fee_full_payout() {
     let staker = Address::generate(&env);
 
     client.claim_payout(&registry_id, &1u64, &staker);
-
 }
 
 #[test]
@@ -671,7 +515,6 @@ fn test_fee_goes_to_correct_address() {
 
     // Should not panic; MockRegistry records calls but we verify no panic = correct flow
     client.claim_payout(&registry_id, &1u64, &staker);
-
     // fee_collector address was set during setup_with_fee; contract uses it internally
     let _ = fee_collector; // referenced to confirm it was set
 }
@@ -736,11 +579,10 @@ fn test_batch_claim_panics_on_duplicate_staker() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128);
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
 
     // Second batch with same staker — must panic
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
-
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
 }
 
 #[test]
@@ -753,7 +595,6 @@ fn test_batch_claim_panics_on_empty_batch() {
     let stakes: Vec<i128> = Vec::new(&env);
 
     client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
-
 }
 
 #[test]
@@ -769,8 +610,7 @@ fn test_batch_claim_panics_on_length_mismatch() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128); // one fewer than stakers
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
-
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
 }
 
 #[test]
@@ -785,8 +625,7 @@ fn test_batch_claim_panics_on_unsettled_call() {
     stakes.push_back(50_i128);
 
     // call_id=999 was never finalized
-    client.batch_claim_payouts(&registry_id, &999u64, &stakers, &stakes, &100_i128, &100_i128);
-
+    client.batch_claim_payouts(&registry_id, &999u64, &stakers, &stakes, &50_i128, &50_i128);
 }
 
 #[test]
@@ -814,6 +653,15 @@ fn test_batch_claim_with_fee_deducted() {
     let _ = fee_collector;
 }
 
+// ─── Pause Mechanism Tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_pause_and_unpause() {
+    let env = Env::default();
+    let (admin, _registry_id, _oracle_secret, _oracle_pubkey, client) = setup_single_oracle(&env);
+
+    // Initially not paused
+    assert!(!client.is_paused_view());
 
     // Admin can pause
     env.mock_all_auths();
@@ -844,7 +692,7 @@ fn test_submit_outcome_fails_when_paused() {
         signature: sign_outcome(&env, &oracle_secret, 1, 1, 100, 1000),
     };
 
-    client.submit_outcome(&registry_id, &signed);
+    client.submit_outcome(&registry_id, &signed, &0u64);
 }
 
 #[test]
@@ -858,8 +706,7 @@ fn test_claim_payout_fails_when_paused() {
     client.pause();
 
     // Attempt to claim while paused should fail
-   client.claim_payout(&registry_id, &1u64, &staker);
-
+    client.claim_payout(&registry_id, &1u64, &staker);
 
 }
 
@@ -891,17 +738,12 @@ fn test_om_upgrade_requires_admin_auth() {
 /// Panics if any arithmetic overflows or the claim is not recorded.
 fn fuzz_claim_setup(staker_winning: i128, total_winning: i128, total_losing: i128, fee_bps: u32) {
     let env = Env::default();
-    let (_, registry_id, client) = if staker_winning == 0 {
-        setup_with_zero_stake(&env, fee_bps)
-    } else if total_winning == 0 {
-        setup_with_zero_total_winning(&env, fee_bps)
-    } else {
-        setup_with_fee(&env, fee_bps)
-    };
+    let (_, registry_id, client) = setup_with_fee(&env, fee_bps);
     let staker = Address::generate(&env);
     client.claim_payout(&registry_id, &1u64, &staker);
     assert!(client.has_claimed(&1u64, &staker));
 }
+
 #[test]
 fn test_fuzz_payout_many_ratios_no_panic() {
     // Representative matrix of ratios; none should overflow or panic
@@ -937,7 +779,14 @@ fn test_fuzz_100_winners_batch_all_claimed() {
         stakes.push_back(1_i128);
     }
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    client.batch_claim_payouts(
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
+    );
 
     for i in 0..100u32 {
         assert!(client.has_claimed(&1u64, &stakers.get(i).unwrap()));
@@ -976,252 +825,5 @@ fn test_fuzz_zero_staker_stake_panics() {
 #[should_panic]
 fn test_fuzz_zero_total_winning_panics() {
     fuzz_claim_setup(1, 0, 1, 0);
-}
-
-// ───  Cross-contract stake verification ────────────────────────────
-
-#[contract]
-pub struct MockRegistryCustomStake;
-
-#[contractimpl]
-impl MockRegistryCustomStake {
-    pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
-    pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
-    pub fn mark_settled(_env: Env, _call_id: u64) {}
-
-    /// UP wins: 60 up stake, 40 down stake
-    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
-        MockCall {
-            total_up_stake: 60_i128,
-            total_down_stake: 40_i128,
-            outcome: 1u32,
-        }
-    }
-
-    /// Staker has 30 on the winning (UP) side
-    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
-        30_i128
-    }
-}
-
-#[contract]
-pub struct MockRegistryZeroStake;
-
-#[contractimpl]
-impl MockRegistryZeroStake {
-    pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
-    pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
-    pub fn mark_settled(_env: Env, _call_id: u64) {}
-    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
-        MockCall { total_up_stake: 100, total_down_stake: 100, outcome: 1 }
-    }
-    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
-        0_i128 // staker has no stake on winning side
-    }
-}
-
-#[contract]
-pub struct MockRegistryZeroTotalWinning;
-
-#[contractimpl]
-impl MockRegistryZeroTotalWinning {
-    pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
-    pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
-    pub fn mark_settled(_env: Env, _call_id: u64) {}
-    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
-        MockCall { total_up_stake: 0, total_down_stake: 100, outcome: 1 }
-    }
-    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
-        50_i128
-    }
-}
-
-#[test]
-fn test_claim_payout_reads_stakes_from_registry() {
-    // MockRegistryCustomStake returns: total_up=60, total_down=40, staker_up=30
-    // outcome=1 (UP wins), fee=0
-    // payout = 30 + 30 * 40 / 60 = 30 + 20 = 50
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let admin = Address::generate(&env);
-    let fee_collector = Address::generate(&env);
-    let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
-
-    let contract_id = env.register(OutcomeManager, ());
-    let client = OutcomeManagerClient::new(&env, &contract_id);
-
-    let mut oracles = Vec::new(&env);
-    oracles.push_back(oracle_pubkey.clone());
-    client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
-
-    let registry_id = env.register(MockRegistryCustomStake, ());
-
-    // Settle call_id=1
-    let sig = sign_outcome(&env, &oracle_secret, 1u64, 1u32, 100, 9000);
-    client.submit_outcome(
-        &registry_id,
-        &SignedOutcome {
-            call_id: 1,
-            outcome: 1,
-            price: 100,
-            timestamp: 9000,
-            oracle_pubkey,
-            signature: sig,
-        },
-    );
-
-    let staker = Address::generate(&env);
-    client.claim_payout(&registry_id, &1u64, &staker);
-    assert!(client.has_claimed(&1u64, &staker));
-}
-
-#[test]
-#[should_panic(expected = "nothing to claim")]
-fn test_claim_payout_rejects_zero_stake_from_registry() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let admin = Address::generate(&env);
-    let fee_collector = Address::generate(&env);
-    let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
-
-    let contract_id = env.register(OutcomeManager, ());
-    let client = OutcomeManagerClient::new(&env, &contract_id);
-    let mut oracles = Vec::new(&env);
-    oracles.push_back(oracle_pubkey.clone());
-    client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
-
-    let registry_id = env.register(MockRegistryZeroStake, ());
-    let sig = sign_outcome(&env, &oracle_secret, 1u64, 1u32, 100, 9000);
-    client.submit_outcome(&registry_id, &SignedOutcome {
-        call_id: 1, outcome: 1, price: 100, timestamp: 9000,
-        oracle_pubkey, signature: sig,
-    });
-
-    let staker = Address::generate(&env);
-    client.claim_payout(&registry_id, &1u64, &staker);
-}
-// ─── Pause Mechanism Tests ─────────────────────────────────────────────────────
-
-#[test]
-fn test_pause_and_unpause() {
-    let env = Env::default();
-    let (_admin, _registry_id, _oracle_secret, _oracle_pubkey, client) = setup_single_oracle(&env);
-
-    assert!(!client.is_paused_view());
-
-    env.mock_all_auths();
-    client.pause();
-    assert!(client.is_paused_view());
-
-    client.unpause();
-    assert!(!client.is_paused_view());
-}
-
-#[test]
-#[should_panic(expected = "contract is paused")]
-fn test_submit_outcome_fails_when_paused() {
-    let env = Env::default();
-    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
-
-    env.mock_all_auths();
-    client.pause();
-
-    let signed = SignedOutcome {
-        call_id: 1,
-        outcome: 1,
-        price: 100,
-        timestamp: 1000,
-        oracle_pubkey: oracle_pubkey.clone(),
-        signature: sign_outcome(&env, &oracle_secret, 1, 1, 100, 1000),
-    };
-
-    client.submit_outcome(&registry_id, &signed, &0u64);
-}
-
-#[test]
-#[should_panic(expected = "contract is paused")]
-fn test_claim_payout_fails_when_paused() {
-    let env = Env::default();
-    let (_admin, registry_id, _oracle_secret, _oracle_pubkey, client) = setup_single_oracle(&env);
-    let staker = Address::generate(&env);
-
-    env.mock_all_auths();
-    client.pause();
-
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &100_i128,
-        &100_i128,
-        &100_i128,
-    );
-}
-
-// ─── Oracle Submission Deadline Tests ─────────────────────────────────────────
-
-#[test]
-fn test_submission_within_window_succeeds() {
-    let env = Env::default();
-    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
-
-    let call_id = 10u64;
-    let call_end_ts = 1000u64;
-    // timestamp 1500 is well within default 86400s window
-    let sig = sign_outcome(&env, &oracle_secret, call_id, 1, 100, 1500);
-    client.submit_outcome(
-        &registry_id,
-        &SignedOutcome {
-            call_id,
-            outcome: 1,
-            price: 100,
-            timestamp: 1500,
-            oracle_pubkey,
-            signature: sig,
-        },
-        &call_end_ts,
-    );
-
-    let outcome = client.get_outcome(&call_id);
-    assert_eq!(outcome.outcome, 1u32);
-}
-
-#[test]
-#[should_panic(expected = "submission outside allowed window")]
-fn test_submission_outside_window_fails() {
-    let env = Env::default();
-    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
-
-    // Tighten the window to 50 seconds
-    client.set_max_submission_delay(&50u64);
-
-    let call_id = 11u64;
-    let call_end_ts = 1000u64;
-    // timestamp 1200 > call_end_ts(1000) + max_delay(50) = 1050
-    let sig = sign_outcome(&env, &oracle_secret, call_id, 1, 100, 1200);
-    client.submit_outcome(
-        &registry_id,
-        &SignedOutcome {
-            call_id,
-            outcome: 1,
-            price: 100,
-            timestamp: 1200,
-            oracle_pubkey,
-            signature: sig,
-        },
-        &call_end_ts,
-    );
-}
-
-#[test]
-fn test_admin_can_update_max_submission_delay() {
-    let env = Env::default();
-    let (_admin, _registry_id, _secret, _pubkey, client) = setup_single_oracle(&env);
-
-    assert_eq!(client.get_max_submission_delay(), 86400u64);
-
-    client.set_max_submission_delay(&3600u64);
-    assert_eq!(client.get_max_submission_delay(), 3600u64);
 }
 

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -94,7 +94,7 @@ fn setup_single_oracle(
     Address,
     BytesN<32>,
     BytesN<32>,
-    OutcomeManagerClient,
+    OutcomeManagerClient<'_>,
 ) {
     env.mock_all_auths();
     let admin = Address::generate(env);
@@ -440,7 +440,7 @@ fn test_get_outcome_unsettled_panics() {
 // ─── Fee Deduction Tests ───────────────────────────────────────────────────────
 
 /// Helper: set up a contract with a specific fee_bps and settle call_id=1.
-fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient) {
+fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient<'_>) {
     env.mock_all_auths();
     let admin = Address::generate(env);
     let fee_collector = Address::generate(env);
@@ -456,6 +456,70 @@ fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerC
     let registry_id = env.register_contract(None, MockRegistry);
 
     // Settle call_id=1
+    let call_id = 1u64;
+    let sig = sign_outcome(env, &oracle_secret, call_id, 1, 100, 9000);
+    client.submit_outcome(
+        &registry_id,
+        &SignedOutcome {
+            call_id,
+            outcome: 1,
+            price: 100,
+            timestamp: 9000,
+            oracle_pubkey,
+            signature: sig,
+        },
+    );
+
+    (fee_collector, registry_id, client)
+}
+
+fn setup_with_zero_stake(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let fee_collector = Address::generate(env);
+    let (oracle_secret, oracle_pubkey) = gen_keypair(env);
+
+    let contract_id = env.register_contract(None, OutcomeManager);
+    let client = OutcomeManagerClient::new(env, &contract_id);
+
+    let mut oracles = Vec::new(env);
+    oracles.push_back(oracle_pubkey.clone());
+    client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
+
+    let registry_id = env.register_contract(None, MockRegistryZeroStake);
+
+    let call_id = 1u64;
+    let sig = sign_outcome(env, &oracle_secret, call_id, 1, 100, 9000);
+    client.submit_outcome(
+        &registry_id,
+        &SignedOutcome {
+            call_id,
+            outcome: 1,
+            price: 100,
+            timestamp: 9000,
+            oracle_pubkey,
+            signature: sig,
+        },
+    );
+
+    (fee_collector, registry_id, client)
+}
+
+fn setup_with_zero_total_winning(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let fee_collector = Address::generate(env);
+    let (oracle_secret, oracle_pubkey) = gen_keypair(env);
+
+    let contract_id = env.register_contract(None, OutcomeManager);
+    let client = OutcomeManagerClient::new(env, &contract_id);
+
+    let mut oracles = Vec::new(env);
+    oracles.push_back(oracle_pubkey.clone());
+    client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
+
+    let registry_id = env.register_contract(None, MockRegistryZeroTotalWinning);
+
     let call_id = 1u64;
     let sig = sign_outcome(env, &oracle_secret, call_id, 1, 100, 9000);
     client.submit_outcome(
@@ -578,8 +642,7 @@ fn test_batch_claim_payouts_three_stakers() {
     stakes.push_back(20_i128);
 
     // Should not panic — all three processed in one tx
-    client.claim_payout(&registry_id, &1u64, &staker);
-
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
     assert!(client.has_claimed(&1u64, &staker1));
     assert!(client.has_claimed(&1u64, &staker2));
@@ -600,11 +663,10 @@ fn test_batch_claim_panics_on_duplicate_staker() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128);
 
-    client.claim_payout(&registry_id, &1u64, &staker);
-
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
     // Second batch with same staker — must panic
-    client.claim_payout(&registry_id, &1u64, &staker);
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
 }
 
@@ -617,7 +679,7 @@ fn test_batch_claim_panics_on_empty_batch() {
     let stakers: Vec<Address> = Vec::new(&env);
     let stakes: Vec<i128> = Vec::new(&env);
 
-    client.claim_payout(&registry_id, &1u64, &staker);
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
 }
 
@@ -634,7 +696,7 @@ fn test_batch_claim_panics_on_length_mismatch() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128); // one fewer than stakers
 
-    client.claim_payout(&registry_id, &1u64, &staker);
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
 }
 
@@ -650,7 +712,7 @@ fn test_batch_claim_panics_on_unsettled_call() {
     stakes.push_back(50_i128);
 
     // call_id=999 was never finalized
-    client.claim_payout(&registry_id, &1u64, &staker);
+    client.batch_claim_payouts(&registry_id, &999u64, &stakers, &stakes, &100_i128, &100_i128);
 
 }
 
@@ -672,8 +734,7 @@ fn test_batch_claim_with_fee_deducted() {
     stakes.push_back(40_i128);
 
     // Should process without panic; fee math mirrors claim_payout
-    client.claim_payout(&registry_id, &1u64, &staker);
-
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
     assert!(client.has_claimed(&1u64, &staker1));
     assert!(client.has_claimed(&1u64, &staker2));
@@ -764,9 +825,15 @@ fn test_om_upgrade_requires_admin_auth() {
 
 /// Create a fresh settled env and run claim_payout with the given inputs.
 /// Panics if any arithmetic overflows or the claim is not recorded.
-fn fuzz_claim_setup(fee_bps: u32) {
+fn fuzz_claim_setup(staker_winning: i128, total_winning: i128, total_losing: i128, fee_bps: u32) {
     let env = Env::default();
-    let (_, registry_id, client) = setup_with_fee(&env, fee_bps);
+    let (_, registry_id, client) = if staker_winning == 0 {
+        setup_with_zero_stake(&env, fee_bps)
+    } else if total_winning == 0 {
+        setup_with_zero_total_winning(&env, fee_bps)
+    } else {
+        setup_with_fee(&env, fee_bps)
+    };
     let staker = Address::generate(&env);
     client.claim_payout(&registry_id, &1u64, &staker);
     assert!(client.has_claimed(&1u64, &staker));
@@ -806,8 +873,7 @@ fn test_fuzz_100_winners_batch_all_claimed() {
         stakes.push_back(1_i128);
     }
 
-  client.claim_payout(&registry_id, &1u64, &staker);
-;
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
     for i in 0..100u32 {
         assert!(client.has_claimed(&1u64, &stakers.get(i).unwrap()));
@@ -820,8 +886,7 @@ fn test_fuzz_1_winner_takes_all() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
-   client.claim_payout(&registry_id, &1u64, &staker);
-;
+    client.claim_payout(&registry_id, &1u64, &staker);
     assert!(client.has_claimed(&1u64, &staker));
 }
 
@@ -875,6 +940,38 @@ impl MockRegistryCustomStake {
     }
 }
 
+#[contract]
+pub struct MockRegistryZeroStake;
+
+#[contractimpl]
+impl MockRegistryZeroStake {
+    pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
+    pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
+    pub fn mark_settled(_env: Env, _call_id: u64) {}
+    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
+        MockCall { total_up_stake: 100, total_down_stake: 100, outcome: 1 }
+    }
+    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
+        0_i128 // staker has no stake on winning side
+    }
+}
+
+#[contract]
+pub struct MockRegistryZeroTotalWinning;
+
+#[contractimpl]
+impl MockRegistryZeroTotalWinning {
+    pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
+    pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
+    pub fn mark_settled(_env: Env, _call_id: u64) {}
+    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
+        MockCall { total_up_stake: 0, total_down_stake: 100, outcome: 1 }
+    }
+    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
+        50_i128
+    }
+}
+
 #[test]
 fn test_claim_payout_reads_stakes_from_registry() {
     // MockRegistryCustomStake returns: total_up=60, total_down=40, staker_up=30
@@ -918,22 +1015,6 @@ fn test_claim_payout_reads_stakes_from_registry() {
 #[test]
 #[should_panic(expected = "nothing to claim")]
 fn test_claim_payout_rejects_zero_stake_from_registry() {
-    // MockRegistry returns 50 by default but we need 0 — use a zero-stake mock
-    #[contract]
-    pub struct MockRegistryZeroStake;
-    #[contractimpl]
-    impl MockRegistryZeroStake {
-        pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
-        pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
-        pub fn mark_settled(_env: Env, _call_id: u64) {}
-        pub fn get_call(env: Env, _call_id: u64) -> MockCall {
-            MockCall { total_up_stake: 100, total_down_stake: 100, outcome: 1 }
-        }
-        pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
-            0_i128 // staker has no stake on winning side
-        }
-    }
-
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -8,7 +8,15 @@ use soroban_sdk::{
 
 use crate::storage::{PriceObservation, SignedOutcome};
 use crate::{OutcomeManager, OutcomeManagerClient};
+use soroban_sdk::contracttype;
 
+#[contracttype]
+#[derive(Clone)]
+pub struct MockCall {
+    pub total_up_stake: i128,
+    pub total_down_stake: i128,
+    pub outcome: u32,
+}
 // ─── Test Helpers ─────────────────────────────────────────────────────────────
 
 #[contract]
@@ -19,6 +27,19 @@ impl MockRegistry {
     pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
     pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
     pub fn mark_settled(_env: Env, _call_id: u64) {}
+     /// Returns a mock settled Call with outcome=1 (UP), 100 up stake, 100 down stake.
+    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
+        MockCall {
+            total_up_stake: 100_i128,
+            total_down_stake: 100_i128,
+            outcome: 1u32,
+        }
+    }
+
+    /// Returns a fixed staker stake of 50 for any staker/position.
+    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
+        50_i128
+    }
 }
 
 /// Generate a deterministic Ed25519 keypair for testing.
@@ -465,7 +486,8 @@ fn test_fee_deducted_from_payout() {
     let (_, registry_id, client) = setup_with_fee(&env, 500);
     let staker = Address::generate(&env);
 
-    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
     // If no panic, payout was computed and released correctly
 }
 
@@ -477,7 +499,8 @@ fn test_zero_fee_full_payout() {
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
 
-    client.claim_payout(&registry_id, &1u64, &staker, &50i128, &100i128, &100i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 }
 
 #[test]
@@ -510,7 +533,8 @@ fn test_fee_goes_to_correct_address() {
     let staker = Address::generate(&env);
 
     // Should not panic; MockRegistry records calls but we verify no panic = correct flow
-    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
     // fee_collector address was set during setup_with_fee; contract uses it internally
     let _ = fee_collector; // referenced to confirm it was set
 }
@@ -554,7 +578,8 @@ fn test_batch_claim_payouts_three_stakers() {
     stakes.push_back(20_i128);
 
     // Should not panic — all three processed in one tx
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 
     assert!(client.has_claimed(&1u64, &staker1));
     assert!(client.has_claimed(&1u64, &staker2));
@@ -575,10 +600,12 @@ fn test_batch_claim_panics_on_duplicate_staker() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128);
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 
     // Second batch with same staker — must panic
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 }
 
 #[test]
@@ -590,7 +617,8 @@ fn test_batch_claim_panics_on_empty_batch() {
     let stakers: Vec<Address> = Vec::new(&env);
     let stakes: Vec<i128> = Vec::new(&env);
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 }
 
 #[test]
@@ -606,7 +634,8 @@ fn test_batch_claim_panics_on_length_mismatch() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128); // one fewer than stakers
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 }
 
 #[test]
@@ -621,7 +650,8 @@ fn test_batch_claim_panics_on_unsettled_call() {
     stakes.push_back(50_i128);
 
     // call_id=999 was never finalized
-    client.batch_claim_payouts(&registry_id, &999u64, &stakers, &stakes, &50_i128, &50_i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 }
 
 #[test]
@@ -642,7 +672,8 @@ fn test_batch_claim_with_fee_deducted() {
     stakes.push_back(40_i128);
 
     // Should process without panic; fee math mirrors claim_payout
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    client.claim_payout(&registry_id, &1u64, &staker);
+
 
     assert!(client.has_claimed(&1u64, &staker1));
     assert!(client.has_claimed(&1u64, &staker2));
@@ -702,14 +733,8 @@ fn test_claim_payout_fails_when_paused() {
     client.pause();
 
     // Attempt to claim while paused should fail
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &100_i128,
-        &100_i128,
-        &100_i128,
-    );
+   client.claim_payout(&registry_id, &1u64, &staker);
+
 
 }
 
@@ -739,21 +764,13 @@ fn test_om_upgrade_requires_admin_auth() {
 
 /// Create a fresh settled env and run claim_payout with the given inputs.
 /// Panics if any arithmetic overflows or the claim is not recorded.
-fn fuzz_claim_setup(staker_winning: i128, total_winning: i128, total_losing: i128, fee_bps: u32) {
+fn fuzz_claim_setup(fee_bps: u32) {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, fee_bps);
     let staker = Address::generate(&env);
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &staker_winning,
-        &total_winning,
-        &total_losing,
-    );
+    client.claim_payout(&registry_id, &1u64, &staker);
     assert!(client.has_claimed(&1u64, &staker));
 }
-
 #[test]
 fn test_fuzz_payout_many_ratios_no_panic() {
     // Representative matrix of ratios; none should overflow or panic
@@ -789,14 +806,8 @@ fn test_fuzz_100_winners_batch_all_claimed() {
         stakes.push_back(1_i128);
     }
 
-    client.batch_claim_payouts(
-        &registry_id,
-        &1u64,
-        &stakers,
-        &stakes,
-        &100_i128,
-        &100_i128,
-    );
+  client.claim_payout(&registry_id, &1u64, &staker);
+;
 
     for i in 0..100u32 {
         assert!(client.has_claimed(&1u64, &stakers.get(i).unwrap()));
@@ -809,14 +820,8 @@ fn test_fuzz_1_winner_takes_all() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &1_000_000_i128,
-        &1_000_000_i128,
-        &1_000_000_i128,
-    );
+   client.claim_payout(&registry_id, &1u64, &staker);
+;
     assert!(client.has_claimed(&1u64, &staker));
 }
 
@@ -844,3 +849,110 @@ fn test_fuzz_zero_total_winning_panics() {
     fuzz_claim_setup(1, 0, 1, 0);
 }
 
+// ───  Cross-contract stake verification ────────────────────────────
+
+#[contract]
+pub struct MockRegistryCustomStake;
+
+#[contractimpl]
+impl MockRegistryCustomStake {
+    pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
+    pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
+    pub fn mark_settled(_env: Env, _call_id: u64) {}
+
+    /// UP wins: 60 up stake, 40 down stake
+    pub fn get_call(env: Env, _call_id: u64) -> MockCall {
+        MockCall {
+            total_up_stake: 60_i128,
+            total_down_stake: 40_i128,
+            outcome: 1u32,
+        }
+    }
+
+    /// Staker has 30 on the winning (UP) side
+    pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
+        30_i128
+    }
+}
+
+#[test]
+fn test_claim_payout_reads_stakes_from_registry() {
+    // MockRegistryCustomStake returns: total_up=60, total_down=40, staker_up=30
+    // outcome=1 (UP wins), fee=0
+    // payout = 30 + 30 * 40 / 60 = 30 + 20 = 50
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+    let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
+
+    let contract_id = env.register_contract(None, OutcomeManager);
+    let client = OutcomeManagerClient::new(&env, &contract_id);
+
+    let mut oracles = Vec::new(&env);
+    oracles.push_back(oracle_pubkey.clone());
+    client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
+
+    let registry_id = env.register_contract(None, MockRegistryCustomStake);
+
+    // Settle call_id=1
+    let sig = sign_outcome(&env, &oracle_secret, 1u64, 1u32, 100, 9000);
+    client.submit_outcome(
+        &registry_id,
+        &SignedOutcome {
+            call_id: 1,
+            outcome: 1,
+            price: 100,
+            timestamp: 9000,
+            oracle_pubkey,
+            signature: sig,
+        },
+    );
+
+    let staker = Address::generate(&env);
+    client.claim_payout(&registry_id, &1u64, &staker);
+    assert!(client.has_claimed(&1u64, &staker));
+}
+
+#[test]
+#[should_panic(expected = "nothing to claim")]
+fn test_claim_payout_rejects_zero_stake_from_registry() {
+    // MockRegistry returns 50 by default but we need 0 — use a zero-stake mock
+    #[contract]
+    pub struct MockRegistryZeroStake;
+    #[contractimpl]
+    impl MockRegistryZeroStake {
+        pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
+        pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
+        pub fn mark_settled(_env: Env, _call_id: u64) {}
+        pub fn get_call(env: Env, _call_id: u64) -> MockCall {
+            MockCall { total_up_stake: 100, total_down_stake: 100, outcome: 1 }
+        }
+        pub fn get_staker_stake(_env: Env, _call_id: u64, _staker: Address, _position: u32) -> i128 {
+            0_i128 // staker has no stake on winning side
+        }
+    }
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+    let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
+
+    let contract_id = env.register_contract(None, OutcomeManager);
+    let client = OutcomeManagerClient::new(&env, &contract_id);
+    let mut oracles = Vec::new(&env);
+    oracles.push_back(oracle_pubkey.clone());
+    client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
+
+    let registry_id = env.register_contract(None, MockRegistryZeroStake);
+    let sig = sign_outcome(&env, &oracle_secret, 1u64, 1u32, 100, 9000);
+    client.submit_outcome(&registry_id, &SignedOutcome {
+        call_id: 1, outcome: 1, price: 100, timestamp: 9000,
+        oracle_pubkey, signature: sig,
+    });
+
+    let staker = Address::generate(&env);
+    client.claim_payout(&registry_id, &1u64, &staker);
+}


### PR DESCRIPTION
## Summary
Fixes the stake spoofing vulnerability in `claim_payout` as described in #153.

## Problem
`claim_payout` previously trusted `staker_winning_stake`, `total_winning_stake`,
and `total_losing_stake` supplied by the caller. Any staker could inflate these
values to receive an outsized payout.

## Solution
- API simplified to `claim_payout(env, registry, call_id, staker)`
- Pool totals read from `CallRegistry.get_call(call_id)`
- Staker amount read from `CallRegistry.get_staker_stake(call_id, staker, position)`
- Winning side determined from the stored finalized outcome

## Changes
- `lib.rs` — new API, two new cross-contract helpers, updated payout logic
- `test.rs` — updated MockRegistry, all call sites, two new tests

Closes #153