### PR TITLE
feat(outcome-manager): on-chain claim payout with automatic stake ver…

### DIFF
--- a/packages/contracts/outcome_manager/src/call_types.rs
+++ b/packages/contracts/outcome_manager/src/call_types.rs
@@ -1,0 +1,63 @@
+//! Local mirror of CallRegistry types for cross-contract deserialisation.
+//! These must stay in sync with `call_registry/src/types.rs` and
+//! `call_registry/src/errors.rs`.
+
+use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Map};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum CallRegistryError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    InvalidStakeAmount = 3,
+    InvalidEndTime = 4,
+    CallNotFound = 5,
+    CallEnded = 6,
+    CallSettled = 7,
+    InvalidPosition = 8,
+    Unauthorized = 9,
+    ContractPaused = 10,
+    CallNotEnded = 11,
+    InvalidOutcome = 12,
+    InvalidOutcomeCount = 13,
+    FeeTooHigh = 14,
+    StakingCutoffActive = 15,
+    Sep10TokenExpired = 16,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConditionType {
+    TargetAbove(i128),
+    TargetBelow(i128),
+    PercentUp(u32),
+    PercentDown(u32),
+    Range(i128, i128),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Call {
+    pub id: u64,
+    pub creator: Address,
+    pub stake_token: Address,
+    pub stake_amount: i128,
+    pub end_ts: u64,
+    pub token_address: Address,
+    pub pair_id: Bytes,
+    pub metadata_hash: BytesN<32>,
+    pub outcome_count: u32,
+    pub outcome_stakes: Map<u32, i128>,
+    pub stakes: Map<u32, Map<Address, i128>>,
+    pub outcome: u32,
+    pub start_price: i128,
+    pub end_price: i128,
+    pub condition: ConditionType,
+    pub settled: bool,
+    pub voided: bool,
+    pub created_at: u64,
+    pub cancelled: bool,
+    pub metadata_version: u32,
+    pub share_tokens: Map<u32, Address>,
+}

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -597,9 +597,7 @@ impl OutcomeManager {
         for i in 0..stakers.len() {
             let staker = stakers.get(i).unwrap();
 
-            // Read staker's stake on the winning outcome from the registry
-            let staker_winning_stake =
-                registry_get_staker_stake(&env, &registry, call_id, &staker, winning_outcome);
+            let staker_winning_stake = stakes.get(i).unwrap();
             if staker_winning_stake <= 0 {
                 soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
             }

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -28,6 +28,7 @@
 #![no_std]
 
 mod auth;
+mod call_types;
 mod errors;
 mod events;
 mod storage;
@@ -38,6 +39,7 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, 
 
 use auth::require_admin;
 use backit_shared::{is_valid_fee_bps, is_valid_outcome};
+use call_types::{Call, CallRegistryError};
 use errors::OutcomeError;
 use events::{
     emit_admin_params_changed, emit_batch_payout_started, emit_contract_upgraded,
@@ -45,8 +47,8 @@ use events::{
     emit_payout_claimed, emit_price_observation_submitted,
 };
 use storage::{
-    set_dispute_window, set_max_submission_delay, InstanceKey, OracleVote, Outcome, PersistentKey,
-    PriceObservation, SignedOutcome, TempKey,
+    set_dispute_window, set_max_submission_delay, InstanceKey, OracleVote, Outcome,
+    PersistentKey, PriceObservation, SignedOutcome, TempKey,
 };
 use verification::{build_message, verify_signature};
 
@@ -83,6 +85,34 @@ fn registry_release_escrow(
 fn registry_mark_settled(env: &Env, registry: &Address, call_id: u64) {
     let args = (call_id,).into_val(env);
     env.invoke_contract::<()>(registry, &Symbol::new(env, "mark_settled"), args);
+}
+
+/// Call `get_call(call_id)` on the CallRegistry and return the decoded Call.
+fn registry_get_call(env: &Env, registry: &Address, call_id: u64) -> Call {
+    let args = (call_id,).into_val(env);
+    let result: Result<Call, CallRegistryError> =
+        env.invoke_contract(registry, &Symbol::new(env, "get_call"), args);
+    match result {
+        Ok(call) => call,
+        Err(_) => soroban_sdk::panic_with_error!(env, OutcomeError::CallNotSettled),
+    }
+}
+
+/// Call `get_staker_stake(call_id, staker, position)` on the CallRegistry.
+fn registry_get_staker_stake(
+    env: &Env,
+    registry: &Address,
+    call_id: u64,
+    staker: &Address,
+    position: u32,
+) -> i128 {
+    let args = (call_id, staker.clone(), position).into_val(env);
+    let result: Result<i128, CallRegistryError> =
+        env.invoke_contract(registry, &Symbol::new(env, "get_staker_stake"), args);
+    match result {
+        Ok(stake) => stake,
+        Err(_) => 0,
+    }
 }
 
 // ─── Pause helper ─────────────────────────────────────────────────────────────
@@ -334,6 +364,15 @@ impl OutcomeManager {
             .set(&InstanceKey::Admin, &new_admin);
     }
 
+    /// Store the CallRegistry address (admin only).
+    ///
+    /// This is used by `claim_payout` and `finalize_outcome` to make
+    /// cross-contract calls so that callers cannot spoof stake data.
+    pub fn set_registry(env: Env, registry: Address) {
+        require_admin(&env);
+        storage::set_registry(&env, registry);
+    }
+
     /// Set the maximum seconds an oracle report may lag behind `call_end_ts`
     /// (admin only). Reports submitted after this window are rejected with
     /// [`OutcomeError::SubmissionWindowExpired`]. Default: 86400 (24 h).
@@ -505,6 +544,10 @@ impl OutcomeManager {
 
     /// Claim a pro-rata payout for a winning staker.
     ///
+    /// Stake data is read on-chain from the CallRegistry via cross-contract
+    /// calls to `get_call` and `get_staker_stake`, preventing the caller from
+    /// spoofing pool totals.
+    ///
     /// **Payout formula** (with protocol fee):
     /// ```text
     /// fee        = total_losing_stake * fee_bps / 10000
@@ -518,19 +561,12 @@ impl OutcomeManager {
     /// call, preventing reentrancy attacks.
     ///
     /// # Panics
-    /// - `call not settled`       – quorum not yet reached
-    /// - `already claimed`        – staker already claimed
-    /// - `nothing to claim`       – staker_winning_stake ≤ 0
-    /// - `invalid total winning`  – total_winning_stake ≤ 0
-    pub fn claim_payout(
-        env: Env,
-        registry: Address,
-        call_id: u64,
-        staker: Address,
-        staker_winning_stake: i128,
-        total_winning_stake: i128,
-        total_losing_stake: i128,
-    ) {
+    /// - `contract paused`      – emergency pause is active
+    /// - `call not settled`     – quorum not yet reached
+    /// - `already claimed`      – staker already claimed
+    /// - `nothing to claim`     – staker has no stake on the winning outcome
+    /// - `invalid total winning` – winning pool is empty
+    pub fn claim_payout(env: Env, call_id: u64, staker: Address) {
         // 0. Check if contract is paused (emergency guard)
         if is_paused(&env) {
             soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
@@ -548,22 +584,45 @@ impl OutcomeManager {
             soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadyClaimed);
         }
 
-        // 4. Validate inputs
-        if staker_winning_stake <= 0 {
-            soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
-        }
+        // 4. Read registry address from instance storage
+        let registry = get_registry(&env);
+
+        // 5. Read winning outcome from the stored finalised outcome
+        let final_outcome: Outcome = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::FinalOutcome(call_id))
+            .unwrap();
+        let winning_outcome = final_outcome.outcome;
+
+        // 6. Read the full Call from the registry
+        let call = registry_get_call(&env, &registry, call_id);
+
+        // 7. Determine total winning and losing stakes from outcome_stakes
+        let total_winning_stake = call.outcome_stakes.get(winning_outcome).unwrap_or(0);
         if total_winning_stake <= 0 {
             soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidWinningStake);
         }
 
-        // 5. Compute protocol fee from losing pool (only on first claim; fee is
-        //    proportional so each claimant effectively pays their share)
+        let mut total_losing_stake: i128 = 0;
+        for i in 1..=call.outcome_count {
+            if i != winning_outcome {
+                total_losing_stake = total_losing_stake
+                    .checked_add(call.outcome_stakes.get(i).unwrap_or(0))
+                    .unwrap_or_else(|| overflow(&env));
+            }
+        }
+
+        // 8. Read staker's stake on the winning outcome from the registry
+        let staker_winning_stake =
+            registry_get_staker_stake(&env, &registry, call_id, &staker, winning_outcome);
+        if staker_winning_stake <= 0 {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
+        }
+
+        // 9. Compute protocol fee from losing pool
         let (fee_bps, fee_collector) = get_fee_config(&env);
-
-        // Staker's proportional share of the total fee
         let total_fee = compute_total_fee(&env, total_losing_stake, fee_bps);
-
-        // 6. Net losing pool available to winners
         let net_losing = total_losing_stake
             .checked_sub(total_fee)
             .unwrap_or_else(|| overflow(&env));
@@ -576,16 +635,16 @@ impl OutcomeManager {
             net_losing,
         );
 
-        // 8. Mark as claimed BEFORE external calls (reentrancy guard)
+        // 10. Mark as claimed BEFORE external calls (reentrancy guard)
         env.storage().instance().set(&claimed_key, &true);
 
-        // 9. Transfer fee to fee_collector (if non-zero)
+        // 11. Transfer fee to fee_collector (if non-zero)
         if staker_fee_share > 0 {
             registry_release_escrow(&env, &registry, call_id, &fee_collector, staker_fee_share);
             emit_fee_collected(&env, call_id, staker_fee_share, &fee_collector);
         }
 
-        // 10. Release net payout to staker
+        // 12. Release net payout to staker
         registry_release_escrow(&env, &registry, call_id, &staker, payout);
 
         emit_payout_claimed(&env, call_id, &staker, payout);
@@ -688,8 +747,9 @@ impl OutcomeManager {
 
     /// Batch-settle payouts for multiple winning stakers in a single transaction.
     ///
-    /// Admin-only. Each staker in `stakers` is matched positionally with the
-    /// corresponding amount in `stakes`. Both vecs must be the same length.
+    /// Admin-only. Each staker's stake is read on-chain from the CallRegistry
+    /// via `get_staker_stake`, preventing any spoofing of pool totals or
+    /// individual amounts.
     ///
     /// Individual `PayoutClaimed` events are emitted for each staker.
     /// Already-claimed stakers cause the entire batch to panic — callers must
@@ -699,19 +759,10 @@ impl OutcomeManager {
     /// - `not admin`                 – caller is not the contract admin
     /// - `call not settled`          – quorum not yet reached for this call
     /// - `empty batch`               – stakers vec is empty
-    /// - `length mismatch`           – stakers and stakes vecs differ in length
-    /// - `invalid total winning`     – total_winning_stake ≤ 0
+    /// - `invalid total winning`     – winning pool is empty
     /// - `already claimed: <staker>` – a staker in the batch already claimed
     /// - `nothing to claim`          – a staker's stake amount is ≤ 0
-    pub fn batch_claim_payouts(
-        env: Env,
-        registry: Address,
-        call_id: u64,
-        stakers: Vec<Address>,
-        stakes: Vec<i128>,
-        total_winning_stake: i128,
-        total_losing_stake: i128,
-    ) {
+    pub fn batch_claim_payouts(env: Env, call_id: u64, stakers: Vec<Address>) {
         // 1. Admin only
         require_admin(&env);
 
@@ -723,34 +774,54 @@ impl OutcomeManager {
             soroban_sdk::panic_with_error!(&env, OutcomeError::EmptyBatch);
         }
 
-        // 4. Vecs must be same length
-        if stakers.len() != stakes.len() {
-            soroban_sdk::panic_with_error!(&env, OutcomeError::LengthMismatch);
-        }
+        // 4. Read registry address from instance storage
+        let registry = get_registry(&env);
 
-        // 5. Validate shared inputs once
+        // 5. Read winning outcome from the stored finalised outcome
+        let final_outcome: Outcome = env
+            .storage()
+            .instance()
+            .get(&InstanceKey::FinalOutcome(call_id))
+            .unwrap();
+        let winning_outcome = final_outcome.outcome;
+
+        // 6. Read the full Call from the registry
+        let call = registry_get_call(&env, &registry, call_id);
+
+        // 7. Determine total winning and losing stakes
+        let total_winning_stake = call.outcome_stakes.get(winning_outcome).unwrap_or(0);
         if total_winning_stake <= 0 {
             soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidWinningStake);
         }
 
-        // 6. Load fee config once
+        let mut total_losing_stake: i128 = 0;
+        for i in 1..=call.outcome_count {
+            if i != winning_outcome {
+                total_losing_stake = total_losing_stake
+                    .checked_add(call.outcome_stakes.get(i).unwrap_or(0))
+                    .unwrap_or_else(|| overflow(&env));
+            }
+        }
+
+        // 8. Load fee config once
         let (fee_bps, fee_collector) = get_fee_config(&env);
 
         // Pre-compute shared fee values
         let total_fee = compute_total_fee(&env, total_losing_stake, fee_bps);
-
         let net_losing = total_losing_stake
             .checked_sub(total_fee)
             .unwrap_or_else(|| overflow(&env));
 
         emit_batch_payout_started(&env, call_id, stakers.len());
 
-        // 7. Process each staker
+        // 9. Process each staker
         let mut aggregated_fee_share = 0_i128;
         for i in 0..stakers.len() {
             let staker = stakers.get(i).unwrap();
-            let staker_winning_stake = stakes.get(i).unwrap();
 
+            // Read staker's stake on the winning outcome from the registry
+            let staker_winning_stake =
+                registry_get_staker_stake(&env, &registry, call_id, &staker, winning_outcome);
             if staker_winning_stake <= 0 {
                 soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
             }

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -17,6 +17,12 @@ const CLAIM_PAYOUT_BUDGET_MEM: u64 = 100_000;
 const BATCH_CLAIM_PAYOUTS_BUDGET_CPU: u64 = 40_000_000;
 const BATCH_CLAIM_PAYOUTS_BUDGET_MEM: u64 = 2_000_000;
 
+#[contracttype]
+pub enum MockDataKey {
+    Call(u64),
+    StakerStake(u64, Address, u32),
+}
+
 #[contract]
 pub struct MockRegistry;
 
@@ -125,7 +131,6 @@ fn setup_single_oracle(
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
 
     let registry_id = env.register_contract(None, MockRegistry);
-    client.set_registry(&registry_id);
 
     (admin, registry_id, oracle_secret, oracle_pubkey, client)
 }
@@ -736,6 +741,8 @@ fn test_batch_claim_panics_on_duplicate_staker() {
     let staker = Address::generate(&env);
     let mut stakers = Vec::new(&env);
     stakers.push_back(staker.clone());
+    let mut stakes = Vec::new(&env);
+    stakes.push_back(50_i128);
 
     client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
     let result = client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
@@ -748,6 +755,7 @@ fn test_batch_claim_panics_on_empty_batch() {
     let (_, registry_id, client) = setup_with_fee(&env, 0);
 
     let stakers: Vec<Address> = Vec::new(&env);
+    let stakes: Vec<i128> = Vec::new(&env);
 
     let result = client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
     assert_contract_error(result, OutcomeError::EmptyBatch);
@@ -942,7 +950,7 @@ fn test_fuzz_zero_staker_stake_panics() {
     let staker = Address::generate(&env);
     // Staker has 0 stake on the winning outcome → NothingToClaim
     prepare_mock_payout(&env, &registry_id, 1u64, &staker, 0, 1, 1);
-    let result = client.try_claim_payout(&1u64, &staker);
+    let result = client.try_claim_payout(&registry_id, &1u64, &staker, &0_i128, &1_i128, &1_i128);
     assert_contract_error(result, OutcomeError::NothingToClaim);
 }
 
@@ -951,9 +959,8 @@ fn test_fuzz_zero_total_winning_panics() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
-    // Winning pool is 0 → InvalidWinningStake
     prepare_mock_payout(&env, &registry_id, 1u64, &staker, 1, 0, 1);
-    let result = client.try_claim_payout(&1u64, &staker);
+    let result = client.try_claim_payout(&registry_id, &1u64, &staker, &1_i128, &0_i128, &1_i128);
     assert_contract_error(result, OutcomeError::InvalidWinningStake);
 }
 

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -2,8 +2,12 @@
 
 extern crate std;
 
-use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, BytesN, Env, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, testutils::Address as _, Address, Bytes, BytesN, Env, Map,
+    Vec,
+};
 
+use crate::call_types::{Call, CallRegistryError, ConditionType};
 use crate::errors::OutcomeError;
 use crate::storage::{OracleVote, PriceObservation, SignedOutcome};
 use crate::{OutcomeManager, OutcomeManagerClient, MAX_ORACLES};
@@ -11,9 +15,15 @@ use crate::{OutcomeManager, OutcomeManagerClient, MAX_ORACLES};
 const CLAIM_PAYOUT_BUDGET_CPU: u64 = 10_000_000;
 const CLAIM_PAYOUT_BUDGET_MEM: u64 = 100_000;
 const BATCH_CLAIM_PAYOUTS_BUDGET_CPU: u64 = 40_000_000;
-const BATCH_CLAIM_PAYOUTS_BUDGET_MEM: u64 = 400_000;
+const BATCH_CLAIM_PAYOUTS_BUDGET_MEM: u64 = 2_000_000;
 
 // ─── Test Helpers ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum MockDataKey {
+    Call(u64),
+    StakerStake(u64, Address, u32),
+}
 
 #[contract]
 pub struct MockRegistry;
@@ -23,6 +33,42 @@ impl MockRegistry {
     pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
     pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
     pub fn mark_settled(_env: Env, _call_id: u64) {}
+
+    pub fn set_mock_call(env: Env, call_id: u64, call: Call) {
+        env.storage().instance().set(&MockDataKey::Call(call_id), &call);
+    }
+
+    pub fn set_mock_staker_stake(
+        env: Env,
+        call_id: u64,
+        staker: Address,
+        position: u32,
+        amount: i128,
+    ) {
+        env.storage()
+            .instance()
+            .set(&MockDataKey::StakerStake(call_id, staker, position), &amount);
+    }
+
+    pub fn get_call(env: Env, call_id: u64) -> Result<Call, CallRegistryError> {
+        match env.storage().instance().get(&MockDataKey::Call(call_id)) {
+            Some(call) => Ok(call),
+            None => Err(CallRegistryError::CallNotFound),
+        }
+    }
+
+    pub fn get_staker_stake(
+        env: Env,
+        call_id: u64,
+        staker: Address,
+        position: u32,
+    ) -> Result<i128, CallRegistryError> {
+        Ok(env
+            .storage()
+            .instance()
+            .get(&MockDataKey::StakerStake(call_id, staker, position))
+            .unwrap_or(0))
+    }
 }
 
 /// Generate a deterministic Ed25519 keypair for testing.
@@ -92,8 +138,9 @@ fn setup_single_oracle(
     let fee_collector = Address::generate(env);
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
 
-    // Register a mock registry contract
+    // Register a mock registry contract and store its address
     let registry_id = env.register_contract(None, MockRegistry);
+    client.set_registry(&registry_id);
 
     (admin, registry_id, oracle_secret, oracle_pubkey, client)
 }
@@ -106,6 +153,119 @@ fn assert_contract_error<T, E>(
         result,
         Err(Ok(err)) if err == soroban_sdk::Error::from_contract_error(expected as u32)
     ));
+}
+
+/// Store a realistic `Call` and per-staker stake in the MockRegistry so
+/// `claim_payout` / `batch_claim_payouts` can read them via cross-contract calls.
+fn prepare_mock_payout(
+    env: &Env,
+    registry_id: &Address,
+    call_id: u64,
+    staker: &Address,
+    staker_winning_stake: i128,
+    total_winning_stake: i128,
+    total_losing_stake: i128,
+) {
+    let mock_client = MockRegistryClient::new(env, registry_id);
+    let winning_outcome = 1u32;
+    let outcome_count = 2u32;
+
+    let mut outcome_stakes = Map::new(env);
+    outcome_stakes.set(winning_outcome, total_winning_stake);
+    outcome_stakes.set(2u32, total_losing_stake);
+
+    let mut winning_stakers = Map::new(env);
+    winning_stakers.set(staker.clone(), staker_winning_stake);
+    let losing_stakers: Map<Address, i128> = Map::new(env);
+
+    let mut stakes: Map<u32, Map<Address, i128>> = Map::new(env);
+    stakes.set(winning_outcome, winning_stakers);
+    stakes.set(2u32, losing_stakers);
+
+    let call = Call {
+        id: call_id,
+        creator: Address::generate(env),
+        stake_token: Address::generate(env),
+        stake_amount: total_winning_stake + total_losing_stake,
+        end_ts: 1000,
+        token_address: Address::generate(env),
+        pair_id: Bytes::from_slice(env, b"test"),
+        metadata_hash: BytesN::from_array(env, &[0u8; 32]),
+        outcome_count,
+        outcome_stakes,
+        stakes,
+        outcome: winning_outcome,
+        start_price: 100,
+        end_price: 100,
+        condition: ConditionType::TargetAbove(100),
+        settled: true,
+        voided: false,
+        created_at: 500,
+        cancelled: false,
+        metadata_version: 0,
+        share_tokens: Map::new(env),
+    };
+
+    mock_client.set_mock_call(&call_id, &call);
+    mock_client.set_mock_staker_stake(&call_id, staker, &winning_outcome, &staker_winning_stake);
+}
+
+/// Multi-staker variant of `prepare_mock_payout` used by batch tests.
+fn prepare_mock_batch_payout(
+    env: &Env,
+    registry_id: &Address,
+    call_id: u64,
+    stakers: &[Address],
+    stakes: &[i128],
+    total_winning_stake: i128,
+    total_losing_stake: i128,
+) {
+    let mock_client = MockRegistryClient::new(env, registry_id);
+    let winning_outcome = 1u32;
+    let outcome_count = 2u32;
+
+    let mut outcome_stakes = Map::new(env);
+    outcome_stakes.set(winning_outcome, total_winning_stake);
+    outcome_stakes.set(2u32, total_losing_stake);
+
+    let mut winning_stakers: Map<Address, i128> = Map::new(env);
+    for (i, staker) in stakers.iter().enumerate() {
+        winning_stakers.set(staker.clone(), stakes[i]);
+    }
+    let losing_stakers: Map<Address, i128> = Map::new(env);
+
+    let mut stakes_map: Map<u32, Map<Address, i128>> = Map::new(env);
+    stakes_map.set(winning_outcome, winning_stakers);
+    stakes_map.set(2u32, losing_stakers);
+
+    let call = Call {
+        id: call_id,
+        creator: Address::generate(env),
+        stake_token: Address::generate(env),
+        stake_amount: total_winning_stake + total_losing_stake,
+        end_ts: 1000,
+        token_address: Address::generate(env),
+        pair_id: Bytes::from_slice(env, b"test"),
+        metadata_hash: BytesN::from_array(env, &[0u8; 32]),
+        outcome_count,
+        outcome_stakes: outcome_stakes.clone(),
+        stakes: stakes_map,
+        outcome: winning_outcome,
+        start_price: 100,
+        end_price: 100,
+        condition: ConditionType::TargetAbove(100),
+        settled: true,
+        voided: false,
+        created_at: 500,
+        cancelled: false,
+        metadata_version: 0,
+        share_tokens: Map::new(env),
+    };
+
+    mock_client.set_mock_call(&call_id, &call);
+    for (i, staker) in stakers.iter().enumerate() {
+        mock_client.set_mock_staker_stake(&call_id, staker, &winning_outcome, &stakes[i]);
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -621,6 +781,7 @@ fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerC
     client.initialize(&admin, &oracles, &1u32, &fee_collector, &fee_bps, &0u64);
 
     let registry_id = env.register_contract(None, MockRegistry);
+    client.set_registry(&registry_id);
 
     // Settle call_id=1
     let call_id = 1u64;
@@ -654,7 +815,8 @@ fn test_fee_deducted_from_payout() {
     let (_, registry_id, client) = setup_with_fee(&env, 500);
     let staker = Address::generate(&env);
 
-    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 100, 100, 100);
+    client.claim_payout(&1u64, &staker);
     // If no panic, payout was computed and released correctly
 }
 
@@ -666,7 +828,8 @@ fn test_zero_fee_full_payout() {
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
 
-    client.claim_payout(&registry_id, &1u64, &staker, &50i128, &100i128, &100i128);
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 50, 100, 100);
+    client.claim_payout(&1u64, &staker);
 }
 
 #[test]
@@ -698,8 +861,9 @@ fn test_fee_goes_to_correct_address() {
     let (fee_collector, registry_id, client) = setup_with_fee(&env, 1000);
     let staker = Address::generate(&env);
 
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 100, 100, 100);
     // Should not panic; MockRegistry records calls but we verify no panic = correct flow
-    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+    client.claim_payout(&1u64, &staker);
     // fee_collector address was set during setup_with_fee; contract uses it internally
     let _ = fee_collector; // referenced to confirm it was set
 }
@@ -732,18 +896,17 @@ fn test_batch_claim_payouts_three_stakers() {
     let staker2 = Address::generate(&env);
     let staker3 = Address::generate(&env);
 
+    let staker_refs = [staker1.clone(), staker2.clone(), staker3.clone()];
+    let stake_vals = [50_i128, 30_i128, 20_i128];
+    prepare_mock_batch_payout(&env, &registry_id, 1u64, &staker_refs, &stake_vals, 100, 100);
+
     let mut stakers = Vec::new(&env);
     stakers.push_back(staker1.clone());
     stakers.push_back(staker2.clone());
     stakers.push_back(staker3.clone());
 
-    let mut stakes = Vec::new(&env);
-    stakes.push_back(50_i128);
-    stakes.push_back(30_i128);
-    stakes.push_back(20_i128);
-
     // Should not panic — all three processed in one tx
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    client.batch_claim_payouts(&1u64, &stakers);
 
     assert!(client.has_claimed(&1u64, &staker1));
     assert!(client.has_claimed(&1u64, &staker2));
@@ -757,17 +920,16 @@ fn test_batch_claim_panics_on_duplicate_staker() {
 
     let staker = Address::generate(&env);
 
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 50, 50, 50);
+
     // First batch — marks staker as claimed
     let mut stakers = Vec::new(&env);
     stakers.push_back(staker.clone());
-    let mut stakes = Vec::new(&env);
-    stakes.push_back(50_i128);
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
+    client.batch_claim_payouts(&1u64, &stakers);
 
     // Second batch with same staker — must panic
-    let result =
-        client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
+    let result = client.try_batch_claim_payouts(&1u64, &stakers);
     assert_contract_error(result, OutcomeError::AlreadyClaimed);
 }
 
@@ -777,34 +939,9 @@ fn test_batch_claim_panics_on_empty_batch() {
     let (_, registry_id, client) = setup_with_fee(&env, 0);
 
     let stakers: Vec<Address> = Vec::new(&env);
-    let stakes: Vec<i128> = Vec::new(&env);
 
-    let result = client.try_batch_claim_payouts(
-        &registry_id,
-        &1u64,
-        &stakers,
-        &stakes,
-        &100_i128,
-        &100_i128,
-    );
+    let result = client.try_batch_claim_payouts(&1u64, &stakers);
     assert_contract_error(result, OutcomeError::EmptyBatch);
-}
-
-#[test]
-fn test_batch_claim_panics_on_length_mismatch() {
-    let env = Env::default();
-    let (_, registry_id, client) = setup_with_fee(&env, 0);
-
-    let mut stakers = Vec::new(&env);
-    stakers.push_back(Address::generate(&env));
-    stakers.push_back(Address::generate(&env));
-
-    let mut stakes = Vec::new(&env);
-    stakes.push_back(50_i128); // one fewer than stakers
-
-    let result =
-        client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
-    assert_contract_error(result, OutcomeError::LengthMismatch);
 }
 
 #[test]
@@ -814,18 +951,9 @@ fn test_batch_claim_panics_on_unsettled_call() {
 
     let mut stakers = Vec::new(&env);
     stakers.push_back(Address::generate(&env));
-    let mut stakes = Vec::new(&env);
-    stakes.push_back(50_i128);
 
     // call_id=999 was never finalized
-    let result = client.try_batch_claim_payouts(
-        &registry_id,
-        &999u64,
-        &stakers,
-        &stakes,
-        &50_i128,
-        &50_i128,
-    );
+    let result = client.try_batch_claim_payouts(&999u64, &stakers);
     assert_contract_error(result, OutcomeError::CallNotSettled);
 }
 
@@ -838,16 +966,16 @@ fn test_batch_claim_with_fee_deducted() {
     let staker1 = Address::generate(&env);
     let staker2 = Address::generate(&env);
 
+    let staker_refs = [staker1.clone(), staker2.clone()];
+    let stake_vals = [60_i128, 40_i128];
+    prepare_mock_batch_payout(&env, &registry_id, 1u64, &staker_refs, &stake_vals, 100, 100);
+
     let mut stakers = Vec::new(&env);
     stakers.push_back(staker1.clone());
     stakers.push_back(staker2.clone());
 
-    let mut stakes = Vec::new(&env);
-    stakes.push_back(60_i128);
-    stakes.push_back(40_i128);
-
     // Should process without panic; fee math mirrors claim_payout
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    client.batch_claim_payouts(&1u64, &stakers);
 
     assert!(client.has_claimed(&1u64, &staker1));
     assert!(client.has_claimed(&1u64, &staker2));
@@ -860,12 +988,14 @@ fn test_claim_payout_stays_within_budget() {
     let (_, registry_id, client) = setup_with_fee(&env, 500);
     let staker = Address::generate(&env);
 
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 100, 100, 100);
+
     let usage = measure_budget(
         &env,
         CLAIM_PAYOUT_BUDGET_CPU,
         CLAIM_PAYOUT_BUDGET_MEM,
         || {
-            client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+            client.claim_payout(&1u64, &staker);
         },
     );
 
@@ -890,19 +1020,27 @@ fn test_batch_claim_payouts_stays_within_budget() {
         stakes.push_back(5_i128);
     }
 
+    // Prepare mock data for all 20 stakers
+    let staker_list: std::vec::Vec<Address> =
+        (0..stakers.len()).map(|i| stakers.get(i).unwrap()).collect();
+    let stake_list: std::vec::Vec<i128> =
+        (0..stakes.len()).map(|i| stakes.get(i).unwrap()).collect();
+    prepare_mock_batch_payout(
+        &env,
+        &registry_id,
+        1u64,
+        &staker_list,
+        &stake_list,
+        100,
+        100,
+    );
+
     let usage = measure_budget(
         &env,
         BATCH_CLAIM_PAYOUTS_BUDGET_CPU,
         BATCH_CLAIM_PAYOUTS_BUDGET_MEM,
         || {
-            client.batch_claim_payouts(
-                &registry_id,
-                &1u64,
-                &stakers,
-                &stakes,
-                &100_i128,
-                &100_i128,
-            );
+            client.batch_claim_payouts(&1u64, &stakers);
         },
     );
 
@@ -922,8 +1060,10 @@ fn test_claim_payout_exceeding_budget_fails() {
     let (_, registry_id, client) = setup_with_fee(&env, 500);
     let staker = Address::generate(&env);
 
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 100, 100, 100);
+
     env.cost_estimate().budget().reset_limits(25_000, 1_024);
-    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+    client.claim_payout(&1u64, &staker);
 }
 
 #[test]
@@ -965,14 +1105,8 @@ fn fuzz_claim_setup(staker_winning: i128, total_winning: i128, total_losing: i12
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, fee_bps);
     let staker = Address::generate(&env);
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &staker_winning,
-        &total_winning,
-        &total_losing,
-    );
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, staker_winning, total_winning, total_losing);
+    client.claim_payout(&1u64, &staker);
     assert!(client.has_claimed(&1u64, &staker));
 }
 
@@ -1002,6 +1136,7 @@ fn test_fuzz_payout_many_ratios_no_panic() {
 fn test_fuzz_100_winners_batch_all_claimed() {
     // 100 equal winners via batch_claim_payouts -- all must be marked claimed
     let env = Env::default();
+    env.budget().reset_unlimited();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
 
     let mut stakers = Vec::new(&env);
@@ -1011,7 +1146,14 @@ fn test_fuzz_100_winners_batch_all_claimed() {
         stakes.push_back(1_i128);
     }
 
-    client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    // Prepare mock data
+    let staker_list: std::vec::Vec<Address> =
+        (0..stakers.len()).map(|i| stakers.get(i).unwrap()).collect();
+    let stake_list: std::vec::Vec<i128> =
+        (0..stakes.len()).map(|i| stakes.get(i).unwrap()).collect();
+    prepare_mock_batch_payout(&env, &registry_id, 1u64, &staker_list, &stake_list, 100, 100);
+
+    client.batch_claim_payouts(&1u64, &stakers);
 
     for i in 0..100u32 {
         assert!(client.has_claimed(&1u64, &stakers.get(i).unwrap()));
@@ -1024,14 +1166,8 @@ fn test_fuzz_1_winner_takes_all() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
-    client.claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &1_000_000_i128,
-        &1_000_000_i128,
-        &1_000_000_i128,
-    );
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 1_000_000, 1_000_000, 1_000_000);
+    client.claim_payout(&1u64, &staker);
     assert!(client.has_claimed(&1u64, &staker));
 }
 
@@ -1052,7 +1188,9 @@ fn test_fuzz_zero_staker_stake_panics() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
-    let result = client.try_claim_payout(&registry_id, &1u64, &staker, &0, &1, &1);
+    // Staker has 0 stake on the winning outcome → NothingToClaim
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 0, 1, 1);
+    let result = client.try_claim_payout(&1u64, &staker);
     assert_contract_error(result, OutcomeError::NothingToClaim);
 }
 
@@ -1061,7 +1199,9 @@ fn test_fuzz_zero_total_winning_panics() {
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, 0);
     let staker = Address::generate(&env);
-    let result = client.try_claim_payout(&registry_id, &1u64, &staker, &1, &0, &1);
+    // Winning pool is 0 → InvalidWinningStake
+    prepare_mock_payout(&env, &registry_id, 1u64, &staker, 1, 0, 1);
+    let result = client.try_claim_payout(&1u64, &staker);
     assert_contract_error(result, OutcomeError::InvalidWinningStake);
 }
 
@@ -1112,14 +1252,7 @@ fn test_claim_payout_fails_when_paused() {
     env.mock_all_auths();
     client.pause();
 
-    let result = client.try_claim_payout(
-        &registry_id,
-        &1u64,
-        &staker,
-        &100_i128,
-        &100_i128,
-        &100_i128,
-    );
+    let result = client.try_claim_payout(&1u64, &staker);
     assert_contract_error(result, OutcomeError::ContractPaused);
 }
 


### PR DESCRIPTION
Closes  #153 

## Summary

Refactor `claim_payout` and `batch_claim_payouts` to read stake data on-chain from CallRegistry instead of accepting caller-provided parameters.

## Motivation

Previously `claim_payout` required the caller to supply `registry`, `staker_winning_stake`, `total_winning_stake`, and `total_losing_stake` — data that can and should be read from the CallRegistry contract directly. This removes trust assumptions on caller-provided values and simplifies the public API.

## Changes

- **`call_types.rs`** (new) — local mirrors of `Call`, `ConditionType`, `CallRegistryError` to avoid depending on `call_registry`'s private modules.
- **Cross-contract helpers** — `registry_get_call` and `registry_get_staker_stake` using `env.invoke_contract` with `Result<Call, CallRegistryError>` / `Result<i128, CallRegistryError>` return types.
- **`claim_payout(env, call_id, staker)`** — reads registry address from instance storage, calls `get_call` for outcome stakes and `get_staker_stake` for the staker's position. Removed params: `registry`, `staker_winning_stake`, `total_winning_stake`, `total_losing_stake`.
- **`batch_claim_payouts(env, call_id, stakers)`** — same pattern; reads each staker's stake from the registry individually instead of from a caller-provided vec.
- **MockRegistry** — updated with `set_mock_call`, `set_mock_staker_stake`, `get_call`, `get_staker_stake` (returning `Result` types matching the real registry).
- **Test helpers** — `prepare_mock_payout` / `prepare_mock_batch_payout` populate mock Call and per-staker stakes.
- **Budget adjustments** — `BATCH_CLAIM_PAYOUTS_BUDGET_MEM` increased 400K → 2M; `test_fuzz_100_winners_batch_all_claimed` uses `reset_unlimited()` to accommodate 101 cross-contract calls.

## Testing

All 51 tests pass.