### PR TITLE
feat(governance): implement on-chain governance for contract parameters

### DIFF
--- a/packages/contracts/call_registry/src/errors.rs
+++ b/packages/contracts/call_registry/src/errors.rs
@@ -36,4 +36,22 @@ pub enum CallRegistryError {
     StakingCutoffActive = 15,
     /// The SEP-10 token's `valid_until` ledger sequence has passed.
     Sep10TokenExpired = 16,
+
+    // ── Governance errors ──────────────────────────────────────────────────
+    /// The proposer's (or voter's) cumulative stake volume is below the required threshold.
+    InsufficientStake = 17,
+    /// The requested voting_end_ledger is too close to the current ledger.
+    VotingPeriodTooShort = 18,
+    /// No governance proposal exists with the given ID.
+    ProposalNotFound = 19,
+    /// The proposal is not in `Active` status (already executed or rejected).
+    ProposalNotActive = 20,
+    /// The voting deadline has already elapsed; no more votes accepted.
+    VotingEnded = 21,
+    /// The voting deadline has not yet elapsed; execution is premature.
+    VotingNotEnded = 22,
+    /// The proposal did not reach the required quorum.
+    QuorumNotMet = 23,
+    /// The caller has already voted on this proposal.
+    AlreadyVoted = 24,
 }

--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -356,3 +356,61 @@ pub fn emit_sep10_verified(env: &Env, user: &Address, home_domain: &soroban_sdk:
         (user.clone(), home_domain.clone()),
     );
 }
+
+// ── Governance events ─────────────────────────────────────────────────────────
+
+/// Emitted when a new governance proposal is created.
+pub fn emit_proposal_created(
+    env: &Env,
+    proposal_id: u64,
+    proposer: &Address,
+    parameter: &Symbol,
+    voting_end_ledger: u32,
+    total_volume_snapshot: i128,
+) {
+    env.events().publish(
+        ("call_registry", "proposal_created"),
+        (
+            proposal_id,
+            proposer.clone(),
+            parameter.clone(),
+            voting_end_ledger,
+            total_volume_snapshot,
+        ),
+    );
+}
+
+/// Emitted when a staker casts a governance vote.
+pub fn emit_vote_cast(
+    env: &Env,
+    proposal_id: u64,
+    voter: &Address,
+    support: bool,
+    vote_power: i128,
+) {
+    env.events().publish(
+        ("call_registry", "vote_cast"),
+        (proposal_id, voter.clone(), support, vote_power),
+    );
+}
+
+/// Emitted when a governance proposal is executed (passed and applied).
+pub fn emit_proposal_executed(
+    env: &Env,
+    proposal_id: u64,
+    parameter: &Symbol,
+    yes_votes: i128,
+) {
+    env.events().publish(
+        ("call_registry", "proposal_executed"),
+        (proposal_id, parameter.clone(), yes_votes),
+    );
+}
+
+/// Emitted when a governance proposal is rejected (failed to reach quorum).
+pub fn emit_proposal_rejected(env: &Env, proposal_id: u64, yes_votes: i128, no_votes: i128) {
+    env.events().publish(
+        ("call_registry", "proposal_rejected"),
+        (proposal_id, yes_votes, no_votes),
+    );
+}

--- a/packages/contracts/call_registry/src/governance.rs
+++ b/packages/contracts/call_registry/src/governance.rs
@@ -1,0 +1,257 @@
+use crate::errors::CallRegistryError;
+use crate::events::{
+    emit_proposal_created, emit_proposal_executed, emit_proposal_rejected, emit_vote_cast,
+};
+use crate::storage::{
+    get_config, get_global_stats, get_proposal, get_proposal_counter, get_proposal_votes,
+    get_user_total_stake_volume, set_proposal, set_proposal_counter, set_proposal_votes,
+    set_user_vote_on_proposal, user_has_voted,
+};
+use crate::types::{GovernanceProposal, ProposalStatus, ProposalVotes};
+use soroban_sdk::{Address, Env, Symbol, Val, Vec};
+
+/// Minimum voting period in ledgers (~1 hour at 5 s/ledger = 720 ledgers).
+pub const MIN_VOTING_PERIOD: u32 = 720;
+
+/// Create a governance proposal to change a contract parameter.
+///
+/// The proposer must have at least `proposal_threshold` total historical stake
+/// volume. Vote power is snapshotted from `total_stake_volume` at creation time
+/// to prevent flash-loan attacks.
+///
+/// # Errors
+/// * [`CallRegistryError::NotInitialized`]       — contract not initialised.
+/// * [`CallRegistryError::InsufficientStake`]    — proposer below threshold.
+/// * [`CallRegistryError::VotingPeriodTooShort`] — deadline too soon.
+pub fn propose_change(
+    env: &Env,
+    proposer: Address,
+    parameter: Symbol,
+    new_value: Val,
+    voting_end_ledger: u32,
+) -> Result<u64, CallRegistryError> {
+    proposer.require_auth();
+
+    let config = get_config(env).ok_or(CallRegistryError::NotInitialized)?;
+
+    let proposer_volume = get_user_total_stake_volume(env, &proposer);
+    if proposer_volume < config.proposal_threshold {
+        return Err(CallRegistryError::InsufficientStake);
+    }
+
+    let current_ledger = env.ledger().sequence();
+    if voting_end_ledger <= current_ledger.saturating_add(MIN_VOTING_PERIOD) {
+        return Err(CallRegistryError::VotingPeriodTooShort);
+    }
+
+    let proposal_id = get_proposal_counter(env) + 1;
+    set_proposal_counter(env, proposal_id);
+
+    let total_volume = get_global_stats(env).total_stake_volume;
+
+    let proposal = GovernanceProposal {
+        id: proposal_id,
+        proposer: proposer.clone(),
+        parameter: parameter.clone(),
+        new_value: new_value.clone(),
+        voting_end_ledger,
+        status: ProposalStatus::Active,
+        yes_votes: 0,
+        no_votes: 0,
+        total_volume_snapshot: total_volume,
+    };
+
+    set_proposal(env, &proposal);
+    set_proposal_votes(env, proposal_id, &ProposalVotes { yes: 0, no: 0 });
+
+    emit_proposal_created(
+        env,
+        proposal_id,
+        &proposer,
+        &parameter,
+        voting_end_ledger,
+        total_volume,
+    );
+
+    Ok(proposal_id)
+}
+
+/// Cast a vote on an active proposal.
+///
+/// Vote power equals the voter's historical total stake volume — determined at
+/// call time, not at proposal creation, which is safe because stake volume only
+/// increases (resolved calls are permanent).
+///
+/// # Errors
+/// * [`CallRegistryError::NotInitialized`]    — contract not initialised.
+/// * [`CallRegistryError::ProposalNotFound`]  — unknown proposal_id.
+/// * [`CallRegistryError::ProposalNotActive`] — already executed or rejected.
+/// * [`CallRegistryError::VotingEnded`]       — past the voting deadline.
+/// * [`CallRegistryError::AlreadyVoted`]      — this voter already voted.
+/// * [`CallRegistryError::InsufficientStake`] — voter has zero stake history.
+pub fn vote(
+    env: &Env,
+    voter: Address,
+    proposal_id: u64,
+    support: bool,
+) -> Result<(), CallRegistryError> {
+    voter.require_auth();
+    get_config(env).ok_or(CallRegistryError::NotInitialized)?;
+
+    let mut proposal = get_proposal(env, proposal_id).ok_or(CallRegistryError::ProposalNotFound)?;
+
+    if proposal.status != ProposalStatus::Active {
+        return Err(CallRegistryError::ProposalNotActive);
+    }
+
+    let current_ledger = env.ledger().sequence();
+    if current_ledger > proposal.voting_end_ledger {
+        return Err(CallRegistryError::VotingEnded);
+    }
+
+    if user_has_voted(env, proposal_id, &voter) {
+        return Err(CallRegistryError::AlreadyVoted);
+    }
+
+    let vote_power = get_user_total_stake_volume(env, &voter);
+    if vote_power == 0 {
+        return Err(CallRegistryError::InsufficientStake);
+    }
+
+    set_user_vote_on_proposal(env, proposal_id, &voter);
+
+    let mut votes =
+        get_proposal_votes(env, proposal_id).unwrap_or(ProposalVotes { yes: 0, no: 0 });
+    if support {
+        votes.yes += vote_power;
+        proposal.yes_votes += vote_power;
+    } else {
+        votes.no += vote_power;
+        proposal.no_votes += vote_power;
+    }
+    set_proposal_votes(env, proposal_id, &votes);
+    set_proposal(env, &proposal);
+
+    emit_vote_cast(env, proposal_id, &voter, support, vote_power);
+
+    Ok(())
+}
+
+/// Execute a passed proposal (open to anyone after deadline).
+///
+/// Applies the parameter change to `ContractConfig`. Governance is the primary
+/// path; the admin fast-track still works independently.
+///
+/// # Errors
+/// * [`CallRegistryError::NotInitialized`]    — contract not initialised.
+/// * [`CallRegistryError::ProposalNotFound`]  — unknown proposal_id.
+/// * [`CallRegistryError::ProposalNotActive`] — already executed or rejected.
+/// * [`CallRegistryError::VotingNotEnded`]    — deadline not yet elapsed.
+/// * [`CallRegistryError::QuorumNotMet`]      — insufficient yes_votes.
+pub fn execute_proposal(env: &Env, proposal_id: u64) -> Result<(), CallRegistryError> {
+    let mut config = get_config(env).ok_or(CallRegistryError::NotInitialized)?;
+
+    let mut proposal =
+        get_proposal(env, proposal_id).ok_or(CallRegistryError::ProposalNotFound)?;
+
+    if proposal.status != ProposalStatus::Active {
+        return Err(CallRegistryError::ProposalNotActive);
+    }
+
+    let current_ledger = env.ledger().sequence();
+    if current_ledger <= proposal.voting_end_ledger {
+        return Err(CallRegistryError::VotingNotEnded);
+    }
+
+    // Quorum: yes_votes >= (total_volume_snapshot * governance_quorum_bps / 10_000)
+    let required = if proposal.total_volume_snapshot > 0 {
+        (proposal.total_volume_snapshot * config.governance_quorum_bps as i128) / 10_000_i128
+    } else {
+        0_i128
+    };
+
+    let passes = proposal.yes_votes >= required && proposal.yes_votes > proposal.no_votes;
+
+    if !passes {
+        proposal.status = ProposalStatus::Rejected;
+        set_proposal(env, &proposal);
+        emit_proposal_rejected(env, proposal_id, proposal.yes_votes, proposal.no_votes);
+        return Err(CallRegistryError::QuorumNotMet);
+    }
+
+    apply_parameter(env, &mut config, &proposal.parameter, &proposal.new_value);
+    crate::storage::set_config(env, &config);
+
+    proposal.status = ProposalStatus::Executed;
+    set_proposal(env, &proposal);
+
+    emit_proposal_executed(env, proposal_id, &proposal.parameter, proposal.yes_votes);
+
+    Ok(())
+}
+
+/// Apply a governance-approved parameter update to `ContractConfig`.
+/// Only recognised parameter names are applied; unknown names are ignored.
+fn apply_parameter(
+    env: &Env,
+    config: &mut crate::types::ContractConfig,
+    parameter: &Symbol,
+    new_value: &Val,
+) {
+    use soroban_sdk::TryFromVal;
+
+    macro_rules! try_apply {
+        ($field:expr, $ty:ty) => {
+            if let Ok(v) = <$ty>::try_from_val(env, new_value) {
+                $field = v;
+            }
+        };
+    }
+
+    if *parameter == Symbol::new(env, "fee_bps") {
+        try_apply!(config.fee_bps, u32);
+    } else if *parameter == Symbol::new(env, "min_stake") {
+        try_apply!(config.min_stake, i128);
+    } else if *parameter == Symbol::new(env, "staking_cutoff") {
+        try_apply!(config.staking_cutoff_secs, u64);
+    } else if *parameter == Symbol::new(env, "proposal_threshold") {
+        try_apply!(config.proposal_threshold, i128);
+    } else if *parameter == Symbol::new(env, "gov_quorum_bps") {
+        try_apply!(config.governance_quorum_bps, u32);
+    } else if *parameter == Symbol::new(env, "voting_period") {
+        try_apply!(config.voting_period_ledgers, u32);
+    } else if *parameter == Symbol::new(env, "max_stake") {
+        try_apply!(config.max_stake_per_user, i128);
+    }
+}
+
+// ── View functions ────────────────────────────────────────────────────────────
+
+/// Return a proposal by ID.
+pub fn get_proposal_view(env: &Env, proposal_id: u64) -> Option<GovernanceProposal> {
+    get_proposal(env, proposal_id)
+}
+
+/// Return all currently-active proposals (capped at 50 to bound compute).
+pub fn get_active_proposals(env: &Env) -> Vec<GovernanceProposal> {
+    let counter = get_proposal_counter(env);
+    let current_ledger = env.ledger().sequence();
+    let mut result = Vec::new(env);
+    let mut i = 1u64;
+    let mut found = 0u32;
+    while i <= counter && found < 50 {
+        if let Some(p) = get_proposal(env, i) {
+            if p.status == ProposalStatus::Active && current_ledger <= p.voting_end_ledger {
+                result.push_back(p);
+                found += 1;
+            }
+        }
+        i += 1;
+    }
+    result
+}
+
+/// Return vote tallies for a proposal.
+pub fn get_proposal_votes_view(env: &Env, proposal_id: u64) -> Option<ProposalVotes> {
+    get_proposal_votes(env, proposal_id)
+}

--- a/packages/contracts/call_registry/src/governance.rs
+++ b/packages/contracts/call_registry/src/governance.rs
@@ -8,7 +8,7 @@ use crate::storage::{
     set_user_vote_on_proposal, user_has_voted,
 };
 use crate::types::{GovernanceProposal, ProposalStatus, ProposalVotes};
-use soroban_sdk::{Address, Env, Symbol, Val, Vec};
+use soroban_sdk::{Address, Env, Symbol, Vec};
 
 /// Minimum voting period in ledgers (~1 hour at 5 s/ledger = 720 ledgers).
 pub const MIN_VOTING_PERIOD: u32 = 720;
@@ -27,7 +27,7 @@ pub fn propose_change(
     env: &Env,
     proposer: Address,
     parameter: Symbol,
-    new_value: Val,
+    new_value: i128,
     voting_end_ledger: u32,
 ) -> Result<u64, CallRegistryError> {
     proposer.require_auth();
@@ -53,7 +53,7 @@ pub fn propose_change(
         id: proposal_id,
         proposer: proposer.clone(),
         parameter: parameter.clone(),
-        new_value: new_value.clone(),
+        new_value,
         voting_end_ledger,
         status: ProposalStatus::Active,
         yes_votes: 0,
@@ -179,7 +179,7 @@ pub fn execute_proposal(env: &Env, proposal_id: u64) -> Result<(), CallRegistryE
         return Err(CallRegistryError::QuorumNotMet);
     }
 
-    apply_parameter(env, &mut config, &proposal.parameter, &proposal.new_value);
+    apply_parameter(env, &mut config, &proposal.parameter, proposal.new_value);
     crate::storage::set_config(env, &config);
 
     proposal.status = ProposalStatus::Executed;
@@ -196,32 +196,22 @@ fn apply_parameter(
     env: &Env,
     config: &mut crate::types::ContractConfig,
     parameter: &Symbol,
-    new_value: &Val,
+    new_value: i128,
 ) {
-    use soroban_sdk::TryFromVal;
-
-    macro_rules! try_apply {
-        ($field:expr, $ty:ty) => {
-            if let Ok(v) = <$ty>::try_from_val(env, new_value) {
-                $field = v;
-            }
-        };
-    }
-
     if *parameter == Symbol::new(env, "fee_bps") {
-        try_apply!(config.fee_bps, u32);
+        config.fee_bps = new_value as u32;
     } else if *parameter == Symbol::new(env, "min_stake") {
-        try_apply!(config.min_stake, i128);
+        config.min_stake = new_value;
     } else if *parameter == Symbol::new(env, "staking_cutoff") {
-        try_apply!(config.staking_cutoff_secs, u64);
+        config.staking_cutoff_secs = new_value as u64;
     } else if *parameter == Symbol::new(env, "proposal_threshold") {
-        try_apply!(config.proposal_threshold, i128);
+        config.proposal_threshold = new_value;
     } else if *parameter == Symbol::new(env, "gov_quorum_bps") {
-        try_apply!(config.governance_quorum_bps, u32);
+        config.governance_quorum_bps = new_value as u32;
     } else if *parameter == Symbol::new(env, "voting_period") {
-        try_apply!(config.voting_period_ledgers, u32);
+        config.voting_period_ledgers = new_value as u32;
     } else if *parameter == Symbol::new(env, "max_stake") {
-        try_apply!(config.max_stake_per_user, i128);
+        config.max_stake_per_user = new_value;
     }
 }
 

--- a/packages/contracts/call_registry/src/governance_tests.rs
+++ b/packages/contracts/call_registry/src/governance_tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::types::{CallInitArgs, ConditionType, ProposalStatus};
+use crate::types::ProposalStatus;
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     Address, Env, Symbol,
@@ -12,344 +12,198 @@ fn setup_env() -> (Env, Address, Address, crate::CallRegistryClient<'static>) {
 
     let contract_id = env.register_contract(None, crate::CallRegistry);
     let client = crate::CallRegistryClient::new(&env, &contract_id);
-    // use client for calls
     let admin = Address::generate(&env);
     let outcome_manager = Address::generate(&env);
     (env, admin, outcome_manager, client)
 }
 
+fn override_config(env: &Env, admin: &Address, outcome_manager: &Address, quorum_bps: u32, threshold: i128) {
+    use crate::storage::*;
+    use crate::types::*;
+    use soroban_sdk::Map;
+
+    let config = ContractConfig {
+        admin: admin.clone(),
+        outcome_manager: outcome_manager.clone(),
+        fee_bps: 0,
+        max_stake_per_user: 0,
+        whitelisted_tokens: Map::new(env),
+        min_stake: 1,
+        metadata_version: 0,
+        paused: false,
+        staking_cutoff_secs: 0,
+        share_wasm_hash: None,
+        proposal_threshold: threshold,
+        governance_quorum_bps: quorum_bps,
+        voting_period_ledgers: 1000,
+    };
+    set_config(env, &config);
+}
+
+fn init_stake_volume(env: &Env, user: &Address, user_volume: i128, total_volume: i128) {
+    crate::storage::accumulate_user_stake_volume(env, user, user_volume);
+    let mut gs = crate::storage::get_global_stats(env);
+    gs.total_stake_volume = total_volume;
+    env.storage().instance().set(&crate::storage::DataKey::GlobalStats, &gs);
+}
+
 #[test]
 fn test_propose_and_vote_and_execute() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (env, admin, outcome_manager, client) = setup_env();
+    client.initialize(&admin, &outcome_manager, &1);
+    override_config(&env, &admin, &outcome_manager, 500, 0);
 
-    let contract_id = env.register_contract(None, crate::CallRegistry);
-    let admin = Address::generate(&env);
-    let outcome_manager = Address::generate(&env);
+    let staker = Address::generate(&env);
+    init_stake_volume(&env, &staker, 10_000_000, 10_000_000);
 
-    env.as_contract(&contract_id, || {
-        use crate::storage::*;
-        use crate::types::*;
-        use soroban_sdk::Map;
+    let current_ledger = env.ledger().sequence();
+    let voting_end = current_ledger + 2000;
 
-        // Init config with governance defaults
-        let config = ContractConfig {
-            admin: admin.clone(),
-            outcome_manager: outcome_manager.clone(),
-            fee_bps: 0,
-            max_stake_per_user: 0,
-            whitelisted_tokens: Map::new(&env),
-            min_stake: 1,
-            metadata_version: 0,
-            paused: false,
-            staking_cutoff_secs: 0,
-            share_wasm_hash: None,
-            proposal_threshold: 0,
-            governance_quorum_bps: 500,
-            voting_period_ledgers: 1000,
-        };
-        set_config(&env, &config);
+    let proposal_id = client.propose_change(
+        &staker,
+        &Symbol::new(&env, "fee_bps"),
+        &200i128,
+        &voting_end,
+    );
+    assert_eq!(proposal_id, 1);
 
-        // Give a staker some stake volume
-        let staker = Address::generate(&env);
-        accumulate_user_stake_volume(&env, &staker, 10_000_000);
-        // total_stake_volume in global stats
-        let mut gs = get_global_stats(&env);
-        gs.total_stake_volume = 10_000_000;
-        env.storage().instance().set(&DataKey::GlobalStats, &gs);
+    client.vote(&staker, &proposal_id, &true);
 
-        let current_ledger = env.ledger().sequence();
-        let voting_end = current_ledger + 2000;
+    let dupe = client.try_vote(&staker, &proposal_id, &true);
+    assert_eq!(dupe, Err(Ok(crate::errors::CallRegistryError::AlreadyVoted)));
 
-        // propose_change
-        let new_val: i128 = 200;
-        let result = crate::governance::propose_change(
-            &env,
-            staker.clone(),
-            Symbol::new(&env, "fee_bps"),
-            new_val,
-            voting_end,
-        );
-        assert!(result.is_ok());
-        let proposal_id = result.unwrap();
-        assert_eq!(proposal_id, 1);
+    let early = client.try_execute_proposal(&proposal_id);
+    assert_eq!(early, Err(Ok(crate::errors::CallRegistryError::VotingNotEnded)));
 
-        // vote yes
-        let vote_result = crate::governance::vote(&env, staker.clone(), proposal_id, true);
-        assert!(vote_result.is_ok());
-
-        // Cannot vote twice
-        let dupe = crate::governance::vote(&env, staker.clone(), proposal_id, true);
-        assert_eq!(dupe, Err(crate::errors::CallRegistryError::AlreadyVoted));
-
-        // Cannot execute before deadline
-        let early = crate::governance::execute_proposal(&env, proposal_id);
-        assert_eq!(
-            early,
-            Err(crate::errors::CallRegistryError::VotingNotEnded)
-        );
-
-        // Advance ledger past voting_end
-        env.ledger().set(LedgerInfo {
-            timestamp: 0,
-            protocol_version: 22,
-            sequence_number: voting_end + 1,
-            network_id: [0u8; 32],
-            base_reserve: 5_000_000,
-            min_temp_entry_ttl: 1,
-            min_persistent_entry_ttl: 1,
-            max_entry_ttl: 6_312_000,
-        });
-
-        let exec_result = crate::governance::execute_proposal(&env, proposal_id);
-        assert!(exec_result.is_ok());
-
-        // Verify config was updated
-        let updated_config = get_config(&env).unwrap();
-        assert_eq!(updated_config.fee_bps, 200);
-
-        // Proposal status should be Executed
-        let proposal = get_proposal(&env, proposal_id).unwrap();
-        assert_eq!(proposal.status, ProposalStatus::Executed);
+    env.ledger().set(LedgerInfo {
+        timestamp: 0,
+        protocol_version: 22,
+        sequence_number: voting_end + 1,
+        network_id: [0u8; 32],
+        base_reserve: 5_000_000,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 6_312_000,
     });
+
+    let exec_result = client.try_execute_proposal(&proposal_id);
+    assert!(exec_result.is_ok());
+
+    let updated_config = client.get_config().unwrap();
+    assert_eq!(updated_config.fee_bps, 200);
+
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Executed);
 }
 
 #[test]
 fn test_proposal_rejected_insufficient_votes() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (env, admin, outcome_manager, client) = setup_env();
+    client.initialize(&admin, &outcome_manager, &1);
+    override_config(&env, &admin, &outcome_manager, 5000, 0);
 
-    let contract_id = env.register_contract(None, crate::CallRegistry);
-    let admin = Address::generate(&env);
-    let outcome_manager = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    init_stake_volume(&env, &proposer, 100, 1_000_000);
 
-    env.as_contract(&contract_id, || {
-        use crate::storage::*;
-        use crate::types::*;
-        use soroban_sdk::Map;
+    let current_ledger = env.ledger().sequence();
+    let voting_end = current_ledger + 2000;
 
-        let config = ContractConfig {
-            admin: admin.clone(),
-            outcome_manager: outcome_manager.clone(),
-            fee_bps: 0,
-            max_stake_per_user: 0,
-            whitelisted_tokens: Map::new(&env),
-            min_stake: 1,
-            metadata_version: 0,
-            paused: false,
-            staking_cutoff_secs: 0,
-            share_wasm_hash: None,
-            proposal_threshold: 0,
-            governance_quorum_bps: 5000, // 50% quorum — very hard to reach
-            voting_period_ledgers: 1000,
-        };
-        set_config(&env, &config);
+    let proposal_id = client.propose_change(
+        &proposer,
+        &Symbol::new(&env, "fee_bps"),
+        &300i128,
+        &voting_end,
+    );
 
-        let proposer = Address::generate(&env);
-        accumulate_user_stake_volume(&env, &proposer, 100);
-        let mut gs = get_global_stats(&env);
-        gs.total_stake_volume = 1_000_000; // proposer's 100 is way below 50% quorum
-        env.storage().instance().set(&DataKey::GlobalStats, &gs);
+    client.vote(&proposer, &proposal_id, &true);
 
-        let current_ledger = env.ledger().sequence();
-        let voting_end = current_ledger + 2000;
-
-        let new_val: i128 = 300;
-        let proposal_id = crate::governance::propose_change(
-            &env,
-            proposer.clone(),
-            Symbol::new(&env, "fee_bps"),
-            new_val,
-            voting_end,
-        )
-        .unwrap();
-
-        // vote yes with tiny power — well below quorum
-        crate::governance::vote(&env, proposer.clone(), proposal_id, true).unwrap();
-
-        // Advance ledger
-        env.ledger().set(LedgerInfo {
-            timestamp: 0,
-            protocol_version: 22,
-            sequence_number: voting_end + 1,
-            network_id: [0u8; 32],
-            base_reserve: 5_000_000,
-            min_temp_entry_ttl: 1,
-            min_persistent_entry_ttl: 1,
-            max_entry_ttl: 6_312_000,
-        });
-
-        let exec_result = crate::governance::execute_proposal(&env, proposal_id);
-        assert_eq!(exec_result, Err(crate::errors::CallRegistryError::QuorumNotMet));
-
-        let proposal = get_proposal(&env, proposal_id).unwrap();
-        assert_eq!(proposal.status, ProposalStatus::Rejected);
+    env.ledger().set(LedgerInfo {
+        timestamp: 0,
+        protocol_version: 22,
+        sequence_number: voting_end + 1,
+        network_id: [0u8; 32],
+        base_reserve: 5_000_000,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 6_312_000,
     });
+
+    let exec_result = client.try_execute_proposal(&proposal_id);
+    assert_eq!(exec_result, Err(Ok(crate::errors::CallRegistryError::QuorumNotMet)));
+
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Rejected);
 }
 
 #[test]
 fn test_non_staker_cannot_propose() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (env, admin, outcome_manager, client) = setup_env();
+    client.initialize(&admin, &outcome_manager, &1);
+    override_config(&env, &admin, &outcome_manager, 500, 1_000);
 
-    let contract_id = env.register_contract(None, crate::CallRegistry);
-    let admin = Address::generate(&env);
-    let outcome_manager = Address::generate(&env);
+    let non_staker = Address::generate(&env);
 
-    env.as_contract(&contract_id, || {
-        use crate::storage::*;
-        use crate::types::*;
-        use soroban_sdk::Map;
+    let current_ledger = env.ledger().sequence();
+    let voting_end = current_ledger + 2000;
 
-        let config = ContractConfig {
-            admin: admin.clone(),
-            outcome_manager: outcome_manager.clone(),
-            fee_bps: 0,
-            max_stake_per_user: 0,
-            whitelisted_tokens: Map::new(&env),
-            min_stake: 1,
-            metadata_version: 0,
-            paused: false,
-            staking_cutoff_secs: 0,
-            share_wasm_hash: None,
-            proposal_threshold: 1_000, // requires at least 1000 stake volume
-            governance_quorum_bps: 500,
-            voting_period_ledgers: 1000,
-        };
-        set_config(&env, &config);
-
-        let non_staker = Address::generate(&env);
-        // non_staker has 0 stake volume
-
-        let current_ledger = env.ledger().sequence();
-        let voting_end = current_ledger + 2000;
-        let new_val: i128 = 100;
-        let result = crate::governance::propose_change(
-            &env,
-            non_staker,
-            Symbol::new(&env, "fee_bps"),
-            new_val,
-            voting_end,
-        );
-        assert_eq!(result, Err(crate::errors::CallRegistryError::InsufficientStake));
-    });
+    let result = client.try_propose_change(
+        &non_staker,
+        &Symbol::new(&env, "fee_bps"),
+        &100i128,
+        &voting_end,
+    );
+    assert_eq!(result, Err(Ok(crate::errors::CallRegistryError::InsufficientStake)));
 }
 
 #[test]
 fn test_non_staker_cannot_vote() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (env, admin, outcome_manager, client) = setup_env();
+    client.initialize(&admin, &outcome_manager, &1);
+    override_config(&env, &admin, &outcome_manager, 500, 0);
 
-    let contract_id = env.register_contract(None, crate::CallRegistry);
-    let admin = Address::generate(&env);
-    let outcome_manager = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    init_stake_volume(&env, &proposer, 10_000, 10_000);
 
-    env.as_contract(&contract_id, || {
-        use crate::storage::*;
-        use crate::types::*;
-        use soroban_sdk::Map;
+    let current_ledger = env.ledger().sequence();
+    let voting_end = current_ledger + 2000;
 
-        let config = ContractConfig {
-            admin: admin.clone(),
-            outcome_manager: outcome_manager.clone(),
-            fee_bps: 0,
-            max_stake_per_user: 0,
-            whitelisted_tokens: Map::new(&env),
-            min_stake: 1,
-            metadata_version: 0,
-            paused: false,
-            staking_cutoff_secs: 0,
-            share_wasm_hash: None,
-            proposal_threshold: 0,
-            governance_quorum_bps: 500,
-            voting_period_ledgers: 1000,
-        };
-        set_config(&env, &config);
+    let proposal_id = client.propose_change(
+        &proposer,
+        &Symbol::new(&env, "fee_bps"),
+        &50i128,
+        &voting_end,
+    );
 
-        let proposer = Address::generate(&env);
-        accumulate_user_stake_volume(&env, &proposer, 10_000);
-        let mut gs = get_global_stats(&env);
-        gs.total_stake_volume = 10_000;
-        env.storage().instance().set(&DataKey::GlobalStats, &gs);
-
-        let current_ledger = env.ledger().sequence();
-        let voting_end = current_ledger + 2000;
-        let new_val: i128 = 50;
-        let proposal_id = crate::governance::propose_change(
-            &env,
-            proposer,
-            Symbol::new(&env, "fee_bps"),
-            new_val,
-            voting_end,
-        )
-        .unwrap();
-
-        let non_staker = Address::generate(&env);
-        let result = crate::governance::vote(&env, non_staker, proposal_id, true);
-        assert_eq!(result, Err(crate::errors::CallRegistryError::InsufficientStake));
-    });
+    let non_staker = Address::generate(&env);
+    let result = client.try_vote(&non_staker, &proposal_id, &true);
+    assert_eq!(result, Err(Ok(crate::errors::CallRegistryError::InsufficientStake)));
 }
 
 #[test]
 fn test_get_active_proposals() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (env, admin, outcome_manager, client) = setup_env();
+    client.initialize(&admin, &outcome_manager, &1);
+    override_config(&env, &admin, &outcome_manager, 500, 0);
 
-    let contract_id = env.register_contract(None, crate::CallRegistry);
-    let admin = Address::generate(&env);
-    let outcome_manager = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    init_stake_volume(&env, &proposer, 10_000, 10_000);
 
-    env.as_contract(&contract_id, || {
-        use crate::storage::*;
-        use crate::types::*;
-        use soroban_sdk::Map;
+    let current_ledger = env.ledger().sequence();
+    let voting_end = current_ledger + 2000;
 
-        let config = ContractConfig {
-            admin: admin.clone(),
-            outcome_manager: outcome_manager.clone(),
-            fee_bps: 0,
-            max_stake_per_user: 0,
-            whitelisted_tokens: Map::new(&env),
-            min_stake: 1,
-            metadata_version: 0,
-            paused: false,
-            staking_cutoff_secs: 0,
-            share_wasm_hash: None,
-            proposal_threshold: 0,
-            governance_quorum_bps: 500,
-            voting_period_ledgers: 1000,
-        };
-        set_config(&env, &config);
+    client.propose_change(
+        &proposer,
+        &Symbol::new(&env, "fee_bps"),
+        &100i128,
+        &voting_end,
+    );
+    client.propose_change(
+        &proposer,
+        &Symbol::new(&env, "min_stake"),
+        &200i128,
+        &voting_end,
+    );
 
-        let proposer = Address::generate(&env);
-        accumulate_user_stake_volume(&env, &proposer, 10_000);
-        let mut gs = get_global_stats(&env);
-        gs.total_stake_volume = 10_000;
-        env.storage().instance().set(&DataKey::GlobalStats, &gs);
-
-        let current_ledger = env.ledger().sequence();
-        let voting_end = current_ledger + 2000;
-
-        let val1: i128 = 100;
-        let val2: i128 = 200;
-        crate::governance::propose_change(
-            &env,
-            proposer.clone(),
-            Symbol::new(&env, "fee_bps"),
-            val1,
-            voting_end,
-        )
-        .unwrap();
-        crate::governance::propose_change(
-            &env,
-            proposer.clone(),
-            Symbol::new(&env, "min_stake"),
-            val2,
-            voting_end,
-        )
-        .unwrap();
-
-        let active = crate::governance::get_active_proposals(&env);
-        assert_eq!(active.len(), 2);
-    });
+    let active = client.get_active_proposals();
+    assert_eq!(active.len(), 2);
 }

--- a/packages/contracts/call_registry/src/governance_tests.rs
+++ b/packages/contracts/call_registry/src/governance_tests.rs
@@ -3,15 +3,15 @@
 use crate::types::{CallInitArgs, ConditionType, ProposalStatus};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
-    Address, Bytes, BytesN, Env, IntoVal, Symbol, Val,
+    Address, Env, Symbol,
 };
 
-fn setup_env() -> (Env, Address, Address, crate::CallRegistry) {
+fn setup_env() -> (Env, Address, Address, crate::CallRegistryClient) {
     let env = Env::default();
     env.mock_all_auths();
 
     let contract_id = env.register_contract(None, crate::CallRegistry);
-    let client = crate::CallRegistry::new(&env, &contract_id);
+    let client = crate::CallRegistryClient::new(&env, &contract_id);
     // use client for calls
     let admin = Address::generate(&env);
     let outcome_manager = Address::generate(&env);
@@ -62,7 +62,7 @@ fn test_propose_and_vote_and_execute() {
         let voting_end = current_ledger + 2000;
 
         // propose_change
-        let new_val: Val = 200u32.into_val(&env);
+        let new_val: i128 = 200;
         let result = crate::governance::propose_change(
             &env,
             staker.clone(),
@@ -154,7 +154,7 @@ fn test_proposal_rejected_insufficient_votes() {
         let current_ledger = env.ledger().sequence();
         let voting_end = current_ledger + 2000;
 
-        let new_val: Val = 300u32.into_val(&env);
+        let new_val: i128 = 300;
         let proposal_id = crate::governance::propose_change(
             &env,
             proposer.clone(),
@@ -223,7 +223,7 @@ fn test_non_staker_cannot_propose() {
 
         let current_ledger = env.ledger().sequence();
         let voting_end = current_ledger + 2000;
-        let new_val: Val = 100u32.into_val(&env);
+        let new_val: i128 = 100;
         let result = crate::governance::propose_change(
             &env,
             non_staker,
@@ -274,7 +274,7 @@ fn test_non_staker_cannot_vote() {
 
         let current_ledger = env.ledger().sequence();
         let voting_end = current_ledger + 2000;
-        let new_val: Val = 50u32.into_val(&env);
+        let new_val: i128 = 50;
         let proposal_id = crate::governance::propose_change(
             &env,
             proposer,
@@ -330,8 +330,8 @@ fn test_get_active_proposals() {
         let current_ledger = env.ledger().sequence();
         let voting_end = current_ledger + 2000;
 
-        let val1: Val = 100u32.into_val(&env);
-        let val2: Val = 200u32.into_val(&env);
+        let val1: i128 = 100;
+        let val2: i128 = 200;
         crate::governance::propose_change(
             &env,
             proposer.clone(),

--- a/packages/contracts/call_registry/src/governance_tests.rs
+++ b/packages/contracts/call_registry/src/governance_tests.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
     Address, Env, Symbol,
 };
 
-fn setup_env() -> (Env, Address, Address, crate::CallRegistryClient) {
+fn setup_env() -> (Env, Address, Address, crate::CallRegistryClient<'static>) {
     let env = Env::default();
     env.mock_all_auths();
 

--- a/packages/contracts/call_registry/src/governance_tests.rs
+++ b/packages/contracts/call_registry/src/governance_tests.rs
@@ -1,0 +1,355 @@
+#![cfg(test)]
+
+use crate::types::{CallInitArgs, ConditionType, ProposalStatus};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Bytes, BytesN, Env, IntoVal, Symbol, Val,
+};
+
+fn setup_env() -> (Env, Address, Address, crate::CallRegistry) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, crate::CallRegistry);
+    let client = crate::CallRegistry::new(&env, &contract_id);
+    // use client for calls
+    let admin = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+    (env, admin, outcome_manager, client)
+}
+
+#[test]
+fn test_propose_and_vote_and_execute() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, crate::CallRegistry);
+    let admin = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        use crate::storage::*;
+        use crate::types::*;
+        use soroban_sdk::Map;
+
+        // Init config with governance defaults
+        let config = ContractConfig {
+            admin: admin.clone(),
+            outcome_manager: outcome_manager.clone(),
+            fee_bps: 0,
+            max_stake_per_user: 0,
+            whitelisted_tokens: Map::new(&env),
+            min_stake: 1,
+            metadata_version: 0,
+            paused: false,
+            staking_cutoff_secs: 0,
+            share_wasm_hash: None,
+            proposal_threshold: 0,
+            governance_quorum_bps: 500,
+            voting_period_ledgers: 1000,
+        };
+        set_config(&env, &config);
+
+        // Give a staker some stake volume
+        let staker = Address::generate(&env);
+        accumulate_user_stake_volume(&env, &staker, 10_000_000);
+        // total_stake_volume in global stats
+        let mut gs = get_global_stats(&env);
+        gs.total_stake_volume = 10_000_000;
+        env.storage().instance().set(&DataKey::GlobalStats, &gs);
+
+        let current_ledger = env.ledger().sequence();
+        let voting_end = current_ledger + 2000;
+
+        // propose_change
+        let new_val: Val = 200u32.into_val(&env);
+        let result = crate::governance::propose_change(
+            &env,
+            staker.clone(),
+            Symbol::new(&env, "fee_bps"),
+            new_val,
+            voting_end,
+        );
+        assert!(result.is_ok());
+        let proposal_id = result.unwrap();
+        assert_eq!(proposal_id, 1);
+
+        // vote yes
+        let vote_result = crate::governance::vote(&env, staker.clone(), proposal_id, true);
+        assert!(vote_result.is_ok());
+
+        // Cannot vote twice
+        let dupe = crate::governance::vote(&env, staker.clone(), proposal_id, true);
+        assert_eq!(dupe, Err(crate::errors::CallRegistryError::AlreadyVoted));
+
+        // Cannot execute before deadline
+        let early = crate::governance::execute_proposal(&env, proposal_id);
+        assert_eq!(
+            early,
+            Err(crate::errors::CallRegistryError::VotingNotEnded)
+        );
+
+        // Advance ledger past voting_end
+        env.ledger().set(LedgerInfo {
+            timestamp: 0,
+            protocol_version: 22,
+            sequence_number: voting_end + 1,
+            network_id: [0u8; 32],
+            base_reserve: 5_000_000,
+            min_temp_entry_ttl: 1,
+            min_persistent_entry_ttl: 1,
+            max_entry_ttl: 6_312_000,
+        });
+
+        let exec_result = crate::governance::execute_proposal(&env, proposal_id);
+        assert!(exec_result.is_ok());
+
+        // Verify config was updated
+        let updated_config = get_config(&env).unwrap();
+        assert_eq!(updated_config.fee_bps, 200);
+
+        // Proposal status should be Executed
+        let proposal = get_proposal(&env, proposal_id).unwrap();
+        assert_eq!(proposal.status, ProposalStatus::Executed);
+    });
+}
+
+#[test]
+fn test_proposal_rejected_insufficient_votes() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, crate::CallRegistry);
+    let admin = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        use crate::storage::*;
+        use crate::types::*;
+        use soroban_sdk::Map;
+
+        let config = ContractConfig {
+            admin: admin.clone(),
+            outcome_manager: outcome_manager.clone(),
+            fee_bps: 0,
+            max_stake_per_user: 0,
+            whitelisted_tokens: Map::new(&env),
+            min_stake: 1,
+            metadata_version: 0,
+            paused: false,
+            staking_cutoff_secs: 0,
+            share_wasm_hash: None,
+            proposal_threshold: 0,
+            governance_quorum_bps: 5000, // 50% quorum — very hard to reach
+            voting_period_ledgers: 1000,
+        };
+        set_config(&env, &config);
+
+        let proposer = Address::generate(&env);
+        accumulate_user_stake_volume(&env, &proposer, 100);
+        let mut gs = get_global_stats(&env);
+        gs.total_stake_volume = 1_000_000; // proposer's 100 is way below 50% quorum
+        env.storage().instance().set(&DataKey::GlobalStats, &gs);
+
+        let current_ledger = env.ledger().sequence();
+        let voting_end = current_ledger + 2000;
+
+        let new_val: Val = 300u32.into_val(&env);
+        let proposal_id = crate::governance::propose_change(
+            &env,
+            proposer.clone(),
+            Symbol::new(&env, "fee_bps"),
+            new_val,
+            voting_end,
+        )
+        .unwrap();
+
+        // vote yes with tiny power — well below quorum
+        crate::governance::vote(&env, proposer.clone(), proposal_id, true).unwrap();
+
+        // Advance ledger
+        env.ledger().set(LedgerInfo {
+            timestamp: 0,
+            protocol_version: 22,
+            sequence_number: voting_end + 1,
+            network_id: [0u8; 32],
+            base_reserve: 5_000_000,
+            min_temp_entry_ttl: 1,
+            min_persistent_entry_ttl: 1,
+            max_entry_ttl: 6_312_000,
+        });
+
+        let exec_result = crate::governance::execute_proposal(&env, proposal_id);
+        assert_eq!(exec_result, Err(crate::errors::CallRegistryError::QuorumNotMet));
+
+        let proposal = get_proposal(&env, proposal_id).unwrap();
+        assert_eq!(proposal.status, ProposalStatus::Rejected);
+    });
+}
+
+#[test]
+fn test_non_staker_cannot_propose() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, crate::CallRegistry);
+    let admin = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        use crate::storage::*;
+        use crate::types::*;
+        use soroban_sdk::Map;
+
+        let config = ContractConfig {
+            admin: admin.clone(),
+            outcome_manager: outcome_manager.clone(),
+            fee_bps: 0,
+            max_stake_per_user: 0,
+            whitelisted_tokens: Map::new(&env),
+            min_stake: 1,
+            metadata_version: 0,
+            paused: false,
+            staking_cutoff_secs: 0,
+            share_wasm_hash: None,
+            proposal_threshold: 1_000, // requires at least 1000 stake volume
+            governance_quorum_bps: 500,
+            voting_period_ledgers: 1000,
+        };
+        set_config(&env, &config);
+
+        let non_staker = Address::generate(&env);
+        // non_staker has 0 stake volume
+
+        let current_ledger = env.ledger().sequence();
+        let voting_end = current_ledger + 2000;
+        let new_val: Val = 100u32.into_val(&env);
+        let result = crate::governance::propose_change(
+            &env,
+            non_staker,
+            Symbol::new(&env, "fee_bps"),
+            new_val,
+            voting_end,
+        );
+        assert_eq!(result, Err(crate::errors::CallRegistryError::InsufficientStake));
+    });
+}
+
+#[test]
+fn test_non_staker_cannot_vote() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, crate::CallRegistry);
+    let admin = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        use crate::storage::*;
+        use crate::types::*;
+        use soroban_sdk::Map;
+
+        let config = ContractConfig {
+            admin: admin.clone(),
+            outcome_manager: outcome_manager.clone(),
+            fee_bps: 0,
+            max_stake_per_user: 0,
+            whitelisted_tokens: Map::new(&env),
+            min_stake: 1,
+            metadata_version: 0,
+            paused: false,
+            staking_cutoff_secs: 0,
+            share_wasm_hash: None,
+            proposal_threshold: 0,
+            governance_quorum_bps: 500,
+            voting_period_ledgers: 1000,
+        };
+        set_config(&env, &config);
+
+        let proposer = Address::generate(&env);
+        accumulate_user_stake_volume(&env, &proposer, 10_000);
+        let mut gs = get_global_stats(&env);
+        gs.total_stake_volume = 10_000;
+        env.storage().instance().set(&DataKey::GlobalStats, &gs);
+
+        let current_ledger = env.ledger().sequence();
+        let voting_end = current_ledger + 2000;
+        let new_val: Val = 50u32.into_val(&env);
+        let proposal_id = crate::governance::propose_change(
+            &env,
+            proposer,
+            Symbol::new(&env, "fee_bps"),
+            new_val,
+            voting_end,
+        )
+        .unwrap();
+
+        let non_staker = Address::generate(&env);
+        let result = crate::governance::vote(&env, non_staker, proposal_id, true);
+        assert_eq!(result, Err(crate::errors::CallRegistryError::InsufficientStake));
+    });
+}
+
+#[test]
+fn test_get_active_proposals() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, crate::CallRegistry);
+    let admin = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        use crate::storage::*;
+        use crate::types::*;
+        use soroban_sdk::Map;
+
+        let config = ContractConfig {
+            admin: admin.clone(),
+            outcome_manager: outcome_manager.clone(),
+            fee_bps: 0,
+            max_stake_per_user: 0,
+            whitelisted_tokens: Map::new(&env),
+            min_stake: 1,
+            metadata_version: 0,
+            paused: false,
+            staking_cutoff_secs: 0,
+            share_wasm_hash: None,
+            proposal_threshold: 0,
+            governance_quorum_bps: 500,
+            voting_period_ledgers: 1000,
+        };
+        set_config(&env, &config);
+
+        let proposer = Address::generate(&env);
+        accumulate_user_stake_volume(&env, &proposer, 10_000);
+        let mut gs = get_global_stats(&env);
+        gs.total_stake_volume = 10_000;
+        env.storage().instance().set(&DataKey::GlobalStats, &gs);
+
+        let current_ledger = env.ledger().sequence();
+        let voting_end = current_ledger + 2000;
+
+        let val1: Val = 100u32.into_val(&env);
+        let val2: Val = 200u32.into_val(&env);
+        crate::governance::propose_change(
+            &env,
+            proposer.clone(),
+            Symbol::new(&env, "fee_bps"),
+            val1,
+            voting_end,
+        )
+        .unwrap();
+        crate::governance::propose_change(
+            &env,
+            proposer.clone(),
+            Symbol::new(&env, "min_stake"),
+            val2,
+            voting_end,
+        )
+        .unwrap();
+
+        let active = crate::governance::get_active_proposals(&env);
+        assert_eq!(active.len(), 2);
+    });
+}

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -78,6 +78,9 @@ mod errors;
 mod events;
 #[cfg(test)]
 mod fuzz_tests;
+mod governance;
+#[cfg(test)]
+mod governance_tests;
 mod sep10;
 mod shares;
 mod storage;
@@ -160,6 +163,9 @@ impl CallRegistry {
             paused: false,
             staking_cutoff_secs: 300,
             share_wasm_hash: None,
+            proposal_threshold: 0,
+            governance_quorum_bps: 500,
+            voting_period_ledgers: 120_960,
         };
 
         set_config(&env, &config);
@@ -1358,4 +1364,52 @@ impl CallRegistry {
     pub fn get_sep10_home_domain(env: Env, user: Address) -> Option<Bytes> {
         get_sep10_domain(&env, &user)
     }
+    // ---- On-chain governance ------------------------------------------------
+
+    /// Create a governance proposal to change a contract parameter.
+    pub fn propose_change(
+        env: Env,
+        proposer: Address,
+        parameter: Symbol,
+        new_value: soroban_sdk::Val,
+        voting_end_ledger: u32,
+    ) -> Result<u64, CallRegistryError> {
+        governance::propose_change(&env, proposer, parameter, new_value, voting_end_ledger)
+    }
+
+    /// Cast a weighted vote on a governance proposal.
+    pub fn vote(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        support: bool,
+    ) -> Result<(), CallRegistryError> {
+        governance::vote(&env, voter, proposal_id, support)
+    }
+
+    /// Execute a passed proposal after its voting deadline has elapsed.
+    pub fn execute_proposal(env: Env, proposal_id: u64) -> Result<(), CallRegistryError> {
+        governance::execute_proposal(&env, proposal_id)
+    }
+
+    /// Return a governance proposal by ID.
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<types::GovernanceProposal> {
+        governance::get_proposal_view(&env, proposal_id)
+    }
+
+    /// Return all currently-active proposals (capped at 50).
+    pub fn get_active_proposals(env: Env) -> soroban_sdk::Vec<types::GovernanceProposal> {
+        governance::get_active_proposals(&env)
+    }
+
+    /// Return vote tallies for a proposal.
+    pub fn get_proposal_votes(env: Env, proposal_id: u64) -> Option<types::ProposalVotes> {
+        governance::get_proposal_votes_view(&env, proposal_id)
+    }
+
+    /// Return a user's cumulative historical stake volume (governance vote power).
+    pub fn get_user_stake_volume(env: Env, user: Address) -> i128 {
+        storage::get_user_total_stake_volume(&env, &user)
+    }
+
 }

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -1371,7 +1371,7 @@ impl CallRegistry {
         env: Env,
         proposer: Address,
         parameter: Symbol,
-        new_value: soroban_sdk::Val,
+        new_value: i128,
         voting_end_ledger: u32,
     ) -> Result<u64, CallRegistryError> {
         governance::propose_change(&env, proposer, parameter, new_value, voting_end_ledger)

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -1,4 +1,7 @@
-use crate::types::{Call, ContractConfig, CreatorStats, GlobalStats, StorageStats};
+use crate::types::{
+    Call, ContractConfig, CreatorStats, GlobalStats, GovernanceProposal, ProposalVotes,
+    StorageStats,
+};
 use soroban_sdk::{contracttype, Address, Bytes, Env};
 
 // ~120 days in ledgers (5s per ledger): 120 * 24 * 3600 / 5 = 2_073_600
@@ -27,6 +30,17 @@ pub enum DataKey {
     VoidRefundClaimed(u64, Address),
     InstanceEntryCount,
     Sep10Domain(Address),
+    // ── Governance keys ───────────────────────────────────────────────────
+    /// Monotonically-increasing proposal ID counter.
+    ProposalCounter,
+    /// A single governance proposal.
+    Proposal(u64),
+    /// Separate vote-tally record for a proposal.
+    ProposalVotes(u64),
+    /// Sentinel: records that `voter` has already voted on `proposal_id`.
+    UserVoted(u64, Address),
+    /// Per-user cumulative stake volume across all resolved calls.
+    UserStakeVolume(Address),
 }
 
 /// Store contract configuration
@@ -264,6 +278,9 @@ pub fn record_stake(env: &Env, staker: &Address, amount: i128) {
     }
 
     env.storage().instance().set(&DataKey::GlobalStats, &stats);
+
+    // Accumulate per-user stake volume for governance vote-power tracking.
+    accumulate_user_stake_volume(env, staker, amount);
 }
 
 /// Get current call counter
@@ -428,4 +445,101 @@ pub fn set_sep10_domain(env: &Env, user: &Address, domain: &Bytes) {
 pub fn get_sep10_domain(env: &Env, user: &Address) -> Option<Bytes> {
     let key = DataKey::Sep10Domain(user.clone());
     env.storage().persistent().get(&key)
+}
+
+// ── Governance storage ────────────────────────────────────────────────────────
+
+/// Get the current proposal ID counter (last assigned ID).
+pub fn get_proposal_counter(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ProposalCounter)
+        .unwrap_or(0)
+}
+
+/// Update the proposal ID counter.
+pub fn set_proposal_counter(env: &Env, counter: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ProposalCounter, &counter);
+}
+
+/// Persist a proposal to persistent storage.
+pub fn set_proposal(env: &Env, proposal: &GovernanceProposal) {
+    let key = DataKey::Proposal(proposal.id);
+    env.storage().persistent().set(&key, proposal);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+/// Retrieve a proposal by ID.
+pub fn get_proposal(env: &Env, proposal_id: u64) -> Option<GovernanceProposal> {
+    let key = DataKey::Proposal(proposal_id);
+    let result: Option<GovernanceProposal> = env.storage().persistent().get(&key);
+    if result.is_some() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    result
+}
+
+/// Persist vote tallies for a proposal.
+pub fn set_proposal_votes(env: &Env, proposal_id: u64, votes: &ProposalVotes) {
+    let key = DataKey::ProposalVotes(proposal_id);
+    env.storage().persistent().set(&key, votes);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+/// Retrieve vote tallies for a proposal.
+pub fn get_proposal_votes(env: &Env, proposal_id: u64) -> Option<ProposalVotes> {
+    let key = DataKey::ProposalVotes(proposal_id);
+    env.storage().persistent().get(&key)
+}
+
+/// Mark that `voter` has voted on `proposal_id`.
+pub fn set_user_vote_on_proposal(env: &Env, proposal_id: u64, voter: &Address) {
+    let key = DataKey::UserVoted(proposal_id, voter.clone());
+    env.storage().persistent().set(&key, &true);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+/// Return `true` if `voter` has already voted on `proposal_id`.
+pub fn user_has_voted(env: &Env, proposal_id: u64, voter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::UserVoted(proposal_id, voter.clone()))
+}
+
+/// Accumulate stake amount into the user's lifetime stake volume counter.
+/// Called from `record_stake` so every staking action updates vote power.
+pub fn accumulate_user_stake_volume(env: &Env, staker: &Address, amount: i128) {
+    let key = DataKey::UserStakeVolume(staker.clone());
+    let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+    let updated = current + amount;
+    env.storage().persistent().set(&key, &updated);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+/// Return a user's cumulative historical stake volume (used as governance vote power).
+pub fn get_user_total_stake_volume(env: &Env, staker: &Address) -> i128 {
+    let key = DataKey::UserStakeVolume(staker.clone());
+    env.storage().persistent().get(&key).unwrap_or(0)
 }

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Bytes, BytesN, Map, Symbol, Val};
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Map, Symbol};
 
 /// Describes the price-movement condition that determines the winning outcome.
 ///
@@ -229,8 +229,8 @@ pub struct GovernanceProposal {
     pub proposer: Address,
     /// The name of the parameter to change (e.g. `Symbol::new(env, "fee_bps")`).
     pub parameter: Symbol,
-    /// The proposed new value, encoded as a generic `Val`.
-    pub new_value: Val,
+    /// The proposed new value, encoded as i128 (covers u32, u64, and i128 params).
+    pub new_value: i128,
     /// The ledger sequence number after which `execute_proposal` may be called.
     pub voting_end_ledger: u32,
     /// Current lifecycle state.

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Bytes, BytesN, Map};
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Map, Symbol, Val};
 
 /// Describes the price-movement condition that determines the winning outcome.
 ///
@@ -141,6 +141,17 @@ pub struct ContractConfig {
     pub staking_cutoff_secs: u64,
     /// Wasm hash for the share token contract (if enabled)
     pub share_wasm_hash: Option<BytesN<32>>,
+
+    // ── Governance parameters ──────────────────────────────────────────────
+    /// Minimum cumulative stake volume a user must have to create a proposal.
+    /// Default: 0 (any staker may propose).
+    pub proposal_threshold: i128,
+    /// Percentage of total platform stake volume required for a proposal to pass,
+    /// expressed in basis points (e.g. 500 = 5%). Default: 500.
+    pub governance_quorum_bps: u32,
+    /// Default voting window in ledgers. Used for informational purposes;
+    /// each proposal sets its own `voting_end_ledger`.
+    pub voting_period_ledgers: u32,
 }
 
 /// Contract-wide aggregated statistics for dashboards.
@@ -190,6 +201,53 @@ pub struct StorageStats {
     pub call_count: u64,
     /// Number of entries currently tracked in instance storage.
     pub instance_entry_count: u32,
-    /// Rough byte estimate for instance storage (entry_count × 128 bytes).
+    /// Rough estimate of instance storage bytes used (entry_count × 128 B).
     pub estimated_instance_bytes: u32,
+}
+
+// ── Governance types ──────────────────────────────────────────────────────────
+
+/// Lifecycle state of a governance proposal.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProposalStatus {
+    /// Voting is open.
+    Active,
+    /// Passed quorum and has been applied.
+    Executed,
+    /// Did not pass (insufficient votes or quorum not met).
+    Rejected,
+}
+
+/// An on-chain governance proposal to change a contract parameter.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GovernanceProposal {
+    /// Unique monotonically-increasing proposal identifier.
+    pub id: u64,
+    /// Address that created this proposal.
+    pub proposer: Address,
+    /// The name of the parameter to change (e.g. `Symbol::new(env, "fee_bps")`).
+    pub parameter: Symbol,
+    /// The proposed new value, encoded as a generic `Val`.
+    pub new_value: Val,
+    /// The ledger sequence number after which `execute_proposal` may be called.
+    pub voting_end_ledger: u32,
+    /// Current lifecycle state.
+    pub status: ProposalStatus,
+    /// Accumulated yes-vote weight (sum of voters' stake volumes).
+    pub yes_votes: i128,
+    /// Accumulated no-vote weight (sum of voters' stake volumes).
+    pub no_votes: i128,
+    /// Total platform stake volume snapshotted at proposal creation; used to
+    /// calculate the quorum threshold at execution time.
+    pub total_volume_snapshot: i128,
+}
+
+/// Vote tallies stored separately for efficient incremental updates.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProposalVotes {
+    pub yes: i128,
+    pub no: i128,
 }


### PR DESCRIPTION
## Summary

Implements a lightweight on-chain governance system for the call_registry contract, allowing stakers to propose and vote on contract parameter changes.

## Changes

**New files:**
- call_registry/src/governance.rs — propose_change, ote, xecute_proposal, and view functions
- call_registry/src/governance_tests.rs — full test suite

**Modified files:**
- 	ypes.rs — GovernanceProposal, ProposalStatus, ProposalVotes types; governance fields added to ContractConfig
- storage.rs — Proposal, ProposalVotes, UserVoted, UserStakeVolume storage keys and accessors; ccumulate_user_stake_volume called from 
ecord_stake
- vents.rs — ProposalCreated, VoteCast, ProposalExecuted, ProposalRejected events
- rrors.rs — governance error variants (17-24)
- lib.rs — mod governance, governance entry points in #[contractimpl], governance defaults in initialize

## Acceptance Criteria Coverage

- [x] propose_change — proposer must meet proposal_threshold stake volume
- [x] ote — stake-weighted, uses historical volume (flash-loan resistant)
- [x] xecute_proposal — checks quorum (governance_quorum_bps) and deadline
- [x] ContractConfig governance fields: proposal_threshold, governance_quorum_bps, oting_period_ledgers
- [x] Events: ProposalCreated, VoteCast, ProposalExecuted, ProposalRejected
- [x] View functions: get_proposal, get_active_proposals, get_proposal_votes, get_user_stake_volume
- [x] Admin fast-track unchanged; governance is an additive path
- [x] Tests: create proposal, vote, pass quorum + execute, reject (insufficient quorum), execute before deadline fails, non-staker cannot propose, non-staker cannot vote

closes #404