### PR TITLE
feat(call_registry): implement SEP-10 on-chain authentication verification

### DIFF
--- a/packages/contracts/call_registry/src/errors.rs
+++ b/packages/contracts/call_registry/src/errors.rs
@@ -34,4 +34,6 @@ pub enum CallRegistryError {
     FeeTooHigh = 14,
     /// Staking attempted within the cutoff window before `end_ts`.
     StakingCutoffActive = 15,
+    /// The SEP-10 token's `valid_until` ledger sequence has passed.
+    Sep10TokenExpired = 16,
 }

--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -332,3 +332,11 @@ pub fn emit_shares_transferred(
         (call_id, from.clone(), to.clone(), outcome, amount),
     );
 }
+
+/// Emitted when a user successfully links their SEP-10-verified home domain.
+pub fn emit_sep10_verified(env: &Env, user: &Address, home_domain: &soroban_sdk::Bytes) {
+    env.events().publish(
+        ("call_registry", "sep10_verified"),
+        (user.clone(), home_domain.clone()),
+    );
+}

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -45,6 +45,7 @@ mod errors;
 mod events;
 #[cfg(test)]
 mod fuzz_tests;
+mod sep10;
 mod shares;
 mod storage;
 #[cfg(test)]
@@ -1102,5 +1103,57 @@ impl CallRegistry {
     /// Returns `true` when `addr` is the native XLM sentinel.
     pub fn is_native_xlm_address(env: Env, addr: Address) -> bool {
         is_native_xlm(&env, &addr)
+    }
+
+    // ── SEP-10 authentication ─────────────────────────────────────────────────
+
+    /// Verify a SEP-10 ed25519 token against a public key (view — no state change).
+    ///
+    /// Returns `true` if the signature is valid and the token has not expired.
+    /// Returns `false` if `valid_until` < current ledger sequence (expired).
+    /// Panics if the ed25519 signature is cryptographically invalid.
+    pub fn verify_sep10_token(
+        env: Env,
+        public_key: BytesN<32>,
+        token: BytesN<64>,
+        valid_until: u32,
+        home_domain: Bytes,
+    ) -> bool {
+        sep10::verify_sep10_token_impl(&env, &public_key, &token, valid_until, &home_domain)
+    }
+
+    /// Verify a SEP-10 token and permanently store the `home_domain` for `user`.
+    ///
+    /// Requires both a Soroban transaction signature (`user.require_auth()`) and
+    /// a valid SEP-10 token for identity binding (KYC / reputation tracking).
+    /// Emits `Sep10Verified(user, home_domain)` on success.
+    ///
+    /// # Errors
+    /// * [`CallRegistryError::Sep10TokenExpired`] – token's `valid_until` has passed.
+    pub fn link_sep10_domain(
+        env: Env,
+        user: Address,
+        public_key: BytesN<32>,
+        token: BytesN<64>,
+        valid_until: u32,
+        home_domain: Bytes,
+    ) -> Result<(), CallRegistryError> {
+        user.require_auth();
+
+        if !sep10::verify_sep10_token_impl(&env, &public_key, &token, valid_until, &home_domain) {
+            return Err(CallRegistryError::Sep10TokenExpired);
+        }
+
+        set_sep10_domain(&env, &user, &home_domain);
+        emit_sep10_verified(&env, &user, &home_domain);
+        extend_storage_ttl(&env);
+
+        Ok(())
+    }
+
+    /// Return the SEP-10-verified `home_domain` for a user, if they have linked one.
+    /// Returns `None` if the user has never called `link_sep10_domain`.
+    pub fn get_sep10_home_domain(env: Env, user: Address) -> Option<Bytes> {
+        get_sep10_domain(&env, &user)
     }
 }

--- a/packages/contracts/call_registry/src/sep10.rs
+++ b/packages/contracts/call_registry/src/sep10.rs
@@ -1,0 +1,45 @@
+use soroban_sdk::{Bytes, BytesN, Env};
+
+/// Canonical prefix for all SEP-10 challenge messages built by this contract.
+pub const SEP10_MESSAGE_PREFIX: &[u8] = b"BACKit:SEP10:";
+
+/// Build the canonical SEP-10 challenge message that a wallet must sign.
+///
+/// Format (all big-endian):
+///   `b"BACKit:SEP10:"` | valid_until(8B) | `b":"` | home_domain
+///
+/// Mirrors the pattern used by `backit_shared::build_message` for oracle sigs.
+pub fn build_sep10_message(env: &Env, valid_until: u32, home_domain: &Bytes) -> Bytes {
+    let mut msg = Bytes::new(env);
+    msg.append(&Bytes::from_slice(env, SEP10_MESSAGE_PREFIX));
+    msg.append(&Bytes::from_slice(env, &valid_until.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(home_domain);
+    msg
+}
+
+/// Verify a SEP-10 ed25519 token against a public key.
+///
+/// Returns `false` if the token has expired (current ledger sequence > `valid_until`).
+/// Panics if the signature is cryptographically invalid — consistent with Soroban
+/// auth patterns where `ed25519_verify` aborts the transaction on failure.
+///
+/// # Arguments
+/// * `public_key`   – 32-byte ed25519 public key (the user's Stellar account key).
+/// * `token`        – 64-byte ed25519 signature over the SEP-10 challenge message.
+/// * `valid_until`  – Ledger sequence number after which the token is expired.
+/// * `home_domain`  – Optional domain bytes included in the signed message.
+pub fn verify_sep10_token_impl(
+    env: &Env,
+    public_key: &BytesN<32>,
+    token: &BytesN<64>,
+    valid_until: u32,
+    home_domain: &Bytes,
+) -> bool {
+    if env.ledger().sequence() > valid_until {
+        return false;
+    }
+    let message = build_sep10_message(env, valid_until, home_domain);
+    env.crypto().ed25519_verify(public_key, &message, token);
+    true
+}

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::types::{Call, ContractConfig, CreatorStats, GlobalStats, StorageStats};
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, Address, Bytes, Env};
 
 // ~120 days in ledgers (5s per ledger): 120 * 24 * 3600 / 5 = 2_073_600
 pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 1_036_800; // ~60 days
@@ -24,6 +24,7 @@ pub enum DataKey {
     DownStakerCount(u64),
     VoidRefundClaimed(u64, Address),
     InstanceEntryCount,
+    Sep10Domain(Address),
 }
 
 /// Store contract configuration
@@ -345,4 +346,21 @@ pub fn get_storage_stats(env: &Env) -> StorageStats {
         instance_entry_count,
         estimated_instance_bytes: instance_entry_count * 128,
     }
+}
+
+/// Persist a verified SEP-10 home_domain for a user.
+pub fn set_sep10_domain(env: &Env, user: &Address, domain: &Bytes) {
+    let key = DataKey::Sep10Domain(user.clone());
+    env.storage().persistent().set(&key, domain);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+/// Retrieve a user's verified SEP-10 home_domain, if any.
+pub fn get_sep10_domain(env: &Env, user: &Address) -> Option<Bytes> {
+    let key = DataKey::Sep10Domain(user.clone());
+    env.storage().persistent().get(&key)
 }

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+extern crate std;
+
 use soroban_sdk::{
     contract, contractimpl,
     testutils::{Address as _, Events as _, Ledger as _, MockAuth, MockAuthInvoke},
@@ -2289,5 +2291,164 @@ mod native_xlm {
         let down_stake = client.get_staker_stake(&call.id, &staker, &2u32);
         assert_eq!(up_stake, half_xlm);
         assert_eq!(down_stake, quarter_xlm);
+    }
+}
+
+// ── SEP-10 tests ─────────────────────────────────────────────────────────────
+
+mod sep10_tests {
+    use super::*;
+    use crate::{CallRegistry, CallRegistryClient};
+    use ed25519_dalek::{Signer, SigningKey};
+    use soroban_sdk::{testutils::Ledger as _, Address, Bytes, BytesN, Env};
+
+    fn build_message_native(valid_until: u32, home_domain: &[u8]) -> std::vec::Vec<u8> {
+        let mut msg = std::vec::Vec::new();
+        msg.extend_from_slice(b"BACKit:SEP10:");
+        msg.extend_from_slice(&valid_until.to_be_bytes());
+        msg.extend_from_slice(b":");
+        msg.extend_from_slice(home_domain);
+        msg
+    }
+
+    fn make_signing_key(seed_byte: u8) -> SigningKey {
+        let mut seed = [0u8; 32];
+        seed[0] = seed_byte;
+        SigningKey::from_bytes(&seed)
+    }
+
+    fn pubkey_to_soroban(env: &Env, signing_key: &SigningKey) -> BytesN<32> {
+        BytesN::from_array(env, &signing_key.verifying_key().to_bytes())
+    }
+
+    fn sign(env: &Env, signing_key: &SigningKey, valid_until: u32, home_domain: &[u8]) -> BytesN<64> {
+        let msg = build_message_native(valid_until, home_domain);
+        let sig = signing_key.sign(&msg);
+        BytesN::from_array(env, &sig.to_bytes())
+    }
+
+    fn setup() -> (Env, CallRegistryClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(CallRegistry, ());
+        let client = CallRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let outcome_manager = Address::generate(&env);
+        client.initialize(&admin, &outcome_manager, &0i128);
+        (env, client, admin, outcome_manager)
+    }
+
+    #[test]
+    fn test_verify_sep10_token_valid() {
+        let (env, client, _, _) = setup();
+        let signing_key = make_signing_key(1);
+        let valid_until: u32 = 1000;
+        let home_domain = b"example.com";
+
+        env.ledger().set_sequence_number(500);
+
+        let pubkey = pubkey_to_soroban(&env, &signing_key);
+        let token = sign(&env, &signing_key, valid_until, home_domain);
+        let domain_bytes = Bytes::from_slice(&env, home_domain);
+
+        assert!(client.verify_sep10_token(&pubkey, &token, &valid_until, &domain_bytes));
+    }
+
+    #[test]
+    fn test_verify_sep10_token_expired() {
+        let (env, client, _, _) = setup();
+        let signing_key = make_signing_key(2);
+        let valid_until: u32 = 100;
+        let home_domain = b"example.com";
+
+        env.ledger().set_sequence_number(200);
+
+        let pubkey = pubkey_to_soroban(&env, &signing_key);
+        let token = sign(&env, &signing_key, valid_until, home_domain);
+        let domain_bytes = Bytes::from_slice(&env, home_domain);
+
+        assert!(!client.verify_sep10_token(&pubkey, &token, &valid_until, &domain_bytes));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_verify_sep10_token_wrong_pubkey() {
+        let (env, client, _, _) = setup();
+        let signing_key = make_signing_key(3);
+        let wrong_key = make_signing_key(99);
+        let valid_until: u32 = 1000;
+        let home_domain = b"example.com";
+
+        env.ledger().set_sequence_number(1);
+
+        let token = sign(&env, &signing_key, valid_until, home_domain);
+        let wrong_pubkey = pubkey_to_soroban(&env, &wrong_key);
+        let domain_bytes = Bytes::from_slice(&env, home_domain);
+
+        client.verify_sep10_token(&wrong_pubkey, &token, &valid_until, &domain_bytes);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_verify_sep10_token_tampered() {
+        let (env, client, _, _) = setup();
+        let signing_key = make_signing_key(4);
+        let valid_until: u32 = 1000;
+        let home_domain = b"example.com";
+
+        env.ledger().set_sequence_number(1);
+
+        let pubkey = pubkey_to_soroban(&env, &signing_key);
+        let mut sig_bytes = signing_key.sign(&build_message_native(valid_until, home_domain)).to_bytes();
+        sig_bytes[0] ^= 0xFF;
+        let tampered_token = BytesN::from_array(&env, &sig_bytes);
+        let domain_bytes = Bytes::from_slice(&env, home_domain);
+
+        client.verify_sep10_token(&pubkey, &tampered_token, &valid_until, &domain_bytes);
+    }
+
+    #[test]
+    fn test_link_sep10_domain_stores_and_emits() {
+        let (env, client, _, _) = setup();
+        let signing_key = make_signing_key(5);
+        let user = Address::generate(&env);
+        let valid_until: u32 = 1000;
+        let home_domain = b"trader.stellar";
+
+        env.ledger().set_sequence_number(1);
+
+        let pubkey = pubkey_to_soroban(&env, &signing_key);
+        let token = sign(&env, &signing_key, valid_until, home_domain);
+        let domain_bytes = Bytes::from_slice(&env, home_domain);
+
+        client.link_sep10_domain(&user, &pubkey, &token, &valid_until, &domain_bytes);
+
+        assert_eq!(client.get_sep10_home_domain(&user), Some(domain_bytes));
+    }
+
+    #[test]
+    fn test_link_sep10_domain_expired_returns_error() {
+        let (env, client, _, _) = setup();
+        let signing_key = make_signing_key(6);
+        let user = Address::generate(&env);
+        let valid_until: u32 = 50;
+        let home_domain = b"expired.stellar";
+
+        env.ledger().set_sequence_number(100);
+
+        let pubkey = pubkey_to_soroban(&env, &signing_key);
+        let token = sign(&env, &signing_key, valid_until, home_domain);
+        let domain_bytes = Bytes::from_slice(&env, home_domain);
+
+        let result = client.try_link_sep10_domain(&user, &pubkey, &token, &valid_until, &domain_bytes);
+        assert!(result.is_err());
+        assert_eq!(client.get_sep10_home_domain(&user), None);
+    }
+
+    #[test]
+    fn test_get_sep10_home_domain_none_before_link() {
+        let (env, client, _, _) = setup();
+        let user = Address::generate(&env);
+        assert_eq!(client.get_sep10_home_domain(&user), None);
     }
 }


### PR DESCRIPTION


- Add sep10.rs with build_sep10_message() and verify_sep10_token_impl() using BACKit:SEP10: prefix format consistent with existing oracle messages
- Add verify_sep10_token() public view — returns false on expiry, panics on invalid signature (consistent with Soroban auth patterns)
- Add link_sep10_domain() — requires require_auth() + valid SEP-10 token, stores home_domain per user, emits Sep10Verified(user, home_domain)
- Add get_sep10_home_domain() view for Verified Stellar Domain badges
- Add Sep10TokenExpired = 16 to CallRegistryError
- Add DataKey::Sep10Domain(Address) with persistent TTL helpers
- Add emit_sep10_verified() event
- 7 new tests: valid token, expired (false), wrong pubkey (panic), tampered (panic), link stores domain, link expired errors, getter None

Closes #405 