### PR TITLE
Implement structured OutcomeManager errors

### DIFF
--- a/packages/contracts/outcome_manager/src/errors.rs
+++ b/packages/contracts/outcome_manager/src/errors.rs
@@ -1,0 +1,33 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum OutcomeError {
+    AlreadyInitialized = 1,
+    InvalidQuorum = 2,
+    UnauthorizedOracle = 3,
+    AlreadySettled = 4,
+    DuplicateSubmission = 5,
+    InvalidOutcome = 6,
+    CallNotSettled = 7,
+    AlreadyClaimed = 8,
+    NothingToClaim = 9,
+    InvalidWinningStake = 10,
+    Overflow = 11,
+    CallNotFinalized = 12,
+    InvalidFeeBps = 13,
+    ContractPaused = 14,
+    MaxOraclesReached = 15,
+    SubmissionWindowExpired = 16,
+    EmptyBatch = 17,
+    LengthMismatch = 18,
+    NotInitialized = 19,
+    FeeCollectorNotSet = 20,
+    ObservationOutOfOrder = 21,
+    InsufficientPriceObservations = 22,
+    NoPriceObservations = 23,
+    ZeroTimeWindow = 24,
+    RegistryNotSet = 25,
+    DisputeWindowExpired = 26,
+}

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 mod auth;
+mod errors;
 mod events;
 mod storage;
 mod test;
@@ -10,14 +11,15 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, 
 
 use auth::require_admin;
 use backit_shared::{is_valid_fee_bps, is_valid_outcome};
+use errors::OutcomeError;
 use events::{
     emit_admin_params_changed, emit_batch_payout_started, emit_contract_upgraded,
     emit_fee_collected, emit_outcome_disputed, emit_outcome_finalized, emit_outcome_submitted,
     emit_payout_claimed, emit_price_observation_submitted,
 };
 use storage::{
-    set_dispute_window, set_max_submission_delay, InstanceKey, Outcome, OracleVote,
-    PersistentKey, PriceObservation, SignedOutcome, TempKey,
+    set_dispute_window, set_max_submission_delay, InstanceKey, OracleVote, Outcome, PersistentKey,
+    PriceObservation, SignedOutcome, TempKey,
 };
 use verification::{build_message, verify_signature};
 
@@ -65,6 +67,42 @@ fn is_paused(env: &Env) -> bool {
         .unwrap_or(false)
 }
 
+fn not_initialized<T>(env: &Env) -> T {
+    soroban_sdk::panic_with_error!(env, OutcomeError::NotInitialized);
+}
+
+fn overflow<T>(env: &Env) -> T {
+    soroban_sdk::panic_with_error!(env, OutcomeError::Overflow);
+}
+
+fn get_oracles(env: &Env) -> Map<BytesN<32>, bool> {
+    match env.storage().instance().get(&InstanceKey::Oracles) {
+        Some(oracles) => oracles,
+        None => not_initialized(env),
+    }
+}
+
+fn get_quorum(env: &Env) -> u32 {
+    match env.storage().instance().get(&InstanceKey::Quorum) {
+        Some(quorum) => quorum,
+        None => not_initialized(env),
+    }
+}
+
+fn get_fee_collector(env: &Env) -> Address {
+    match env.storage().instance().get(&InstanceKey::FeeCollector) {
+        Some(fee_collector) => fee_collector,
+        None => soroban_sdk::panic_with_error!(env, OutcomeError::FeeCollectorNotSet),
+    }
+}
+
+fn get_registry(env: &Env) -> Address {
+    match env.storage().instance().get(&InstanceKey::Registry) {
+        Some(registry) => registry,
+        None => soroban_sdk::panic_with_error!(env, OutcomeError::RegistryNotSet),
+    }
+}
+
 // ─── Contract ─────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -94,19 +132,19 @@ impl OutcomeManager {
         dispute_window_secs: u64,
     ) {
         if env.storage().instance().has(&InstanceKey::Admin) {
-            panic!("already initialized");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadyInitialized);
         }
 
         admin.require_auth();
 
         if quorum == 0 || quorum > oracles.len() as u32 {
-            panic!("invalid quorum");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidQuorum);
         }
         if oracles.len() as u32 > MAX_ORACLES {
-            panic!("too many oracles");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::MaxOraclesReached);
         }
         if !is_valid_fee_bps(fee_bps) {
-            panic!("invalid fee_bps");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidFeeBps);
         }
 
         let mut oracle_map = Map::<BytesN<32>, bool>::new(&env);
@@ -128,15 +166,16 @@ impl OutcomeManager {
         env.storage().instance().set(&InstanceKey::FeeBps, &fee_bps);
         set_dispute_window(&env, dispute_window_secs);
         set_max_submission_delay(&env, 86400);
-        env.storage().instance().set(&InstanceKey::Version, &CONTRACT_VERSION);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Version, &CONTRACT_VERSION);
     }
 
     // ── Admin Controls ─────────────────────────────────────────────────────────
 
     pub fn add_oracle(env: Env, oracle: BytesN<32>) {
         require_admin(&env);
-        let mut oracles: Map<BytesN<32>, bool> =
-            env.storage().instance().get(&InstanceKey::Oracles).unwrap();
+        let mut oracles = get_oracles(&env);
         let mut oracle_list: Vec<BytesN<32>> = env
             .storage()
             .instance()
@@ -147,7 +186,7 @@ impl OutcomeManager {
             return;
         }
         if oracle_list.len() as u32 >= MAX_ORACLES {
-            panic!("max oracles reached");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::MaxOraclesReached);
         }
         oracles.set(oracle.clone(), true);
         oracle_list.push_back(oracle);
@@ -161,8 +200,7 @@ impl OutcomeManager {
 
     pub fn remove_oracle(env: Env, oracle: BytesN<32>) {
         require_admin(&env);
-        let mut oracles: Map<BytesN<32>, bool> =
-            env.storage().instance().get(&InstanceKey::Oracles).unwrap();
+        let mut oracles = get_oracles(&env);
         let oracle_list: Vec<BytesN<32>> = env
             .storage()
             .instance()
@@ -186,10 +224,9 @@ impl OutcomeManager {
 
     pub fn set_quorum(env: Env, quorum: u32) {
         require_admin(&env);
-        let oracles: Map<BytesN<32>, bool> =
-            env.storage().instance().get(&InstanceKey::Oracles).unwrap();
+        let oracles = get_oracles(&env);
         if quorum == 0 || quorum > oracles.len() as u32 {
-            panic!("invalid quorum");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidQuorum);
         }
         env.storage().instance().set(&InstanceKey::Quorum, &quorum);
     }
@@ -243,14 +280,13 @@ impl OutcomeManager {
     /// - (ed25519_verify panics)  – signature is invalid; tx is reverted
     pub fn submit_outcome(env: Env, registry: Address, signed: SignedOutcome, call_end_ts: u64) {
         if is_paused(&env) {
-            panic!("contract is paused");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
         }
 
         // 1. Validate oracle
-        let oracles: Map<BytesN<32>, bool> =
-            env.storage().instance().get(&InstanceKey::Oracles).unwrap();
+        let oracles = get_oracles(&env);
         if !oracles.contains_key(signed.oracle_pubkey.clone()) {
-            panic!("unauthorized oracle");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::UnauthorizedOracle);
         }
 
         // 2. Reject if already settled
@@ -259,18 +295,18 @@ impl OutcomeManager {
             .instance()
             .has(&InstanceKey::FinalOutcome(signed.call_id))
         {
-            panic!("already settled");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadySettled);
         }
 
         // 3. Guard against duplicate oracle votes
         let submission_key = TempKey::Submission(signed.oracle_pubkey.clone(), signed.call_id);
         if env.storage().temporary().has(&submission_key) {
-            panic!("duplicate submission");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::DuplicateSubmission);
         }
 
         // 4. Validate outcome range
         if !is_valid_outcome(signed.outcome) {
-            panic!("invalid outcome: must be 1 (UP) or 2 (DOWN)");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidOutcome);
         }
 
         // 4b. Enforce submission deadline: oracle timestamp must be within
@@ -278,9 +314,9 @@ impl OutcomeManager {
         let max_delay = storage::get_max_submission_delay(&env);
         let deadline = call_end_ts
             .checked_add(max_delay)
-            .expect("overflow in submission deadline");
+            .unwrap_or_else(|| overflow(&env));
         if signed.timestamp > deadline {
-            panic!("submission outside allowed window");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::SubmissionWindowExpired);
         }
 
         // 5. Build canonical message and verify ed25519 signature
@@ -324,7 +360,7 @@ impl OutcomeManager {
         emit_outcome_submitted(&env, signed.call_id, &signed.oracle_pubkey, signed.outcome);
 
         // 9. Finalize if quorum reached
-        let quorum: u32 = env.storage().instance().get(&InstanceKey::Quorum).unwrap();
+        let quorum = get_quorum(&env);
         if votes >= quorum {
             Self::finalize(
                 &env,
@@ -391,7 +427,7 @@ impl OutcomeManager {
     ) {
         // 0. Check if contract is paused (emergency guard)
         if is_paused(&env) {
-            panic!("contract is paused");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
         }
 
         // 1. Require staker's authorization
@@ -403,21 +439,21 @@ impl OutcomeManager {
             .instance()
             .has(&InstanceKey::FinalOutcome(call_id))
         {
-            panic!("call not settled");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotSettled);
         }
 
         // 3. Prevent double-claim
         let claimed_key = InstanceKey::Claimed(call_id, staker.clone());
         if env.storage().instance().has(&claimed_key) {
-            panic!("already claimed");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadyClaimed);
         }
 
         // 4. Validate inputs
         if staker_winning_stake <= 0 {
-            panic!("nothing to claim");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
         }
         if total_winning_stake <= 0 {
-            panic!("invalid total winning stake");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidWinningStake);
         }
 
         // 5. Compute protocol fee from losing pool (only on first claim; fee is
@@ -427,40 +463,36 @@ impl OutcomeManager {
             .instance()
             .get(&InstanceKey::FeeBps)
             .unwrap_or(0);
-        let fee_collector: Address = env
-            .storage()
-            .instance()
-            .get(&InstanceKey::FeeCollector)
-            .expect("fee collector not set");
+        let fee_collector = get_fee_collector(&env);
 
         // Staker's proportional share of the total fee
         let total_fee = (total_losing_stake as i128)
             .checked_mul(fee_bps as i128)
-            .expect("overflow in fee calculation")
+            .unwrap_or_else(|| overflow(&env))
             .checked_div(10000)
-            .expect("division by zero");
+            .unwrap_or_else(|| overflow(&env));
 
         let staker_fee_share = staker_winning_stake
             .checked_mul(total_fee)
-            .expect("overflow in staker fee share")
+            .unwrap_or_else(|| overflow(&env))
             .checked_div(total_winning_stake)
-            .expect("division by zero");
+            .unwrap_or_else(|| overflow(&env));
 
         // 6. Net losing pool available to winners
         let net_losing = total_losing_stake
             .checked_sub(total_fee)
-            .expect("underflow in net losing");
+            .unwrap_or_else(|| overflow(&env));
 
         // 7. Pro-rata payout from net losing pool
         let prize_share = staker_winning_stake
             .checked_mul(net_losing)
-            .expect("overflow in prize calculation")
+            .unwrap_or_else(|| overflow(&env))
             .checked_div(total_winning_stake)
-            .expect("division by zero");
+            .unwrap_or_else(|| overflow(&env));
 
         let payout = staker_winning_stake
             .checked_add(prize_share)
-            .expect("overflow in payout sum");
+            .unwrap_or_else(|| overflow(&env));
 
         // 8. Mark as claimed BEFORE external calls (reentrancy guard)
         env.storage().instance().set(&claimed_key, &true);
@@ -478,27 +510,33 @@ impl OutcomeManager {
     }
 
     pub fn finalize_outcome(env: Env, call_id: u64) {
-        let pending: Outcome = env
+        let pending: Outcome = match env
             .storage()
             .instance()
             .get(&InstanceKey::PendingOutcome(call_id))
-            .expect("no pending outcome");
+        {
+            Some(pending) => pending,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotFinalized),
+        };
 
-        let window_start: u64 = env
+        let window_start: u64 = match env
             .storage()
             .instance()
             .get(&InstanceKey::DisputeWindowStart(call_id))
-            .expect("no window start");
+        {
+            Some(window_start) => window_start,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotFinalized),
+        };
 
         let dispute_window = storage::get_dispute_window(&env);
         if env.ledger().timestamp() < window_start + dispute_window {
-            panic!("dispute window not yet expired");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotFinalized);
         }
 
         env.storage()
             .instance()
             .set(&InstanceKey::FinalOutcome(call_id), &pending);
-        let registry = storage::get_registry(&env);
+        let registry = get_registry(&env);
         registry_resolve_call(
             &env,
             &registry,
@@ -512,21 +550,31 @@ impl OutcomeManager {
     pub fn dispute_outcome(env: Env, call_id: u64, new_outcome: u32, new_price: i128) {
         require_admin(&env);
 
-        let mut pending: Outcome = env
+        let mut pending: Outcome = match env
             .storage()
             .instance()
             .get(&InstanceKey::PendingOutcome(call_id))
-            .expect("no pending outcome");
+        {
+            Some(pending) => pending,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotFinalized),
+        };
 
-        let window_start: u64 = env
+        let window_start: u64 = match env
             .storage()
             .instance()
             .get(&InstanceKey::DisputeWindowStart(call_id))
-            .expect("no window start");
+        {
+            Some(window_start) => window_start,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotFinalized),
+        };
 
         let dispute_window = storage::get_dispute_window(&env);
         if env.ledger().timestamp() >= window_start + dispute_window {
-            panic!("dispute window has expired");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::DisputeWindowExpired);
+        }
+
+        if !is_valid_outcome(new_outcome) {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidOutcome);
         }
 
         pending.outcome = new_outcome;
@@ -572,22 +620,22 @@ impl OutcomeManager {
             .instance()
             .has(&InstanceKey::FinalOutcome(call_id))
         {
-            panic!("call not settled");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotSettled);
         }
 
         // 3. Reject empty batches
         if stakers.is_empty() {
-            panic!("empty batch");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::EmptyBatch);
         }
 
         // 4. Vecs must be same length
         if stakers.len() != stakes.len() {
-            panic!("length mismatch");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::LengthMismatch);
         }
 
         // 5. Validate shared inputs once
         if total_winning_stake <= 0 {
-            panic!("invalid total winning stake");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidWinningStake);
         }
 
         // 6. Load fee config once
@@ -596,22 +644,18 @@ impl OutcomeManager {
             .instance()
             .get(&InstanceKey::FeeBps)
             .unwrap_or(0);
-        let fee_collector: Address = env
-            .storage()
-            .instance()
-            .get(&InstanceKey::FeeCollector)
-            .expect("fee collector not set");
+        let fee_collector = get_fee_collector(&env);
 
         // Pre-compute shared fee values
         let total_fee = (total_losing_stake as i128)
             .checked_mul(fee_bps as i128)
-            .expect("overflow in fee calculation")
+            .unwrap_or_else(|| overflow(&env))
             .checked_div(10000)
-            .expect("division by zero");
+            .unwrap_or_else(|| overflow(&env));
 
         let net_losing = total_losing_stake
             .checked_sub(total_fee)
-            .expect("underflow in net losing");
+            .unwrap_or_else(|| overflow(&env));
 
         emit_batch_payout_started(&env, call_id, stakers.len());
 
@@ -621,32 +665,32 @@ impl OutcomeManager {
             let staker_winning_stake = stakes.get(i).unwrap();
 
             if staker_winning_stake <= 0 {
-                panic!("nothing to claim");
+                soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
             }
 
             // Guard against duplicates within the batch and prior claims
             let claimed_key = InstanceKey::Claimed(call_id, staker.clone());
             if env.storage().instance().has(&claimed_key) {
-                panic!("already claimed");
+                soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadyClaimed);
             }
 
             // Staker's proportional fee share
             let staker_fee_share = staker_winning_stake
                 .checked_mul(total_fee)
-                .expect("overflow in staker fee share")
+                .unwrap_or_else(|| overflow(&env))
                 .checked_div(total_winning_stake)
-                .expect("division by zero");
+                .unwrap_or_else(|| overflow(&env));
 
             // Pro-rata payout from net losing pool
             let prize_share = staker_winning_stake
                 .checked_mul(net_losing)
-                .expect("overflow in prize calculation")
+                .unwrap_or_else(|| overflow(&env))
                 .checked_div(total_winning_stake)
-                .expect("division by zero");
+                .unwrap_or_else(|| overflow(&env));
 
             let payout = staker_winning_stake
                 .checked_add(prize_share)
-                .expect("overflow in payout sum");
+                .unwrap_or_else(|| overflow(&env));
 
             // Mark claimed BEFORE external calls (reentrancy guard)
             env.storage().instance().set(&claimed_key, &true);
@@ -677,7 +721,7 @@ impl OutcomeManager {
             .instance()
             .has(&InstanceKey::FinalOutcome(call_id))
         {
-            panic!("call not finalized");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotFinalized);
         }
 
         registry_mark_settled(&env, &registry, call_id);
@@ -687,10 +731,14 @@ impl OutcomeManager {
 
     /// Return the finalized outcome, or panic if not yet settled.
     pub fn get_outcome(env: Env, call_id: u64) -> Outcome {
-        env.storage()
+        match env
+            .storage()
             .instance()
             .get(&InstanceKey::FinalOutcome(call_id))
-            .expect("call not settled")
+        {
+            Some(outcome) => outcome,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotSettled),
+        }
     }
 
     /// `true` if the staker has already claimed their payout for this call.
@@ -702,19 +750,12 @@ impl OutcomeManager {
 
     /// Return the current quorum threshold.
     pub fn get_quorum(env: Env) -> u32 {
-        env.storage()
-            .instance()
-            .get(&InstanceKey::Quorum)
-            .expect("not initialized")
+        get_quorum(&env)
     }
 
     /// Return whether a given oracle pubkey is trusted.
     pub fn is_oracle(env: Env, oracle: BytesN<32>) -> bool {
-        let oracles: Map<BytesN<32>, bool> = env
-            .storage()
-            .instance()
-            .get(&InstanceKey::Oracles)
-            .expect("not initialized");
+        let oracles = get_oracles(&env);
         oracles.contains_key(oracle)
     }
 
@@ -759,11 +800,10 @@ impl OutcomeManager {
     /// # Panics
     /// - `not initialized` if the contract has not been initialized.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&InstanceKey::Admin)
-            .expect("not initialized");
+        let admin: Address = match env.storage().instance().get(&InstanceKey::Admin) {
+            Some(admin) => admin,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::NotInitialized),
+        };
         admin.require_auth();
 
         let old_version: u32 = env
@@ -797,13 +837,9 @@ impl OutcomeManager {
         signature: BytesN<64>,
     ) {
         // 1. Validate oracle
-        let oracles: Map<BytesN<32>, bool> = env
-            .storage()
-            .instance()
-            .get(&InstanceKey::Oracles)
-            .expect("not initialized");
+        let oracles = get_oracles(&env);
         if !oracles.contains_key(oracle_pubkey.clone()) {
-            panic!("unauthorized oracle");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::UnauthorizedOracle);
         }
 
         // 2. Build canonical message and verify ed25519 signature
@@ -811,7 +847,10 @@ impl OutcomeManager {
         let mut raw = Bytes::from_slice(&env, b"twap_obs:");
         raw.append(&Bytes::from_slice(&env, &call_id.to_be_bytes()));
         raw.append(&Bytes::from_slice(&env, &observation.price.to_be_bytes()));
-        raw.append(&Bytes::from_slice(&env, &observation.timestamp.to_be_bytes()));
+        raw.append(&Bytes::from_slice(
+            &env,
+            &observation.timestamp.to_be_bytes(),
+        ));
         verify_signature(&env, &oracle_pubkey, &signature, &raw);
 
         // 3. Load existing observations or start fresh
@@ -825,7 +864,7 @@ impl OutcomeManager {
         // 4. Enforce monotonically increasing timestamps
         if let Some(last) = observations.last() {
             if observation.timestamp <= last.timestamp {
-                panic!("observation timestamp must be strictly increasing");
+                soroban_sdk::panic_with_error!(&env, OutcomeError::ObservationOutOfOrder);
             }
         }
 
@@ -848,15 +887,14 @@ impl OutcomeManager {
     /// - `zero time window`                      - all timestamps identical
     pub fn compute_twap(env: Env, call_id: u64) -> i128 {
         let key = TempKey::PriceObservations(call_id);
-        let observations: Vec<PriceObservation> = env
-            .storage()
-            .temporary()
-            .get(&key)
-            .expect("no price observations for call");
+        let observations: Vec<PriceObservation> = match env.storage().temporary().get(&key) {
+            Some(observations) => observations,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::NoPriceObservations),
+        };
 
         let n = observations.len();
         if n < 3 {
-            panic!("minimum 3 price observations required");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InsufficientPriceObservations);
         }
 
         let mut weighted_sum: i128 = 0;
@@ -866,22 +904,21 @@ impl OutcomeManager {
             let obs_i = observations.get(i).unwrap();
             let obs_next = observations.get(i + 1).unwrap();
             let dt = (obs_next.timestamp - obs_i.timestamp) as i128;
-            weighted_sum = obs_i.price
+            weighted_sum = obs_i
+                .price
                 .checked_mul(dt)
-                .expect("overflow in TWAP weighted sum")
+                .unwrap_or_else(|| overflow(&env))
                 .checked_add(weighted_sum)
-                .expect("overflow accumulating weighted sum");
-            total_time = total_time
-                .checked_add(dt)
-                .expect("overflow in total time window");
+                .unwrap_or_else(|| overflow(&env));
+            total_time = total_time.checked_add(dt).unwrap_or_else(|| overflow(&env));
         }
 
         if total_time == 0 {
-            panic!("zero time window");
+            soroban_sdk::panic_with_error!(&env, OutcomeError::ZeroTimeWindow);
         }
 
         weighted_sum
             .checked_div(total_time)
-            .expect("division error in TWAP")
+            .unwrap_or_else(|| overflow(&env))
     }
 }

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -1,11 +1,8 @@
 #![cfg(test)]
 
-use soroban_sdk::{
-    contract, contractimpl,
-    testutils::Address as _,
-    Address, BytesN, Env, Vec,
-};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, BytesN, Env, Vec};
 
+use crate::errors::OutcomeError;
 use crate::storage::{OracleVote, PriceObservation, SignedOutcome};
 use crate::{OutcomeManager, OutcomeManagerClient, MAX_ORACLES};
 
@@ -94,8 +91,17 @@ fn setup_single_oracle(
     (admin, registry_id, oracle_secret, oracle_pubkey, client)
 }
 
-// ─── Initialization Tests ──────────────────────────────────────────────────────
+fn assert_contract_error<T, E>(
+    result: Result<Result<T, E>, Result<soroban_sdk::Error, soroban_sdk::InvokeError>>,
+    expected: OutcomeError,
+) {
+    assert!(matches!(
+        result,
+        Err(Ok(err)) if err == soroban_sdk::Error::from_contract_error(expected as u32)
+    ));
+}
 
+// ─── Initialization Tests ──────────────────────────────────────────────────────
 
 fn sign_observation(
     env: &Env,
@@ -133,7 +139,10 @@ fn test_twap_three_equal_intervals() {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
         client.submit_price_observation(
             &call_id,
-            &PriceObservation { price, timestamp: ts },
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
             &oracle_pubkey,
             &sig,
         );
@@ -152,7 +161,10 @@ fn test_twap_unequal_intervals() {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
         client.submit_price_observation(
             &call_id,
-            &PriceObservation { price, timestamp: ts },
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
             &oracle_pubkey,
             &sig,
         );
@@ -161,7 +173,6 @@ fn test_twap_unequal_intervals() {
 }
 
 #[test]
-#[should_panic(expected = "minimum 3 price observations required")]
 fn test_twap_requires_minimum_3_observations() {
     let env = Env::default();
     let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
@@ -170,16 +181,19 @@ fn test_twap_requires_minimum_3_observations() {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
         client.submit_price_observation(
             &call_id,
-            &PriceObservation { price, timestamp: ts },
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
             &oracle_pubkey,
             &sig,
         );
     }
-    client.compute_twap(&call_id);
+    let result = client.try_compute_twap(&call_id);
+    assert_contract_error(result, OutcomeError::InsufficientPriceObservations);
 }
 
 #[test]
-#[should_panic(expected = "observation timestamp must be strictly increasing")]
 fn test_twap_rejects_non_increasing_timestamp() {
     let env = Env::default();
     let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
@@ -187,17 +201,24 @@ fn test_twap_rejects_non_increasing_timestamp() {
     let sig1 = sign_observation(&env, &oracle_secret, call_id, 100, 1000);
     client.submit_price_observation(
         &call_id,
-        &PriceObservation { price: 100, timestamp: 1000 },
+        &PriceObservation {
+            price: 100,
+            timestamp: 1000,
+        },
         &oracle_pubkey,
         &sig1,
     );
     let sig2 = sign_observation(&env, &oracle_secret, call_id, 200, 1000);
-    client.submit_price_observation(
+    let result = client.try_submit_price_observation(
         &call_id,
-        &PriceObservation { price: 200, timestamp: 1000 },
+        &PriceObservation {
+            price: 200,
+            timestamp: 1000,
+        },
         &oracle_pubkey,
         &sig2,
     );
+    assert_contract_error(result, OutcomeError::ObservationOutOfOrder);
 }
 
 #[test]
@@ -221,7 +242,6 @@ fn test_initialize_success() {
 }
 
 #[test]
-#[should_panic(expected = "already initialized")]
 fn test_initialize_twice_fails() {
     let env = Env::default();
     let (admin, _, _, pubkey, client) = setup_single_oracle(&env);
@@ -229,11 +249,11 @@ fn test_initialize_twice_fails() {
     let fee_collector = Address::generate(&env);
     let mut oracles = Vec::new(&env);
     oracles.push_back(pubkey);
-    client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
+    let result = client.try_initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
+    assert_contract_error(result, OutcomeError::AlreadyInitialized);
 }
 
 #[test]
-#[should_panic(expected = "invalid quorum")]
 fn test_initialize_quorum_zero_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -246,7 +266,8 @@ fn test_initialize_quorum_zero_fails() {
     let fee_collector = Address::generate(&env);
     let mut oracles = Vec::new(&env);
     oracles.push_back(pubkey);
-    client.initialize(&admin, &oracles, &0u32, &fee_collector, &0u32, &0u64);
+    let result = client.try_initialize(&admin, &oracles, &0u32, &fee_collector, &0u32, &0u64);
+    assert_contract_error(result, OutcomeError::InvalidQuorum);
 }
 
 // ─── Oracle Submission & Verification Tests ────────────────────────────────────
@@ -332,7 +353,6 @@ fn test_quorum_reached_with_two_oracles() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized oracle")]
 fn test_submit_unauthorized_oracle_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -342,7 +362,7 @@ fn test_submit_unauthorized_oracle_fails() {
     let call_id = 1u64;
     let sig = sign_outcome(&env, &secret2, call_id, 1, 100, 9000);
 
-    client.submit_outcome(
+    let result = client.try_submit_outcome(
         &mock_registry,
         &SignedOutcome {
             call_id,
@@ -354,6 +374,79 @@ fn test_submit_unauthorized_oracle_fails() {
         },
         &0u64,
     );
+    assert_contract_error(result, OutcomeError::UnauthorizedOracle);
+}
+
+#[test]
+fn test_submit_duplicate_submission_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (secret1, pubkey1) = gen_keypair(&env);
+    let (_, pubkey2) = gen_keypair(&env);
+
+    let contract_id = env.register_contract(None, OutcomeManager);
+    let client = OutcomeManagerClient::new(&env, &contract_id);
+
+    let mut oracles = Vec::new(&env);
+    oracles.push_back(pubkey1.clone());
+    oracles.push_back(pubkey2);
+    let fee_collector = Address::generate(&env);
+    client.initialize(&admin, &oracles, &2u32, &fee_collector, &0u32, &0u64);
+
+    let registry_id = env.register_contract(None, MockRegistry);
+    let signed = SignedOutcome {
+        call_id: 7,
+        outcome: 1,
+        price: 100,
+        timestamp: 1000,
+        oracle_pubkey: pubkey1.clone(),
+        signature: sign_outcome(&env, &secret1, 7, 1, 100, 1000),
+    };
+
+    client.submit_outcome(&registry_id, &signed, &0u64);
+    let result = client.try_submit_outcome(&registry_id, &signed, &0u64);
+    assert_contract_error(result, OutcomeError::DuplicateSubmission);
+}
+
+#[test]
+fn test_submit_invalid_outcome_fails() {
+    let env = Env::default();
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    let result = client.try_submit_outcome(
+        &registry_id,
+        &SignedOutcome {
+            call_id: 8,
+            outcome: 3,
+            price: 100,
+            timestamp: 1000,
+            oracle_pubkey: oracle_pubkey.clone(),
+            signature: sign_outcome(&env, &oracle_secret, 8, 3, 100, 1000),
+        },
+        &0u64,
+    );
+    assert_contract_error(result, OutcomeError::InvalidOutcome);
+}
+
+#[test]
+fn test_submit_outcome_after_settlement_fails() {
+    let env = Env::default();
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    let signed = SignedOutcome {
+        call_id: 9,
+        outcome: 1,
+        price: 100,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_outcome(&env, &oracle_secret, 9, 1, 100, 1000),
+    };
+
+    client.submit_outcome(&registry_id, &signed, &0u64);
+    let result = client.try_submit_outcome(&registry_id, &signed, &0u64);
+    assert_contract_error(result, OutcomeError::AlreadySettled);
 }
 
 // ─── Admin Control Tests ───────────────────────────────────────────────────────
@@ -395,7 +488,6 @@ fn test_get_oracles_tracks_add_remove() {
 }
 
 #[test]
-#[should_panic(expected = "max oracles reached")]
 fn test_add_oracle_enforces_max_limit() {
     let env = Env::default();
     env.mock_all_auths();
@@ -412,7 +504,8 @@ fn test_add_oracle_enforces_max_limit() {
 
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
     let (_, extra_pubkey) = gen_keypair(&env);
-    client.add_oracle(&extra_pubkey);
+    let result = client.try_add_oracle(&extra_pubkey);
+    assert_contract_error(result, OutcomeError::MaxOraclesReached);
 }
 
 #[test]
@@ -478,11 +571,11 @@ fn test_payout_calculation_single_winner_takes_all() {
 }
 
 #[test]
-#[should_panic(expected = "call not settled")]
 fn test_get_outcome_unsettled_panics() {
     let env = Env::default();
     let (_, _, _, _, client) = setup_single_oracle(&env);
-    client.get_outcome(&999u64);
+    let result = client.try_get_outcome(&999u64);
+    assert_contract_error(result, OutcomeError::CallNotSettled);
 }
 
 // ─── Fee Deduction Tests ───────────────────────────────────────────────────────
@@ -586,7 +679,6 @@ fn test_fee_goes_to_correct_address() {
 }
 
 #[test]
-#[should_panic(expected = "invalid fee_bps")]
 fn test_invalid_fee_bps_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -599,7 +691,8 @@ fn test_invalid_fee_bps_panics() {
 
     let mut oracles = Vec::new(&env);
     oracles.push_back(pubkey);
-    client.initialize(&admin, &oracles, &1u32, &fee_collector, &10001u32, &0u64);
+    let result = client.try_initialize(&admin, &oracles, &1u32, &fee_collector, &10001u32, &0u64);
+    assert_contract_error(result, OutcomeError::InvalidFeeBps);
 }
 
 // ─── Batch Payout Tests ────────────────────────────────────────────────────────
@@ -632,7 +725,6 @@ fn test_batch_claim_payouts_three_stakers() {
 }
 
 #[test]
-#[should_panic(expected = "already claimed")]
 fn test_batch_claim_panics_on_duplicate_staker() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
@@ -648,11 +740,12 @@ fn test_batch_claim_panics_on_duplicate_staker() {
     client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
 
     // Second batch with same staker — must panic
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
+    let result =
+        client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
+    assert_contract_error(result, OutcomeError::AlreadyClaimed);
 }
 
 #[test]
-#[should_panic(expected = "empty batch")]
 fn test_batch_claim_panics_on_empty_batch() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
@@ -660,11 +753,18 @@ fn test_batch_claim_panics_on_empty_batch() {
     let stakers: Vec<Address> = Vec::new(&env);
     let stakes: Vec<i128> = Vec::new(&env);
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    let result = client.try_batch_claim_payouts(
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
+    );
+    assert_contract_error(result, OutcomeError::EmptyBatch);
 }
 
 #[test]
-#[should_panic(expected = "length mismatch")]
 fn test_batch_claim_panics_on_length_mismatch() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
@@ -676,11 +776,12 @@ fn test_batch_claim_panics_on_length_mismatch() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128); // one fewer than stakers
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
+    let result =
+        client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
+    assert_contract_error(result, OutcomeError::LengthMismatch);
 }
 
 #[test]
-#[should_panic(expected = "call not settled")]
 fn test_batch_claim_panics_on_unsettled_call() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
@@ -691,7 +792,15 @@ fn test_batch_claim_panics_on_unsettled_call() {
     stakes.push_back(50_i128);
 
     // call_id=999 was never finalized
-    client.batch_claim_payouts(&registry_id, &999u64, &stakers, &stakes, &50_i128, &50_i128);
+    let result = client.try_batch_claim_payouts(
+        &registry_id,
+        &999u64,
+        &stakers,
+        &stakes,
+        &50_i128,
+        &50_i128,
+    );
+    assert_contract_error(result, OutcomeError::CallNotSettled);
 }
 
 #[test]
@@ -719,7 +828,14 @@ fn test_batch_claim_with_fee_deducted() {
     let _ = fee_collector;
 }
 
+#[test]
+fn test_mark_settled_requires_finalized_outcome() {
+    let env = Env::default();
+    let (_admin, registry_id, _oracle_secret, _oracle_pubkey, client) = setup_single_oracle(&env);
 
+    let result = client.try_mark_settled(&registry_id, &999u64);
+    assert_contract_error(result, OutcomeError::CallNotFinalized);
+}
 
 // -- upgrade / version -------------------------------------------------------
 #[test]
@@ -730,7 +846,6 @@ fn test_om_version_returns_contract_version() {
 }
 
 #[test]
-#[should_panic(expected = "not initialized")]
 fn test_om_upgrade_requires_admin_auth() {
     // upgrade() reads admin from instance storage before calling require_auth().
     // Calling it before initialize() panics with "not initialized", proving
@@ -740,7 +855,8 @@ fn test_om_upgrade_requires_admin_auth() {
     let contract_id = env.register_contract(None, OutcomeManager);
     let client = OutcomeManagerClient::new(&env, &contract_id);
     let fake_hash = BytesN::<32>::from_array(&env, &[0u8; 32]);
-    client.upgrade(&fake_hash); // panics: "not initialized"
+    let result = client.try_upgrade(&fake_hash);
+    assert_contract_error(result, OutcomeError::NotInitialized);
 }
 
 // -- Fuzz / property tests for claim_payout arithmetic -----------------------
@@ -767,17 +883,17 @@ fn test_fuzz_payout_many_ratios_no_panic() {
     // Representative matrix of ratios; none should overflow or panic
     let cases: &[(i128, i128, i128, u32)] = &[
         // (staker_winning, total_winning, total_losing, fee_bps)
-        (1,              1,                  0,          0),
-        (1,              1,                  1,          0),
-        (1,              1,                  1,       1000),
-        (1,              1,                  1,       5000),
-        (1,          1_000,          1_000_000,        100),
-        (500,        1_000,          1_000_000,        500),
-        (1_000,      1_000,                  1,          0),
-        (1_000_000,  1_000_000,      1_000_000,      1_000),
-        (1,              1,  1_000_000_000_000,          0),
-        (1, 1_000_000_000_000, 1_000_000_000_000,        0),
-        (500,        1_000,              1_000,       5_000),
+        (1, 1, 0, 0),
+        (1, 1, 1, 0),
+        (1, 1, 1, 1000),
+        (1, 1, 1, 5000),
+        (1, 1_000, 1_000_000, 100),
+        (500, 1_000, 1_000_000, 500),
+        (1_000, 1_000, 1, 0),
+        (1_000_000, 1_000_000, 1_000_000, 1_000),
+        (1, 1, 1_000_000_000_000, 0),
+        (1, 1_000_000_000_000, 1_000_000_000_000, 0),
+        (500, 1_000, 1_000, 5_000),
     ];
     for &(sw, tw, tl, fee) in cases {
         fuzz_claim_setup(sw, tw, tl, fee);
@@ -797,14 +913,7 @@ fn test_fuzz_100_winners_batch_all_claimed() {
         stakes.push_back(1_i128);
     }
 
-    client.batch_claim_payouts(
-        &registry_id,
-        &1u64,
-        &stakers,
-        &stakes,
-        &100_i128,
-        &100_i128,
-    );
+    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
 
     for i in 0..100u32 {
         assert!(client.has_claimed(&1u64, &stakers.get(i).unwrap()));
@@ -841,15 +950,21 @@ fn test_fuzz_asymmetric_1_trillion_vs_1() {
 }
 
 #[test]
-#[should_panic]
 fn test_fuzz_zero_staker_stake_panics() {
-    fuzz_claim_setup(0, 1, 1, 0);
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let result = client.try_claim_payout(&registry_id, &1u64, &staker, &0, &1, &1);
+    assert_contract_error(result, OutcomeError::NothingToClaim);
 }
 
 #[test]
-#[should_panic]
 fn test_fuzz_zero_total_winning_panics() {
-    fuzz_claim_setup(1, 0, 1, 0);
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let result = client.try_claim_payout(&registry_id, &1u64, &staker, &1, &0, &1);
+    assert_contract_error(result, OutcomeError::InvalidWinningStake);
 }
 
 // ─── Pause Mechanism Tests ─────────────────────────────────────────────────────
@@ -870,7 +985,6 @@ fn test_pause_and_unpause() {
 }
 
 #[test]
-#[should_panic(expected = "contract is paused")]
 fn test_submit_outcome_fails_when_paused() {
     let env = Env::default();
     let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
@@ -887,11 +1001,11 @@ fn test_submit_outcome_fails_when_paused() {
         signature: sign_outcome(&env, &oracle_secret, 1, 1, 100, 1000),
     };
 
-    client.submit_outcome(&registry_id, &signed, &0u64);
+    let result = client.try_submit_outcome(&registry_id, &signed, &0u64);
+    assert_contract_error(result, OutcomeError::ContractPaused);
 }
 
 #[test]
-#[should_panic(expected = "contract is paused")]
 fn test_claim_payout_fails_when_paused() {
     let env = Env::default();
     let (_admin, registry_id, _oracle_secret, _oracle_pubkey, client) = setup_single_oracle(&env);
@@ -900,7 +1014,7 @@ fn test_claim_payout_fails_when_paused() {
     env.mock_all_auths();
     client.pause();
 
-    client.claim_payout(
+    let result = client.try_claim_payout(
         &registry_id,
         &1u64,
         &staker,
@@ -908,6 +1022,7 @@ fn test_claim_payout_fails_when_paused() {
         &100_i128,
         &100_i128,
     );
+    assert_contract_error(result, OutcomeError::ContractPaused);
 }
 
 // ─── Oracle Submission Deadline Tests ─────────────────────────────────────────
@@ -939,7 +1054,6 @@ fn test_submission_within_window_succeeds() {
 }
 
 #[test]
-#[should_panic(expected = "submission outside allowed window")]
 fn test_submission_outside_window_fails() {
     let env = Env::default();
     let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
@@ -951,7 +1065,7 @@ fn test_submission_outside_window_fails() {
     let call_end_ts = 1000u64;
     // timestamp 1200 > call_end_ts(1000) + max_delay(50) = 1050
     let sig = sign_outcome(&env, &oracle_secret, call_id, 1, 100, 1200);
-    client.submit_outcome(
+    let result = client.try_submit_outcome(
         &registry_id,
         &SignedOutcome {
             call_id,
@@ -963,6 +1077,7 @@ fn test_submission_outside_window_fails() {
         },
         &call_end_ts,
     );
+    assert_contract_error(result, OutcomeError::SubmissionWindowExpired);
 }
 
 #[test]
@@ -975,4 +1090,3 @@ fn test_admin_can_update_max_submission_delay() {
     client.set_max_submission_delay(&3600u64);
     assert_eq!(client.get_max_submission_delay(), 3600u64);
 }
-


### PR DESCRIPTION
Closes #150

---

Closes: #150 

## Summary
- add OutcomeError for the outcome_manager contract and preserve the requested core error codes
- replace panic!() paths in the contract with structured panic_with_error!() handling plus overflow/not-initialized helpers
- update OutcomeManager tests to assert Soroban contract error codes via 	ry_* calls
