### PR TITLE
feat: moderation report triage and admin actions

### DIFF
--- a/packages/backend/src/admin/admin.controller.ts
+++ b/packages/backend/src/admin/admin.controller.ts
@@ -6,6 +6,11 @@ import {
   Query,
   UseGuards,
   ParseUUIDPipe,
+  Body,
+  DefaultValuePipe,
+  ParseIntPipe,
+  ValidationPipe,
+  UsePipes,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -15,14 +20,16 @@ import {
   ApiOkResponse,
 } from '@nestjs/swagger';
 import { AdminGuard } from '../auth/guards/admin.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AdminService } from './admin.service';
 import { QueryAdminCallsDto } from './dto/query-admin-calls.dto';
 import { Audited } from '../audit/decorators/audited.decorator';
 import { AuditActionType } from '../audit/audit-log.entity';
+import { ReportActionDto } from './dto/report-action.dto';
 
 @ApiTags('admin')
 @ApiBearerAuth('JWT-auth')
-@UseGuards(AdminGuard)
+@UseGuards(JwtAuthGuard, AdminGuard)
 @Controller('admin')
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
@@ -105,5 +112,30 @@ export class AdminController {
   })
   getStats() {
     return this.adminService.getStats();
+  }
+
+  @Get('reports')
+  @ApiOperation({ summary: 'Paginated moderation report queue' })
+  listReports(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.adminService.listReports(page, limit);
+  }
+
+  @Post('reports/:id/dismiss')
+  @ApiOperation({ summary: 'Dismiss reports for a call without hiding it' })
+  dismissReports(@Param('id', ParseUUIDPipe) callId: string) {
+    return this.adminService.dismissReports(callId);
+  }
+
+  @Post('reports/:id/action')
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
+  @ApiOperation({ summary: 'Take moderation action on a reported call' })
+  takeReportAction(
+    @Param('id', ParseUUIDPipe) callId: string,
+    @Body() dto: ReportActionDto,
+  ) {
+    return this.adminService.takeReportAction(callId, dto.banCreator ?? false);
   }
 }

--- a/packages/backend/src/admin/admin.service.spec.ts
+++ b/packages/backend/src/admin/admin.service.spec.ts
@@ -13,6 +13,7 @@ const makeCall = (overrides: Partial<Call> = {}): Call =>
   ({
     id: 'call-uuid-1',
     title: 'Test Call',
+    creatorAddress: '0xCREATOR',
     status: CallStatus.OPEN,
     isHidden: false,
     reportCount: 0,
@@ -43,6 +44,8 @@ const mockCallRepo = () => ({
 
 const mockReportRepo = () => ({
   createQueryBuilder: jest.fn(),
+  findAndCount: jest.fn(),
+  delete: jest.fn(),
 });
 
 const mockUsersRepo = () => ({
@@ -231,6 +234,56 @@ describe('AdminService', () => {
         pendingReports: 5,
         pausedCalls: 3,
       });
+    });
+  });
+
+  describe('moderation reports', () => {
+    it('lists paginated reports grouped by call', async () => {
+      const call = makeCall({ id: 'call-uuid-1' });
+      const reports = [
+        {
+          id: 'r1',
+          callId: 'call-uuid-1',
+          reporterAddress: 'A',
+          call,
+        } as CallReport,
+        {
+          id: 'r2',
+          callId: 'call-uuid-1',
+          reporterAddress: 'B',
+          call,
+        } as CallReport,
+      ];
+      reportRepo.findAndCount.mockResolvedValue([reports, 2]);
+
+      const result = await service.listReports(1, 20);
+      expect(result.total).toBe(2);
+      expect(result.data[0].reportCount).toBe(2);
+      expect(result.data[0].reports).toHaveLength(2);
+    });
+
+    it('dismisses reports and resets call reportCount', async () => {
+      const call = makeCall({ reportCount: 3, isHidden: false });
+      callRepo.findOneBy.mockResolvedValue(call);
+      callRepo.save.mockImplementation(async (value: Call) => value);
+
+      const result = await service.dismissReports(call.id);
+      expect(reportRepo.delete).toHaveBeenCalledWith({ callId: call.id });
+      expect(result.reportCount).toBe(0);
+    });
+
+    it('hides call and optionally bans creator on action', async () => {
+      const call = makeCall({ creatorAddress: '0xCREATOR' } as Call);
+      callRepo.findOneBy.mockResolvedValue(call);
+      callRepo.save.mockImplementation(async (value: Call) => value);
+      usersRepo.findOneBy.mockResolvedValue(
+        makeUser({ walletAddress: '0xCREATOR' }),
+      );
+      usersRepo.save.mockImplementation(async (value: Users) => value);
+
+      const result = await service.takeReportAction(call.id, true);
+      expect(result.isHidden).toBe(true);
+      expect(usersRepo.save).toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/admin/admin.service.ts
+++ b/packages/backend/src/admin/admin.service.ts
@@ -96,6 +96,63 @@ export class AdminService {
     return { activeUsersToday, pendingReports, pausedCalls };
   }
 
+  async listReports(page = 1, limit = 20) {
+    const [reports, total] = await this.reportRepo.findAndCount({
+      relations: ['call'],
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    const grouped = new Map<
+      string,
+      { call: Call; reportCount: number; reports: CallReport[] }
+    >();
+    for (const report of reports) {
+      const existing = grouped.get(report.callId);
+      if (existing) {
+        existing.reportCount += 1;
+        existing.reports.push(report);
+      } else {
+        grouped.set(report.callId, {
+          call: report.call,
+          reportCount: 1,
+          reports: [report],
+        });
+      }
+    }
+
+    return {
+      data: Array.from(grouped.values()),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async dismissReports(callId: string) {
+    const call = await this.findCallOrThrow(callId);
+    await this.reportRepo.delete({ callId });
+    call.reportCount = 0;
+    return this.callRepo.save(call);
+  }
+
+  async takeReportAction(callId: string, banCreator = false) {
+    const call = await this.findCallOrThrow(callId);
+    call.isHidden = true;
+    await this.callRepo.save(call);
+
+    if (banCreator) {
+      await this.banUser(call.creatorAddress);
+    }
+
+    return {
+      callId,
+      isHidden: true,
+      creatorBanned: banCreator,
+    };
+  }
+
   // ─── Helpers ──────────────────────────────────────────────────────────────
 
   private async findCallOrThrow(id: string): Promise<Call> {

--- a/packages/backend/src/admin/dto/report-action.dto.ts
+++ b/packages/backend/src/admin/dto/report-action.dto.ts
@@ -1,0 +1,7 @@
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class ReportActionDto {
+  @IsOptional()
+  @IsBoolean()
+  banCreator?: boolean;
+}

--- a/packages/backend/src/calls/calls.service.spec.ts
+++ b/packages/backend/src/calls/calls.service.spec.ts
@@ -1,20 +1,31 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  ConflictException,
+  NotFoundException,
+  HttpStatus,
+} from '@nestjs/common';
 import { CallsService } from './calls.service';
 import { CallsRepository } from './calls.repository';
 import { CallReport } from './entities/call-report.entity';
-import { OracleService } from '../oracle/oracle.service';
 import { IpfsService } from '../storage/ipfs.service';
+import { Call, CallStatus } from './entities/call.entity';
 
 describe('CallsService', () => {
   let service: CallsService;
 
   const callsRepository = {
     findFeedByFollowing: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
   };
 
-  const callReportRepository = {};
-  const oracleService = {};
+  const callReportRepository = {
+    findOne: jest.fn(),
+    count: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
   const ipfsService = {};
 
   beforeEach(async () => {
@@ -27,7 +38,6 @@ describe('CallsService', () => {
           provide: getRepositoryToken(CallReport),
           useValue: callReportRepository,
         },
-        { provide: OracleService, useValue: oracleService },
         { provide: IpfsService, useValue: ipfsService },
       ],
     }).compile();
@@ -65,5 +75,41 @@ describe('CallsService', () => {
     expect(result.total).toBe(0);
     expect(result.page).toBe(1);
     expect(result.limit).toBe(20);
+  });
+
+  it('throws if reporting a non-existing call', async () => {
+    callsRepository.findOne.mockResolvedValue(null);
+    await expect(
+      service.reportCall('call-id', 'GA_USER', { reason: undefined }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('throws if user already reported same call', async () => {
+    callsRepository.findOne.mockResolvedValue({
+      id: 'call-id',
+      reportCount: 0,
+      isHidden: false,
+      status: CallStatus.OPEN,
+    } as Call);
+    callReportRepository.findOne.mockResolvedValue({ id: 'r1' });
+
+    await expect(
+      service.reportCall('call-id', 'GA_USER', { reason: undefined }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('enforces max 10 reports per hour per reporter', async () => {
+    callsRepository.findOne.mockResolvedValue({
+      id: 'call-id',
+      reportCount: 0,
+      isHidden: false,
+      status: CallStatus.OPEN,
+    } as Call);
+    callReportRepository.findOne.mockResolvedValue(null);
+    callReportRepository.count.mockResolvedValue(10);
+
+    await expect(
+      service.reportCall('call-id', 'GA_USER', { reason: undefined }),
+    ).rejects.toHaveProperty('status', HttpStatus.TOO_MANY_REQUESTS);
   });
 });

--- a/packages/backend/src/calls/calls.service.ts
+++ b/packages/backend/src/calls/calls.service.ts
@@ -2,9 +2,11 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MoreThan, Repository } from 'typeorm';
 import { CallsRepository } from './calls.repository';
 import { CallReport } from './entities/call-report.entity';
 import { ReportCallDto } from './dto/report-call.dto';
@@ -103,6 +105,20 @@ export class CallsService {
     });
     if (alreadyReported)
       throw new ConflictException('You have already reported this call');
+
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const reportCountLastHour = await this.callReportRepository.count({
+      where: {
+        reporterAddress,
+        createdAt: MoreThan(oneHourAgo),
+      },
+    });
+    if (reportCountLastHour >= 10) {
+      throw new HttpException(
+        'Report rate limit reached (max 10 reports per hour)',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
 
     await this.callReportRepository.save(
       this.callReportRepository.create({

--- a/packages/backend/src/calls/dto/report-call.dto.ts
+++ b/packages/backend/src/calls/dto/report-call.dto.ts
@@ -1,8 +1,15 @@
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export enum ReportReason {
+  SPAM = 'SPAM',
+  MISLEADING = 'MISLEADING',
+  OFFENSIVE = 'OFFENSIVE',
+  MARKET_MANIPULATION = 'MARKET_MANIPULATION',
+  OTHER = 'OTHER',
+}
 
 export class ReportCallDto {
   @IsOptional()
-  @IsString()
-  @MaxLength(100)
-  reason?: string;
+  @IsEnum(ReportReason)
+  reason?: ReportReason;
 }

--- a/packages/backend/src/calls/entities/call-report.entity.ts
+++ b/packages/backend/src/calls/entities/call-report.entity.ts
@@ -8,6 +8,7 @@ import {
   Unique,
 } from 'typeorm';
 import { Call } from './call.entity';
+import { ReportReason } from '../dto/report-call.dto';
 
 @Entity('call_reports')
 @Unique(['callId', 'reporterAddress'])
@@ -21,8 +22,8 @@ export class CallReport {
   @Column({ type: 'varchar', length: 42 })
   reporterAddress: string;
 
-  @Column({ type: 'varchar', length: 100, nullable: true })
-  reason: string;
+  @Column({ type: 'enum', enum: ReportReason, nullable: true })
+  reason: ReportReason | null;
 
   @ManyToOne(() => Call, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'callId' })


### PR DESCRIPTION
Closes #181
Closes #182
Closes #183
Closes #212

## Summary
- add normalized report reasons for call reports
- enforce per-reporter rate limit for reporting abuse
- add admin moderation endpoints to list, dismiss, and action reports
- hide reported calls at threshold and support optional creator ban from admin action

## Validation
- pnpm --dir packages/backend test -- --watchman=false calls.service.spec.ts admin.service.spec.ts ✅
- pnpm --dir packages/backend lint ❌ (pre-existing repository-wide lint debt unrelated to this change)
- pnpm --dir packages/backend exec tsc --noEmit ❌ (pre-existing missing deps/types e.g. @nestjs/bullmq, bullmq, helmet)
- pnpm --dir packages/backend build ❌ (same pre-existing missing deps/types)