### PR TITLE
docs: add comprehensive Rustdoc comments to both contracts (#395)

### DIFF
--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -94,6 +94,9 @@ pub fn emit_admin_params_changed_address(
     );
 }
 
+/// Emitted when an admin-controlled `u32` parameter changes (e.g. `fee_bps`).
+///
+/// Use the `param` field to identify which setting changed.
 pub fn emit_admin_params_changed_u32(
     env: &Env,
     param: &str,
@@ -120,6 +123,10 @@ pub fn emit_call_cancelled(env: &Env, call_id: u64, creator: &Address, refunded_
     );
 }
 
+/// Emitted when an admin-controlled `i128` parameter changes (e.g. `min_stake`,
+/// `max_stake_per_user`).
+///
+/// Use the `param` field to identify which setting changed.
 pub fn emit_admin_params_changed_i128(
     env: &Env,
     param: &str,
@@ -138,6 +145,9 @@ pub fn emit_admin_params_changed_i128(
     );
 }
 
+/// Emitted when an admin-controlled `u64` parameter changes (e.g. `staking_cutoff_secs`).
+///
+/// Use the `param` field to identify which setting changed.
 pub fn emit_admin_params_changed_u64(
     env: &Env,
     param: &str,
@@ -155,11 +165,13 @@ pub fn emit_admin_params_changed_u64(
         ),
     );
 }
+/// Emitted when a SAC token is added to the stake-token whitelist.
 pub fn emit_token_whitelisted(env: &Env, token: &Address) {
     env.events()
         .publish(("call_registry", "token_whitelisted"), token.clone());
 }
 
+/// Emitted when a SAC token is removed from the stake-token whitelist.
 pub fn emit_token_delisted(env: &Env, token: &Address) {
     env.events()
         .publish(("call_registry", "token_delisted"), token.clone());
@@ -177,6 +189,10 @@ pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
         .publish(("call_registry", "contract_unpaused"), admin.clone());
 }
 
+/// Emitted when a creator updates the metadata hash attached to their call.
+///
+/// Includes old and new hash values plus the new `metadata_version` counter
+/// so indexers can detect and skip duplicate updates.
 pub fn emit_call_metadata_updated(
     env: &Env,
     call_id: u64,

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -1,3 +1,35 @@
+//! # CallRegistry Contract
+//!
+//! The `call_registry` contract is the core escrow and prediction-market engine
+//! for BACKit on Stellar. It manages the full lifecycle of a *prediction call*:
+//!
+//! 1. **Creation** -- a user opens a call by specifying a token pair, condition,
+//!    stake amount, and deadline (`create_call`).
+//! 2. **Staking** -- other users stake tokens on one of N discrete outcomes
+//!    (`stake_on_call`). Native XLM and SAC-wrapped tokens are both supported.
+//! 3. **Resolution** -- the trusted `OutcomeManager` submits the winning outcome
+//!    and end price after the deadline (`resolve_call`).
+//! 4. **Settlement** -- winners claim their proportional share via share tokens
+//!    (`redeem_shares`) or the outcome manager releases escrow (`release_escrow`).
+//!
+//! ## Architecture
+//!
+//! | Module        | Responsibility                                         |
+//! |---------------|--------------------------------------------------------|
+//! | `lib.rs`      | Public contract entry-points (`#[contractimpl]`)       |
+//! | `types.rs`    | Shared data types (`Call`, `ContractConfig`, ...)      |
+//! | `storage.rs`  | Typed storage accessors                                |
+//! | `events.rs`   | Event-emission helpers                                 |
+//! | `admin.rs`    | Admin-gated parameter mutations                        |
+//! | `shares.rs`   | Share-token deploy / mint / burn helpers               |
+//! | `sep10.rs`    | SEP-10 JWT verification                                |
+//! | `duration.rs` | Duration / TTL utilities                               |
+//!
+//! ## Native XLM support
+//!
+//! Native XLM is identified by the all-zero 32-byte sentinel address
+//! (`CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4`).
+//! Pass this as `stake_token` in `create_call` or `stake_on_call` to stake XLM.
 #![no_std]
 #![allow(deprecated)]
 
@@ -402,6 +434,14 @@ impl CallRegistry {
         env.storage().persistent().get(&key)
     }
 
+    /// Update the metadata hash for an existing call (creator only).
+    ///
+    /// Can only be called while the call is still active (not settled, not
+    /// cancelled, and `end_ts` has not passed). Each successful update
+    /// increments `metadata_version`.
+    ///
+    /// # Errors
+    /// * [`CallRegistryError::CallNotFound`] -- `call_id` does not exist.
     pub fn update_call_metadata(
         env: Env,
         creator: Address,
@@ -454,14 +494,22 @@ impl CallRegistry {
         Ok(())
     }
 
+    /// Add a SAC token to the stake-token whitelist (admin only).
+    ///
+    /// Once whitelisted, the token may be used as `stake_token` in `create_call`.
+    /// Native XLM is always implicitly allowed and does not need whitelisting.
     pub fn whitelist_token(env: Env, token_address: Address) {
         admin::whitelist_token(env, token_address);
     }
 
+    /// Remove a SAC token from the stake-token whitelist (admin only).
+    ///
+    /// Existing calls that already use this token are unaffected.
     pub fn remove_token(env: Env, token_address: Address) {
         admin::remove_token(env, token_address);
     }
 
+    /// Return `true` if `token_address` is currently on the whitelist.
     pub fn is_token_whitelisted(env: Env, token_address: Address) -> bool {
         let config = get_config(&env).expect("not initialized");
         config
@@ -580,6 +628,15 @@ impl CallRegistry {
         Ok(call)
     }
 
+    /// Redeem winning share tokens for a proportional payout.
+    ///
+    /// Burns the redeemer's winning share-token balance and transfers the
+    /// corresponding fraction of the total stake pool back to the redeemer.
+    ///
+    /// **Payout formula:** `balance * total_all_stakes / total_winning_stakes`
+    ///
+    /// # Errors
+    /// * [`CallRegistryError::CallNotFound`] -- `call_id` does not exist.
     pub fn redeem_shares(
         env: Env,
         redeemer: Address,
@@ -643,6 +700,14 @@ impl CallRegistry {
         Ok(payout)
     }
 
+    /// Transfer outcome share tokens from one address to another.
+    ///
+    /// Allows secondary trading of outcome positions before a call is resolved.
+    ///
+    /// # Errors
+    /// * [`CallRegistryError::CallNotFound`]    -- `call_id` does not exist.
+    /// * [`CallRegistryError::InvalidPosition`] -- `outcome` outside [1, outcome_count].
+    /// * [`CallRegistryError::NotInitialized`]  -- share tokens not deployed.
     pub fn transfer_shares(
         env: Env,
         from: Address,
@@ -677,6 +742,9 @@ impl CallRegistry {
         admin::set_max_stake_per_user(env, new_max);
     }
 
+    /// Set the minimum stake required per staking action (admin only).
+    ///
+    /// Both `create_call` and `stake_on_call` enforce this floor.
     pub fn set_min_stake(env: Env, new_min_stake: i128) {
         admin::set_min_stake(env, new_min_stake);
     }

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -1,13 +1,25 @@
 use soroban_sdk::{contracttype, Address, Bytes, BytesN, Map};
 
-/// Describes the condition used to determine whether a call resolves as UP.
+/// Describes the price-movement condition that determines the winning outcome.
+///
+/// All price values use 7 decimal places (e.g. `1_0000000` = 1.0).
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ConditionType {
+    /// Resolves UP when the end price is strictly greater than `target`.
+    /// `target` is an absolute price with 7 decimals.
     TargetAbove(i128),
+    /// Resolves UP when the end price is strictly less than `target`.
+    /// `target` is an absolute price with 7 decimals.
     TargetBelow(i128),
+    /// Resolves UP when the end price has risen by at least `percent`% from
+    /// the start price. `percent` is a whole-number percentage (e.g. `5` = 5%).
     PercentUp(u32),
+    /// Resolves UP when the end price has fallen by at least `percent`% from
+    /// the start price. `percent` is a whole-number percentage (e.g. `5` = 5%).
     PercentDown(u32),
+    /// Resolves UP when the end price falls within `[min, max]` inclusive.
+    /// Both `min` and `max` are absolute prices with 7 decimals.
     Range(i128, i128),
 }
 
@@ -69,6 +81,7 @@ pub struct Call {
     pub created_at: u64,
     /// Whether the call has been cancelled by its creator
     pub cancelled: bool,
+    /// Version counter incremented on each `update_call_metadata` call.
     pub metadata_version: u32,
     /// Map of outcome indices to the deployed share token contract addresses
     pub share_tokens: Map<u32, Address>,
@@ -114,8 +127,12 @@ pub struct ContractConfig {
     /// Maximum stake any single user may place per call per position.
     /// `0` means unlimited.
     pub max_stake_per_user: i128,
+    /// Set of SAC token addresses approved for use as stake tokens.
     pub whitelisted_tokens: Map<Address, bool>,
+    /// Minimum stake required for `create_call` and `stake_on_call`.
+    /// Denominated in the smallest unit of the stake token (stroops for XLM).
     pub min_stake: i128,
+    /// Reserved version field for future metadata schema migrations.
     pub metadata_version: u32,
     /// When true, create/stake/resolve operations are blocked.
     pub paused: bool,
@@ -130,8 +147,11 @@ pub struct ContractConfig {
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct GlobalStats {
+    /// Total number of calls ever created (never decrements).
     pub total_calls: u64,
+    /// Cumulative stake volume across all calls, in the token's smallest unit.
     pub total_stake_volume: i128,
+    /// Number of unique staker addresses that have ever staked on any call.
     pub total_unique_stakers: u64,
 }
 
@@ -151,8 +171,11 @@ pub struct CallStats {
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct CreatorStats {
+    /// Total number of calls this address has ever created.
     pub total_created: u32,
+    /// Total number of calls created by this address that have been resolved.
     pub total_resolved: u32,
+    /// Number of resolved calls where the creator staked on the winning outcome.
     pub total_correct: u32,
 }
 

--- a/packages/contracts/outcome_manager/src/errors.rs
+++ b/packages/contracts/outcome_manager/src/errors.rs
@@ -4,30 +4,56 @@ use soroban_sdk::contracterror;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum OutcomeError {
+    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
+    /// `quorum` is 0 or exceeds the current oracle count.
     InvalidQuorum = 2,
+    /// The oracle public key is not in the trusted oracle set.
     UnauthorizedOracle = 3,
+    /// Quorum was already reached; the call outcome is already settled.
     AlreadySettled = 4,
+    /// This oracle already submitted a vote for the given `call_id`.
     DuplicateSubmission = 5,
+    /// The outcome value is not within [1, outcome_count].
     InvalidOutcome = 6,
+    /// `claim_payout` was called before quorum was reached.
     CallNotSettled = 7,
+    /// The staker has already claimed their payout for this `call_id`.
     AlreadyClaimed = 8,
+    /// The staker's winning stake is 0; there is nothing to claim.
     NothingToClaim = 9,
+    /// `total_winning_stake` is 0 or negative; payout cannot be calculated.
     InvalidWinningStake = 10,
+    /// An arithmetic operation overflowed; the transaction is reverted.
     Overflow = 11,
+    /// No pending outcome exists, or the dispute window has not yet elapsed.
     CallNotFinalized = 12,
+    /// `fee_bps` exceeds 10 000 (100%).
     InvalidFeeBps = 13,
+    /// The contract is paused; `submit_outcome` and `claim_payout` are blocked.
     ContractPaused = 14,
+    /// Adding an oracle would exceed the `MAX_ORACLES` cap of 20.
     MaxOraclesReached = 15,
+    /// The oracle's `timestamp` is after `call_end_ts + max_submission_delay`.
     SubmissionWindowExpired = 16,
+    /// `batch_claim_payouts` was called with an empty `stakers` vec.
     EmptyBatch = 17,
+    /// `stakers` and `stakes` vecs passed to `batch_claim_payouts` differ in length.
     LengthMismatch = 18,
+    /// A function requiring initialization was called before `initialize`.
     NotInitialized = 19,
+    /// A fee collector address has not been set yet.
     FeeCollectorNotSet = 20,
+    /// A price observation was submitted out of chronological order.
     ObservationOutOfOrder = 21,
+    /// `compute_twap` was called but fewer than 3 price observations are stored.
     InsufficientPriceObservations = 22,
+    /// `compute_twap` was called but no price observations exist for this call.
     NoPriceObservations = 23,
+    /// All stored observations share the same timestamp; TWAP window is zero.
     ZeroTimeWindow = 24,
+    /// The `CallRegistry` address has not been set in instance storage.
     RegistryNotSet = 25,
+    /// `dispute_outcome` was called after the dispute window has already closed.
     DisputeWindowExpired = 26,
 }

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -50,6 +50,10 @@ pub fn emit_batch_payout_started(env: &Env, call_id: u64, staker_count: u32) {
     );
 }
 
+/// Emitted when the admin overrides a pending outcome during the dispute window.
+///
+/// `new_outcome` and `new_price` reflect the corrected values. The outcome
+/// still needs `finalize_outcome` to be called once the window closes.
 pub fn emit_outcome_disputed(env: &Env, call_id: u64, new_outcome: u32, new_price: i128) {
     env.events().publish(
         (symbol_short!("outcome"), symbol_short!("disputed")),
@@ -57,11 +61,16 @@ pub fn emit_outcome_disputed(env: &Env, call_id: u64, new_outcome: u32, new_pric
     );
 }
 
+/// Emitted when the admin pauses the contract.
+///
+/// While paused, `submit_outcome` and `claim_payout` revert with
+/// [`OutcomeError::ContractPaused`].
 pub fn emit_contract_paused(env: &Env) {
     env.events()
         .publish((symbol_short!("contract"), symbol_short!("paused")), ());
 }
 
+/// Emitted when the admin unpauses the contract, resuming normal operations.
 pub fn emit_contract_unpaused(env: &Env) {
     env.events()
         .publish((symbol_short!("contract"), symbol_short!("unpaused")), ());

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -1,3 +1,30 @@
+//! # OutcomeManager Contract
+//!
+//! The `outcome_manager` contract is the decentralized oracle layer for BACKit
+//! on Stellar. It collects signed outcome reports from a set of trusted oracle
+//! nodes and, once a configurable quorum agrees, finalizes the result and
+//! triggers settlement in the `CallRegistry` via cross-contract calls.
+//!
+//! ## Oracle submission flow
+//!
+//! 1. After a call's `end_ts` passes, each trusted oracle signs a canonical
+//!    message and calls `submit_outcome`.
+//! 2. The contract verifies the signature, deduplicates votes, and tallies.
+//! 3. When `quorum` matching votes are received the outcome enters a pending
+//!    state behind a configurable dispute window.
+//! 4. After the window elapses, anyone may call `finalize_outcome` to
+//!    permanently record the result and trigger `resolve_call` on the registry.
+//!
+//! ## Architecture
+//!
+//! | Module            | Responsibility                                      |
+//! |-------------------|-----------------------------------------------------|
+//! | `lib.rs`          | Public contract entry-points (`#[contractimpl]`)    |
+//! | `storage.rs`      | Typed storage keys and accessors                    |
+//! | `events.rs`       | Event-emission helpers                              |
+//! | `auth.rs`         | Admin authorization helper                          |
+//! | `verification.rs` | Ed25519 signature verification for oracle reports   |
+//! | `rotation.rs`     | Oracle-key rotation utilities                       |
 #![no_std]
 
 mod auth;
@@ -173,6 +200,10 @@ impl OutcomeManager {
 
     // ── Admin Controls ─────────────────────────────────────────────────────────
 
+    /// Add a new oracle public key to the trusted set (admin only).
+    ///
+    /// No-ops silently if `oracle` is already present. Panics with
+    /// [`OutcomeError::MaxOraclesReached`] if adding would exceed `MAX_ORACLES` (20).
     pub fn add_oracle(env: Env, oracle: BytesN<32>) {
         require_admin(&env);
         let mut oracles = get_oracles(&env);
@@ -198,6 +229,10 @@ impl OutcomeManager {
             .set(&InstanceKey::OracleList, &oracle_list);
     }
 
+    /// Remove an oracle public key from the trusted set (admin only).
+    ///
+    /// Past votes from the removed oracle are unaffected. No-ops if the
+    /// oracle is not currently in the set.
     pub fn remove_oracle(env: Env, oracle: BytesN<32>) {
         require_admin(&env);
         let mut oracles = get_oracles(&env);
@@ -222,6 +257,10 @@ impl OutcomeManager {
             .set(&InstanceKey::OracleList, &filtered);
     }
 
+    /// Update the quorum threshold (admin only).
+    ///
+    /// `quorum` must be at least 1 and must not exceed the current oracle
+    /// count. Panics with [`OutcomeError::InvalidQuorum`] otherwise.
     pub fn set_quorum(env: Env, quorum: u32) {
         require_admin(&env);
         let oracles = get_oracles(&env);
@@ -231,6 +270,9 @@ impl OutcomeManager {
         env.storage().instance().set(&InstanceKey::Quorum, &quorum);
     }
 
+    /// Transfer admin privileges to a new address (admin only).
+    ///
+    /// The new admin takes effect immediately with no confirmation step.
     pub fn set_admin(env: Env, new_admin: Address) {
         require_admin(&env);
         env.storage()
@@ -238,28 +280,38 @@ impl OutcomeManager {
             .set(&InstanceKey::Admin, &new_admin);
     }
 
+    /// Set the maximum seconds an oracle report may lag behind `call_end_ts`
+    /// (admin only). Reports submitted after this window are rejected with
+    /// [`OutcomeError::SubmissionWindowExpired`]. Default: 86400 (24 h).
     pub fn set_max_submission_delay(env: Env, new_delay: u64) {
         require_admin(&env);
         set_max_submission_delay(&env, new_delay);
         emit_admin_params_changed(&env, new_delay);
     }
 
+    /// Return the current maximum oracle submission delay in seconds.
     pub fn get_max_submission_delay(env: Env) -> u64 {
         storage::get_max_submission_delay(&env)
     }
 
     // ── Emergency Pause ────────────────────────────────────────────────────────
 
+    /// Pause the contract (admin only).
+    ///
+    /// While paused, `submit_outcome` and `claim_payout` revert with
+    /// [`OutcomeError::ContractPaused`].
     pub fn pause(env: Env) {
         require_admin(&env);
         env.storage().instance().set(&InstanceKey::Paused, &true);
     }
 
+    /// Unpause the contract (admin only), resuming normal operations.
     pub fn unpause(env: Env) {
         require_admin(&env);
         env.storage().instance().set(&InstanceKey::Paused, &false);
     }
 
+    /// Return `true` if the contract is currently paused.
     pub fn is_paused_view(env: Env) -> bool {
         is_paused(&env)
     }
@@ -509,6 +561,15 @@ impl OutcomeManager {
         emit_payout_claimed(&env, call_id, &staker, payout);
     }
 
+    /// Promote a pending outcome to finalized once the dispute window has elapsed.
+    ///
+    /// Anyone may call this after `dispute_window_secs` have passed since the
+    /// outcome entered the pending state. On success it calls `resolve_call`
+    /// on the registry and emits `OutcomeFinalized`.
+    ///
+    /// # Panics
+    /// - [`OutcomeError::CallNotFinalized`] -- no pending outcome, or the
+    ///   dispute window has not yet elapsed.
     pub fn finalize_outcome(env: Env, call_id: u64) {
         let pending: Outcome = match env
             .storage()
@@ -547,6 +608,16 @@ impl OutcomeManager {
         emit_outcome_finalized(&env, call_id, pending.outcome, pending.price);
     }
 
+    /// Override a pending outcome during the dispute window (admin only).
+    ///
+    /// Must be called before `window_start + dispute_window_secs` elapses.
+    /// The corrected outcome still needs `finalize_outcome` once the window
+    /// closes. Emits `OutcomeDisputed`.
+    ///
+    /// # Panics
+    /// - [`OutcomeError::CallNotFinalized`]     -- no pending outcome exists.
+    /// - [`OutcomeError::DisputeWindowExpired`] -- dispute window already closed.
+    /// - [`OutcomeError::InvalidOutcome`]       -- `new_outcome` is not valid.
     pub fn dispute_outcome(env: Env, call_id: u64, new_outcome: u32, new_price: i128) {
         require_admin(&env);
 


### PR DESCRIPTION
- Add //! module-level docs to call_registry and outcome_manager lib.rs
- Document all ConditionType variants with price unit notes (7 decimals)
- Fill missing /// comments on update_call_metadata, whitelist_token, remove_token, redeem_shares, transfer_shares, set_min_stake
- Add field docs to GlobalStats, CreatorStats, ContractConfig
- Document all 26 OutcomeError variants with trigger conditions
- Add docs to add_oracle, remove_oracle, set_quorum, set_admin, pause/unpause, finalize_outcome, dispute_outcome in outcome_manager
- Document all undocumented emit_* helpers in both events.rs files
- Add cargo doc --open section to packages/contracts/README.md

closes #395 