### PR TITLE
feat: stake comment storage & UI, win streak calculation and leaderboard display

### DIFF
--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -21,6 +21,75 @@ import {
 import { Call } from './entities/call.entity';
 import { Stake } from './entities/stake.entity';
 
+
+// Raw query result types
+interface DailyProfitRow {
+  dailyProfit: string | null;
+  date: string;
+}
+
+interface WeeklyProfitRow {
+  weeklyProfit: string | null;
+  date: string;
+}
+
+interface AccuracyRow {
+  correct: string | null;
+  total: string | null;
+  date: string;
+}
+
+interface WinLossRow {
+  wins: string;
+  losses: string;
+  pending: string;
+  total: string;
+}
+
+interface ProfitLossRow {
+  totalProfitLoss: string | null;
+}
+
+interface AccuracyStatsRow {
+  correct: string | null;
+  total: string | null;
+}
+
+
+// Raw query result types
+interface DailyProfitRow {
+  dailyProfit: string | null;
+  date: string;
+}
+
+interface WeeklyProfitRow {
+  weeklyProfit: string | null;
+  date: string;
+}
+
+interface AccuracyRow {
+  correct: string | null;
+  total: string | null;
+  date: string;
+}
+
+interface WinLossRow {
+  wins: string;
+  losses: string;
+  pending: string;
+  total: string;
+}
+
+interface ProfitLossRow {
+  totalProfitLoss: string | null;
+}
+
+interface AccuracyStatsRow {
+  correct: string | null;
+  total: string | null;
+}
+
+
 @Injectable()
 export class AnalyticsService {
   private readonly logger = new Logger(AnalyticsService.name);
@@ -172,7 +241,7 @@ export class AnalyticsService {
 
     // Convert to cumulative values
     let cumulative = 0;
-    const dataPoints: ProfitDataPoint[] = rawData.map((row) => {
+    const dataPoints: ProfitDataPoint[] = (rawData as DailyProfitRow[]).map((row) => {
       cumulative += parseFloat(row.dailyProfit || 0);
       return {
         date: new Date(row.date).toISOString().split('T')[0],
@@ -206,7 +275,7 @@ export class AnalyticsService {
 
     // Convert to cumulative values
     let cumulative = 0;
-    const dataPoints: ProfitDataPoint[] = rawData.map((row) => {
+    const dataPoints: ProfitDataPoint[] = (rawData as WeeklyProfitRow[]).map((row) => {
       cumulative += parseFloat(row.weeklyProfit || 0);
       return {
         date: new Date(row.date).toISOString().split('T')[0],
@@ -247,7 +316,7 @@ export class AnalyticsService {
     let totalCorrect = 0;
     let totalResolved = 0;
 
-    const dataPoints: AccuracyDataPoint[] = rawData.map((row) => {
+    const dataPoints: AccuracyDataPoint[] = (rawData as AccuracyRow[]).map((row) => {
       totalCorrect += parseInt(row.correct || 0);
       totalResolved += parseInt(row.total || 0);
 
@@ -293,11 +362,12 @@ export class AnalyticsService {
       .andWhere('stake.createdAt <= :endDate', { endDate })
       .getRawOne();
 
+    const r = result as WinLossRow | null;
     return {
-      wins: parseInt(result?.wins || 0),
-      losses: parseInt(result?.losses || 0),
-      pending: parseInt(result?.pending || 0),
-      total: parseInt(result?.total || 0),
+      wins: parseInt(r?.wins || '0'),
+      losses: parseInt(r?.losses || '0'),
+      pending: parseInt(r?.pending || '0'),
+      total: parseInt(r?.total || '0'),
     };
   }
 
@@ -332,9 +402,11 @@ export class AnalyticsService {
       .andWhere('call.resolvedAt <= :endDate', { endDate })
       .getRawOne();
 
-    const totalProfitLoss = parseFloat(profitResult?.totalProfitLoss || 0);
-    const correct = parseInt(accuracyResult?.correct || 0);
-    const total = parseInt(accuracyResult?.total || 0);
+    const pr = profitResult as ProfitLossRow | null;
+    const ar = accuracyResult as AccuracyStatsRow | null;
+    const totalProfitLoss = parseFloat(pr?.totalProfitLoss || '0');
+    const correct = parseInt(ar?.correct || '0');
+    const total = parseInt(ar?.total || '0');
     const overallAccuracy = total > 0 ? (correct / total) * 100 : 0;
 
     return {

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -735,4 +735,78 @@ export class AnalyticsService {
       expiresAt: Date.now() + ttlSeconds * 1000,
     });
   }
+
+  /**
+   * Update win streak for a user after a call outcome is resolved.
+   * Called when indexer processes a resolved outcome event.
+   */
+  async updateWinStreak(userAddress: string, won: boolean): Promise<void> {
+    const result = await this.dataSource.query(
+      `SELECT id, "currentWinStreak", "bestWinStreak" FROM users WHERE "walletAddress" = $1`,
+      [userAddress],
+    );
+    if (!result.length) return;
+
+    const user = result[0];
+    const currentStreak = won ? (user.currentWinStreak || 0) + 1 : 0;
+    const bestStreak = Math.max(user.bestWinStreak || 0, currentStreak);
+
+    await this.dataSource.query(
+      `UPDATE users SET "currentWinStreak" = $1, "bestWinStreak" = $2 WHERE id = $3`,
+      [currentStreak, bestStreak, user.id],
+    );
+  }
+
+  async getCreatedCalls(
+    creatorAddress: string,
+    page: number,
+    limit: number,
+    status?: string,
+  ) {
+    const offset = (page - 1) * limit;
+    const params: unknown[] = [creatorAddress, limit, offset];
+    const statusClause = status ? `AND c.status = $4` : '';
+    if (status) params.push(status.toUpperCase());
+
+    const rows = await this.dataSource.query(
+      `
+      SELECT c.id, c.title, c.status, c."createdAt", c."resolvedAt", c."expiresAt",
+             COALESCE(c."totalYesStake", 0) AS "totalYesStake",
+             COALESCE(c."totalNoStake", 0) AS "totalNoStake",
+             COUNT(DISTINCT s."userAddress") AS "uniqueStakers"
+      FROM calls c
+      LEFT JOIN stakes s ON s."callId" = c.id
+      WHERE c."creatorAddress" = $1 ${statusClause}
+      GROUP BY c.id
+      ORDER BY c."createdAt" DESC
+      LIMIT $2 OFFSET $3
+      `,
+      params,
+    );
+
+    const [countRow] = await this.dataSource.query(
+      `SELECT COUNT(*) AS total FROM calls WHERE "creatorAddress" = $1 ${statusClause}`,
+      status ? [creatorAddress, status.toUpperCase()] : [creatorAddress],
+    );
+
+    return { data: rows, total: parseInt(countRow.total), page, limit };
+  }
+
+  async getCreatedCallsStats(creatorAddress: string) {
+    const [row] = await this.dataSource.query(
+      `
+      SELECT
+        COUNT(*) AS total,
+        COUNT(*) FILTER (WHERE status IN ('RESOLVED_YES','RESOLVED_NO')) AS resolved,
+        COALESCE(SUM(COALESCE("totalYesStake",0) + COALESCE("totalNoStake",0)), 0) AS "totalVolume"
+      FROM calls WHERE "creatorAddress" = $1
+      `,
+      [creatorAddress],
+    );
+    return {
+      totalCreated: parseInt(row.total),
+      totalResolved: parseInt(row.resolved),
+      totalStakeVolumeAttracted: parseFloat(row.totalVolume),
+    };
+  }
 }

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -242,7 +242,7 @@ export class AnalyticsService {
     // Convert to cumulative values
     let cumulative = 0;
     const dataPoints: ProfitDataPoint[] = (rawData as DailyProfitRow[]).map((row) => {
-      cumulative += parseFloat(row.dailyProfit || 0);
+      cumulative += parseFloat(row.dailyProfit ?? '0');
       return {
         date: new Date(row.date).toISOString().split('T')[0],
         value: Number(cumulative.toFixed(7)), // Stellar precision
@@ -276,7 +276,7 @@ export class AnalyticsService {
     // Convert to cumulative values
     let cumulative = 0;
     const dataPoints: ProfitDataPoint[] = (rawData as WeeklyProfitRow[]).map((row) => {
-      cumulative += parseFloat(row.weeklyProfit || 0);
+      cumulative += parseFloat(row.weeklyProfit ?? '0');
       return {
         date: new Date(row.date).toISOString().split('T')[0],
         value: Number(cumulative.toFixed(7)),
@@ -317,8 +317,8 @@ export class AnalyticsService {
     let totalResolved = 0;
 
     const dataPoints: AccuracyDataPoint[] = (rawData as AccuracyRow[]).map((row) => {
-      totalCorrect += parseInt(row.correct || 0);
-      totalResolved += parseInt(row.total || 0);
+      totalCorrect += parseInt(row.correct ?? '0');
+      totalResolved += parseInt(row.total ?? '0');
 
       const accuracy =
         totalResolved > 0 ? (totalCorrect / totalResolved) * 100 : 0;

--- a/packages/backend/src/analytics/entities/stake.entity.ts
+++ b/packages/backend/src/analytics/entities/stake.entity.ts
@@ -38,6 +38,9 @@ export class Stake {
   @Column({ type: 'varchar', length: 255, nullable: true })
   transactionHash?: string;
 
+  @Column({ type: 'varchar', length: 140, nullable: true })
+  comment?: string;
+
   @CreateDateColumn()
   @Index()
   createdAt: Date;

--- a/packages/backend/src/database/migrations/1760000010000-AddStreakAndStakeComment.ts
+++ b/packages/backend/src/database/migrations/1760000010000-AddStreakAndStakeComment.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStreakAndStakeComment1760000010000 implements MigrationInterface {
+  name = 'AddStreakAndStakeComment1760000010000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Win streak fields on users table
+    await queryRunner.query(`
+      ALTER TABLE "users"
+        ADD COLUMN IF NOT EXISTS "currentWinStreak" integer NOT NULL DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS "bestWinStreak" integer NOT NULL DEFAULT 0
+    `);
+
+    // Optional stake comment field
+    await queryRunner.query(`
+      ALTER TABLE "stakes"
+        ADD COLUMN IF NOT EXISTS "comment" varchar(140)
+    `);
+
+    // Add streak badge types to the badge type enum if not already there
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_THREE' AND enumtypid = 'badge_type_enum'::regtype) THEN
+          ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_THREE';
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_FIVE' AND enumtypid = 'badge_type_enum'::regtype) THEN
+          ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_FIVE';
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_TEN' AND enumtypid = 'badge_type_enum'::regtype) THEN
+          ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_TEN';
+        END IF;
+      END
+      $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "currentWinStreak"`);
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "bestWinStreak"`);
+    await queryRunner.query(`ALTER TABLE "stakes" DROP COLUMN IF EXISTS "comment"`);
+  }
+}

--- a/packages/backend/src/user/badge.worker.ts
+++ b/packages/backend/src/user/badge.worker.ts
@@ -6,13 +6,17 @@ import { Badge, BadgeType } from './entities/badge.entity';
 import { Users } from './entities/users.entity';
 
 // ── Thresholds — tweak without touching logic ──────────────────────────────
-const EARLY_ADOPTER_DAYS = 30; // days from platform launch to qualify
-const WHALE_STAKE_THRESHOLD = 1000; // total XLM staked across all calls
-const HIGH_ACCURACY_MIN_CALLS = 10; // minimum resolved calls to qualify
-const HIGH_ACCURACY_WIN_RATE = 0.7; // 70% win rate required
+const EARLY_ADOPTER_DAYS = 30;
+const WHALE_STAKE_THRESHOLD = 1000;
+const HIGH_ACCURACY_MIN_CALLS = 10;
+const HIGH_ACCURACY_WIN_RATE = 0.7;
 
-// Platform launch date — used to determine early adopter eligibility
 const PLATFORM_LAUNCH = new Date('2024-01-01T00:00:00.000Z');
+
+// Streak thresholds
+const STREAK_THREE = 3;
+const STREAK_FIVE = 5;
+const STREAK_TEN = 10;
 
 @Injectable()
 export class BadgeWorker implements OnApplicationBootstrap {
@@ -39,6 +43,7 @@ export class BadgeWorker implements OnApplicationBootstrap {
       this.assignEarlyAdopterBadge(),
       this.assignWhaleBadge(),
       this.assignHighAccuracyBadge(),
+      this.assignStreakBadges(),
     ]);
     this.logger.log('Badge assignment cron complete');
   }
@@ -61,6 +66,21 @@ export class BadgeWorker implements OnApplicationBootstrap {
         type: BadgeType.HIGH_ACCURACY,
         name: 'High Accuracy',
         description: `Achieved a ${HIGH_ACCURACY_WIN_RATE * 100}% win rate across at least ${HIGH_ACCURACY_MIN_CALLS} resolved calls.`,
+      },
+      {
+        type: BadgeType.STREAK_THREE,
+        name: '3 in a Row',
+        description: 'Won 3 consecutive predictions.',
+      },
+      {
+        type: BadgeType.STREAK_FIVE,
+        name: 'On Fire',
+        description: 'Won 5 consecutive predictions.',
+      },
+      {
+        type: BadgeType.STREAK_TEN,
+        name: 'Unstoppable',
+        description: 'Won 10 consecutive predictions.',
       },
     ];
 
@@ -179,6 +199,40 @@ export class BadgeWorker implements OnApplicationBootstrap {
     this.logger.log(
       `High Accuracy: assigned to ${qualifying.length} new users`,
     );
+  }
+
+  // ── Streak Badges ─────────────────────────────────────────────────────────
+
+  private async assignStreakBadges() {
+    const thresholds: { type: BadgeType; streak: number }[] = [
+      { type: BadgeType.STREAK_THREE, streak: STREAK_THREE },
+      { type: BadgeType.STREAK_FIVE, streak: STREAK_FIVE },
+      { type: BadgeType.STREAK_TEN, streak: STREAK_TEN },
+    ];
+
+    for (const { type, streak } of thresholds) {
+      const badge = await this.badgeRepo.findOne({ where: { type } });
+      if (!badge) continue;
+
+      const qualifying: { id: string }[] = await this.dataSource.query(
+        `
+        SELECT u.id
+        FROM users u
+        WHERE u."bestWinStreak" >= $1
+          AND NOT EXISTS (
+            SELECT 1 FROM user_badges ub
+            WHERE ub."userId" = u.id AND ub."badgeId" = $2
+          )
+        `,
+        [streak, badge.id],
+      );
+
+      await this.bulkAssign(
+        qualifying.map((r) => r.id),
+        badge,
+      );
+      this.logger.log(`Streak ${streak}: assigned to ${qualifying.length} users`);
+    }
   }
 
   // ── Shared bulk-assign (idempotent via NOT EXISTS guard in queries) ────────

--- a/packages/backend/src/user/badge.worker.ts
+++ b/packages/backend/src/user/badge.worker.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cron } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { Badge, BadgeType } from './entities/badge.entity';

--- a/packages/backend/src/user/entities/badge.entity.ts
+++ b/packages/backend/src/user/entities/badge.entity.ts
@@ -8,9 +8,12 @@ import {
 import { Users } from './users.entity';
 
 export enum BadgeType {
-  EARLY_ADOPTER = 'EARLY_ADOPTER', // joined in first 30 days of platform
-  WHALE = 'WHALE', // total stake volume exceeds threshold
-  HIGH_ACCURACY = 'HIGH_ACCURACY', // win rate >= 70% with >= 10 resolved calls
+  EARLY_ADOPTER = 'EARLY_ADOPTER',
+  WHALE = 'WHALE',
+  HIGH_ACCURACY = 'HIGH_ACCURACY',
+  STREAK_THREE = 'STREAK_THREE',
+  STREAK_FIVE = 'STREAK_FIVE',
+  STREAK_TEN = 'STREAK_TEN',
 }
 
 @Entity('badges')

--- a/packages/backend/src/user/entities/users.entity.ts
+++ b/packages/backend/src/user/entities/users.entity.ts
@@ -53,6 +53,12 @@ export class Users {
   })
   badges: Badge[];
 
+  @Column({ type: 'int', default: 0 })
+  currentWinStreak: number;
+
+  @Column({ type: 'int', default: 0 })
+  bestWinStreak: number;
+
   @Column({ type: 'boolean', default: false })
   banned: boolean;
 

--- a/packages/frontend/src/app/leaderboard/page.tsx
+++ b/packages/frontend/src/app/leaderboard/page.tsx
@@ -15,6 +15,7 @@ type LeaderboardRow = {
   winRate: number;
   totalProfit: number;
   reputationScore: number;
+  currentWinStreak?: number;
 };
 
 const periodTabs: Array<{ id: Period; label: string }> = [
@@ -98,6 +99,7 @@ export default function LeaderboardPage() {
                   <th className="px-4 py-3">Win Rate</th>
                   <th className="px-4 py-3">Total Profit</th>
                   <th className="px-4 py-3">Reputation Score</th>
+                  <th className="px-4 py-3">Streak</th>
                 </tr>
               </thead>
               <tbody>
@@ -121,6 +123,11 @@ export default function LeaderboardPage() {
                     <td className="px-4 py-3">{row.winRate.toFixed(1)}%</td>
                     <td className="px-4 py-3">${row.totalProfit.toLocaleString()}</td>
                     <td className="px-4 py-3">{row.reputationScore.toFixed(1)}</td>
+                    <td className="px-4 py-3">
+                      {row.currentWinStreak && row.currentWinStreak >= 3
+                        ? `🔥 ${row.currentWinStreak}`
+                        : row.currentWinStreak ?? '—'}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/packages/frontend/src/components/ActivityLog.tsx
+++ b/packages/frontend/src/components/ActivityLog.tsx
@@ -108,6 +108,11 @@ export default function ActivityLog({ participants, callId }: Props) {
                     <p className="text-[10px] text-gray-400">{timeAgo(entry.timestamp)}</p>
                   </div>
                 </div>
+                {entry.comment && (
+                  <p className="mt-1.5 ml-9 text-xs text-gray-500 italic leading-snug">
+                    &ldquo;{entry.comment}&rdquo;
+                  </p>
+                )}
               </div>
             );
           })

--- a/packages/frontend/src/components/ProfileHeader.tsx
+++ b/packages/frontend/src/components/ProfileHeader.tsx
@@ -58,6 +58,13 @@ export default function ProfileHeader({
             <div className="mt-4">
               <BadgeDisplay badges={user.badges} />
             </div>
+            {(user as any).currentWinStreak >= 3 && (
+              <div className={`mt-2 inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-bold ${
+                (user as any).currentWinStreak >= 5 ? 'bg-orange-100 text-orange-700 animate-pulse' : 'bg-yellow-50 text-yellow-700'
+              }`}>
+                🔥 {(user as any).currentWinStreak} Hot Streak!
+              </div>
+            )}
           </div>
         </div>
         

--- a/packages/frontend/src/components/ProfileStats.tsx
+++ b/packages/frontend/src/components/ProfileStats.tsx
@@ -25,6 +25,13 @@ export default function ProfileStats({ user }: ProfileStatsProps) {
       bgColor: 'bg-blue-100'
     },
     {
+      label: 'Best Streak',
+      value: (user as any).bestWinStreak ? `🔥 ${(user as any).bestWinStreak}` : '—',
+      icon: TrendingUp,
+      color: 'text-orange-600',
+      bgColor: 'bg-orange-100'
+    },
+    {
       label: 'Followers',
       value: formatNumber(user.followers),
       icon: Users,

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -53,6 +53,7 @@ export interface Participant {
   amount: string;
   timestamp: string; // ISO date string
   txHash: string;
+  comment?: string;
 }
 
 export interface CallDetailData {


### PR DESCRIPTION
## Summary

Implements social staking comments and win streak gamification features across backend and frontend.

### Changes

**#380 — Stake Comment Storage and Validation**
- Added optional `comment` field (VARCHAR 140) to the `Stake` entity
- Database migration `AddStreakAndStakeComment` adds the column to `stakes` table
- Validation: max 140 chars, rejects URLs, excessive caps (>50%), whitespace-only strings
- Comment included in all staking API responses

**#381 — Stake Comment Input and Feed Display**
- `StakingInterface.tsx`: added textarea with character counter below stake button
- Comment is sent as part of the stake API request body
- `ActivityLog.tsx`: displays comment as italic speech-bubble text under each entry
- Handles missing comments gracefully (no bubble rendered)

**#382 — Win Streak Calculation and Badge Assignment**
- Added `currentWinStreak` and `bestWinStreak` integer columns to the `users` table
- `analytics.service.ts` increments/resets streak on call resolution
- `badge.worker.ts` assigns streak badges idempotently: "3 in a Row" (3), "On Fire" (5), "Unstoppable" (10)
- Streak fields included in `GET /users/:address` and leaderboard responses

**#383 — Win Streak Display on Profile and Leaderboard**
- `ProfileHeader.tsx`: 🔥 streak badge shown when streak ≥ 3, pulse animation at streak ≥ 5
- `ProfileStats.tsx`: "Best Streak" stat card added
- `leaderboard/page.tsx`: "Streak" column with fire emoji for streaks ≥ 3

Closes #380
Closes #381
Closes #382
Closes #383