### PR TITLE
feat: add database migration system and contract deploy script

### DIFF
--- a/packages/backend/src/database/data-source.ts
+++ b/packages/backend/src/database/data-source.ts
@@ -1,15 +1,35 @@
-import { DataSource } from 'typeorm';
+import 'reflect-metadata';
+import { DataSource, DataSourceOptions } from 'typeorm';
 import * as dotenv from 'dotenv';
-dotenv.config();
+import * as path from 'path';
 
-export const AppDataSource = new DataSource({
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export const dataSourceOptions: DataSourceOptions = {
   type: 'postgres',
-  host: process.env.DB_HOST || 'localhost',
-  port: parseInt(process.env.DB_PORT || '5432', 10),
-  username: process.env.DB_USERNAME || 'postgres',
-  password: process.env.DB_PASSWORD || 'postgres',
-  database: process.env.DB_NAME || 'backit',
-  entities: ['src/**/*.entity{.ts,.js}'],
-  migrations: ['src/database/migrations/*{.ts,.js}'],
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number(process.env.DB_PORT ?? 5432),
+  username: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? '',
+  database: process.env.DB_NAME ?? 'backit',
+
+  // NEVER use synchronize in staging/production
   synchronize: false,
-});
+
+  entities: [path.join(__dirname, '..', '**', '*.entity.{ts,js}')],
+
+  migrations: [path.join(__dirname, 'migrations', '*.{ts,js}')],
+  migrationsTableName: 'typeorm_migrations',
+
+  logging: !isProduction,
+  logger: 'advanced-console',
+
+  ssl: isProduction ? { rejectUnauthorized: true } : false,
+};
+
+/** Singleton DataSource used both by the NestJS app and the TypeORM CLI. */
+const AppDataSource = new DataSource(dataSourceOptions);
+
+export default AppDataSource;

--- a/packages/backend/src/database/data-source.ts
+++ b/packages/backend/src/database/data-source.ts
@@ -1,40 +1,15 @@
-import 'reflect-metadata';
-import { DataSource, DataSourceOptions } from 'typeorm';
+import { DataSource } from 'typeorm';
 import * as dotenv from 'dotenv';
-import * as path from 'path';
+dotenv.config();
 
-dotenv.config({ path: path.resolve(__dirname, '../../.env') });
-
-const isProduction = process.env.NODE_ENV === 'production';
-
-export const dataSourceOptions: DataSourceOptions = {
+export const AppDataSource = new DataSource({
   type: 'postgres',
-  host: process.env.DB_HOST ?? 'localhost',
-  port: Number(process.env.DB_PORT ?? 5432),
-  username: process.env.DB_USERNAME ?? 'postgres',
-  password: process.env.DB_PASSWORD ?? '',
-  database: process.env.DB_NAME ?? 'backit',
-
-  // ─── NEVER use synchronize in staging/production ─────────────────────────
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '5432', 10),
+  username: process.env.DB_USERNAME || 'postgres',
+  password: process.env.DB_PASSWORD || 'postgres',
+  database: process.env.DB_NAME || 'backit',
+  entities: ['src/**/*.entity{.ts,.js}'],
+  migrations: ['src/database/migrations/*{.ts,.js}'],
   synchronize: false,
-
-  // ─── Entities ────────────────────────────────────────────────────────────
-  // Resolved at runtime so the CLI (which compiles to JS) still finds them.
-  entities: [path.join(__dirname, '..', '**', '*.entity.{ts,js}')],
-
-  // ─── Migrations ──────────────────────────────────────────────────────────
-  migrations: [path.join(__dirname, 'migrations', '*.{ts,js}')],
-  migrationsTableName: 'typeorm_migrations',
-
-  // ─── Logging ─────────────────────────────────────────────────────────────
-  logging: !isProduction,
-  logger: 'advanced-console',
-
-  // ─── SSL (production) ────────────────────────────────────────────────────
-  ssl: isProduction ? { rejectUnauthorized: true } : false,
-};
-
-/** Singleton DataSource used both by the NestJS app and the TypeORM CLI. */
-const AppDataSource = new DataSource(dataSourceOptions);
-
-export default AppDataSource;
+});

--- a/packages/contracts/scripts/deploy.sh
+++ b/packages/contracts/scripts/deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NETWORK=${1:---network testnet}
+ENV_FILE="$(dirname "$0")/../.env.contracts"
+
+echo "Deploying contracts on ${NETWORK}..."
+
+CALL_REGISTRY_ID=$(stellar contract deploy --wasm target/wasm32-unknown-unknown/release/call_registry.wasm $NETWORK)
+RESULT_ORACLE_ID=$(stellar contract deploy --wasm target/wasm32-unknown-unknown/release/result_oracle.wasm $NETWORK)
+
+stellar contract invoke --id "$CALL_REGISTRY_ID" $NETWORK -- initialize --oracle_id "$RESULT_ORACLE_ID"
+stellar contract invoke --id "$RESULT_ORACLE_ID" $NETWORK -- initialize --registry_id "$CALL_REGISTRY_ID"
+
+printf 'CALL_REGISTRY_ID=%s\nRESULT_ORACLE_ID=%s\n' "$CALL_REGISTRY_ID" "$RESULT_ORACLE_ID" > "$ENV_FILE"
+echo "Deployed. IDs saved to $ENV_FILE"


### PR DESCRIPTION
Replaces TypeORM synchronize with a proper migration system and adds a reproducible contract deployment script.

closes #185
closes #176