### PR TITLE
feat(contracts): implement on-chain call expiry auto-refund mechanism…

### DIFF
--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -325,6 +325,22 @@ pub fn emit_xlm_stake_added(
     );
 }
 
+/// Emitted when a staker claims an expired refund (oracle failed to resolve).
+pub fn emit_expired_refund_claimed(env: &Env, call_id: u64, staker: &Address, amount: i128) {
+    env.events().publish(
+        ("call_registry", "expired_refund_claimed"),
+        (call_id, staker.clone(), amount),
+    );
+}
+
+/// Emitted when an expired refund is paid out in native XLM.
+pub fn emit_xlm_expired_refund_claimed(env: &Env, call_id: u64, staker: &Address, amount: i128) {
+    env.events().publish(
+        ("call_registry", "xlm_expired_refund"),
+        (call_id, staker.clone(), amount),
+    );
+}
+
 /// Emitted when a void refund is paid out in native XLM.
 pub fn emit_xlm_void_refund_claimed(env: &Env, call_id: u64, staker: &Address, amount: i128) {
     env.events().publish(

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -160,6 +160,7 @@ impl CallRegistry {
             paused: false,
             staking_cutoff_secs: 300,
             share_wasm_hash: None,
+            resolution_grace_period: 604800,
         };
 
         set_config(&env, &config);
@@ -1279,6 +1280,62 @@ impl CallRegistry {
             emit_xlm_void_refund_claimed(&env, call_id, &staker, total_refund);
         } else {
             emit_void_refund_claimed(&env, call_id, &staker, total_refund);
+        }
+    }
+
+    /// Claim a full refund for an expired call that was never resolved/settled.
+    /// Only callable after `end_ts + resolution_grace_period` has passed and the
+    /// call has not been settled. Refunds the exact stake (no penalty, no profit).
+    /// Emits ExpiredRefundClaimed.
+    pub fn claim_expired_refund(env: Env, staker: Address, call_id: u64) {
+        staker.require_auth();
+
+        let call = get_call(&env, call_id).expect("Call not found");
+        let config = get_config(&env).expect("not initialized");
+
+        let current_timestamp = env.ledger().timestamp();
+        let grace_deadline = call.end_ts + config.resolution_grace_period;
+
+        if current_timestamp <= grace_deadline {
+            panic!("Grace period has not elapsed");
+        }
+
+        if call.settled {
+            panic!("Call is already settled");
+        }
+
+        if call.voided {
+            panic!("Call is voided; use claim_void_refund");
+        }
+
+        if is_expired_refund_claimed(&env, call_id, &staker) {
+            panic!("Refund already claimed");
+        }
+
+        let mut total_refund: i128 = 0;
+        for position in 1..=call.outcome_count {
+            total_refund += get_user_stake(&env, call_id, &staker, position);
+        }
+
+        if total_refund <= 0 {
+            panic!("No stake to refund");
+        }
+
+        set_expired_refund_claimed(&env, call_id, &staker);
+        extend_storage_ttl(&env);
+
+        transfer_token(
+            &env,
+            &call.stake_token,
+            &env.current_contract_address(),
+            &staker,
+            total_refund,
+        );
+
+        if is_native_xlm(&env, &call.stake_token) {
+            emit_xlm_expired_refund_claimed(&env, call_id, &staker, total_refund);
+        } else {
+            emit_expired_refund_claimed(&env, call_id, &staker, total_refund);
         }
     }
 

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -25,6 +25,7 @@ pub enum DataKey {
     UpStakerCount(u64),
     DownStakerCount(u64),
     VoidRefundClaimed(u64, Address),
+    ExpiredRefundClaimed(u64, Address),
     InstanceEntryCount,
     Sep10Domain(Address),
 }
@@ -379,6 +380,23 @@ pub fn is_void_refund_claimed(env: &Env, call_id: u64, staker: &Address) -> bool
     env.storage()
         .instance()
         .has(&DataKey::VoidRefundClaimed(call_id, staker.clone()))
+}
+
+/// Mark that a staker has claimed their expired refund for a call
+pub fn set_expired_refund_claimed(env: &Env, call_id: u64, staker: &Address) {
+    let key = DataKey::ExpiredRefundClaimed(call_id, staker.clone());
+    let is_new = !env.storage().instance().has(&key);
+    env.storage().instance().set(&key, &true);
+    if is_new {
+        inc_instance_entry_count(env, 1);
+    }
+}
+
+/// Check whether a staker has already claimed their expired refund
+pub fn is_expired_refund_claimed(env: &Env, call_id: u64, staker: &Address) -> bool {
+    env.storage()
+        .instance()
+        .has(&DataKey::ExpiredRefundClaimed(call_id, staker.clone()))
 }
 
 // ── Instance entry counter ────────────────────────────────────────────────────

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -1410,6 +1410,94 @@ mod call_registry {
         client.claim_void_refund(&non_staker, &call.id);
     }
 
+    // ── claim_expired_refund ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_claim_expired_refund_before_grace_period_fails() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, _stake_token) = make_call(&env, &client, &creator);
+
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        // call.end_ts = 2000, grace period = 604800, so deadline = 2000 + 604800 = 606800
+        // Set time to 606800 (exactly at deadline, not past it)
+        env.ledger().set_timestamp(606800);
+
+        let result = client.try_claim_expired_refund(&staker, &call.id);
+        assert!(
+            result.is_err(),
+            "should fail when grace period has not elapsed"
+        );
+    }
+
+    #[test]
+    fn test_claim_expired_refund_after_grace_period_succeeds() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, _stake_token) = make_call(&env, &client, &creator);
+
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        // Past grace deadline: end_ts=2000 + grace=604800 = 606800, set to 606801
+        env.ledger().set_timestamp(606801);
+
+        client.claim_expired_refund(&staker, &call.id);
+    }
+
+    #[test]
+    fn test_claim_expired_refund_settled_call_fails() {
+        let (env, client, _admin, outcome_manager) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, _stake_token) = make_call(&env, &client, &creator);
+
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        // Resolve and settle the call
+        env.ledger().set_timestamp(2001);
+        client.resolve_call(&call.id, &1, &150_000_000_i128);
+        let call_data = client.get_call(&call.id);
+        client.mark_settled(&call.id);
+
+        // Past grace deadline, but call is settled
+        env.ledger().set_timestamp(606801);
+
+        let result = client.try_claim_expired_refund(&staker, &call.id);
+        assert!(
+            result.is_err(),
+            "should fail when call is settled"
+        );
+    }
+
+    #[test]
+    fn test_claim_expired_refund_double_claim_fails() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, _stake_token) = make_call(&env, &client, &creator);
+
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+
+        // Past grace deadline
+        env.ledger().set_timestamp(606801);
+
+        client.claim_expired_refund(&staker, &call.id);
+
+        // Second claim should fail
+        let result = client.try_claim_expired_refund(&staker, &call.id);
+        assert!(
+            result.is_err(),
+            "second claim should fail"
+        );
+    }
+
     // ── 3-outcome market tests ───────────────────────────────────────────────
 
     #[test]

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -141,6 +141,10 @@ pub struct ContractConfig {
     pub staking_cutoff_secs: u64,
     /// Wasm hash for the share token contract (if enabled)
     pub share_wasm_hash: Option<BytesN<32>>,
+    /// Grace period in seconds after `end_ts` during which the oracle must
+    /// resolve the call. After this period elapses, stakers can reclaim their
+    /// stakes via `claim_expired_refund`. Default: 604800 (7 days).
+    pub resolution_grace_period: u64,
 }
 
 /// Contract-wide aggregated statistics for dashboards.


### PR DESCRIPTION
## Summary

Closes #145 — if the oracle fails to resolve a call within a grace period after expiry, all stakers can reclaim their stakes, preventing capital from being locked forever.

## Changes

### `types.rs`
- Added `resolution_grace_period: u64` to `ContractConfig` (default: `604800` = 7 days)

### `storage.rs`
- Added `ExpiredRefundClaimed(u64, Address)` variant to `DataKey`
- Added `set_expired_refund_claimed()` / `is_expired_refund_claimed()` helpers (same pattern as `VoidRefundClaimed`)

### `events.rs`
- Added `emit_expired_refund_claimed()` (SAC token path)
- Added `emit_xlm_expired_refund_claimed()` (native XLM path)

### `lib.rs`
- Added `claim_expired_refund(env, staker, call_id)` which:
  - Requires staker auth
  - Validates `current_timestamp > end_ts + resolution_grace_period`
  - Rejects settled, voided, or already-claimed calls
  - Sums user's stake across all outcome positions
  - Transfers exact stake (no penalty, no profit)
  - Emits `ExpiredRefundClaimed` / `xlm_expired_refund` event

### `test.rs`
- `test_claim_expired_refund_before_grace_period_fails` — exact deadline (≤) is rejected
- `test_claim_expired_refund_after_grace_period_succeeds` — one second past deadline succeeds
- `test_claim_expired_refund_settled_call_fails` — settled call rejected
- `test_claim_expired_refund_double_claim_fails` — second claim rejected

## Tests
All 100 tests pass.