### PR TITLE
feat(frontend): add live countdown timer on CallCard components (#219)

### DIFF
--- a/packages/frontend/src/components/CallCard.tsx
+++ b/packages/frontend/src/components/CallCard.tsx
@@ -2,35 +2,17 @@
 
 import StakeBar from "./StakeBar";
 import ShareButton from "./ShareButton";
+import CountdownTimer from "./CountdownTimer";
 
 interface CallCardProps {
   call: any;
 }
 
 export default function CallCard({ call }: CallCardProps) {
-  // Calculate time remaining
-  const calculateTimeRemaining = () => {
-    if (!call.endTime) return "Unknown";
-    
-    const now = new Date().getTime();
-    const end = new Date(call.endTime).getTime();
-    const diff = end - now;
-
-    if (diff <= 0) return "Ended";
-
-    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-    const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-
-    if (days > 0) return `${days}d ${hours}h`;
-    if (hours > 0) return `${hours}h ${minutes}m`;
-    return `${minutes}m`;
-  };
-
   // Determine status
   const getStatus = () => {
     if (call.resolved) return "Ended";
-    if (call.outcome === 'CLAIMS_READY') return "Claims Ready";
+    if (call.outcome === "CLAIMS_READY") return "Claims Ready";
     return "Open";
   };
 
@@ -43,18 +25,22 @@ export default function CallCard({ call }: CallCardProps) {
             <span className="font-bold text-lg">{call.token}</span>
           </div>
           <div className="flex items-center gap-2 ml-2">
-            <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-              getStatus() === "Open" ? "bg-green-100 text-green-800" :
-              getStatus() === "Ended" ? "bg-gray-100 text-gray-800" :
-              "bg-blue-100 text-blue-800"
-            }`}>
+            <span
+              className={`px-2 py-1 rounded-full text-xs font-medium ${
+                getStatus() === "Open"
+                  ? "bg-green-100 text-green-800"
+                  : getStatus() === "Ended"
+                    ? "bg-gray-100 text-gray-800"
+                    : "bg-blue-100 text-blue-800"
+              }`}
+            >
               {getStatus()}
             </span>
           </div>
         </div>
         <div className="text-right">
           <div className="text-sm text-gray-500">Time Remaining</div>
-          <div className="text-sm font-medium text-orange-500">{calculateTimeRemaining()}</div>
+          <CountdownTimer endTime={call.endTime} resolved={call.resolved} />
         </div>
       </div>
 
@@ -80,15 +66,25 @@ export default function CallCard({ call }: CallCardProps) {
             </div>
             {/* Reputation badge */}
             <div className="absolute -bottom-1 -right-1 bg-yellow-400 rounded-full p-1 border border-white">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-3 h-3 text-yellow-700">
-                <path fillRule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.007 5.404.433c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.433 2.082-5.006z" clipRule="evenodd" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-3 h-3 text-yellow-700"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.007 5.404.433c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.433 2.082-5.006z"
+                  clipRule="evenodd"
+                />
               </svg>
             </div>
           </div>
           <div>
             <div className="text-sm font-medium">Creator</div>
             <div className="text-xs text-gray-500 truncate max-w-[120px]">
-              {call.creatorAddress?.substring(0, 6)}...{call.creatorAddress?.substring(call.creatorAddress.length - 4)}
+              {call.creatorAddress?.substring(0, 6)}...
+              {call.creatorAddress?.substring(call.creatorAddress.length - 4)}
             </div>
           </div>
         </div>

--- a/packages/frontend/src/components/CountdownTimer.tsx
+++ b/packages/frontend/src/components/CountdownTimer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface CountdownTimerProps {
+  endTime: string | number | Date;
+  resolved?: boolean;
+}
+
+export default function CountdownTimer({
+  endTime,
+  resolved,
+}: CountdownTimerProps) {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const end = new Date(endTime).getTime();
+  const diff = end - now;
+
+  if (resolved || diff <= 0) {
+    return <span className="text-sm font-medium text-gray-400">Ended</span>;
+  }
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+  if (days > 0) {
+    const dateStr = new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+    }).format(end);
+    return (
+      <span className="text-sm font-medium text-green-600">Ends {dateStr}</span>
+    );
+  }
+
+  const colorClass = hours > 0 ? "text-yellow-600" : "text-red-600";
+  const timeStr =
+    hours > 0 ? `${hours}h ${minutes}m ${seconds}s` : `${minutes}m ${seconds}s`;
+
+  return (
+    <span className={`text-sm font-medium ${colorClass}`}>
+      Ends in {timeStr}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #219 — replaces static date display on CallCards with a live countdown timer.

## Changes

- **New** `CountdownTimer.tsx` — a self-contained component that:
  - Updates every second via `setInterval` with proper cleanup on unmount
  - Accepts `endTime` (string/number/Date) and optional `resolved` boolean
- **Updated** `CallCard.tsx` — removed the static `calculateTimeRemaining` function, replaced with `<CountdownTimer>` component

## Behavior

| Condition | Display | Text Color |
|---|---|---|
| Resolved or expired | `Ended` | Grey (`text-gray-400`) |
| Less than 1 hour | `Ends in 45m 12s` | Red (`text-red-600`) |
| 1–24 hours | `Ends in 3h 45m 12s` | Yellow (`text-yellow-600`) |
| More than 24 hours | `Ends Jan 15` | Green (`text-green-600`) |

## Verification

- `tsc --noEmit` — clean
- `eslint` — clean (frontend)