### PR TITLE
feat: creator markets API, creator dashboard UI, gas fee estimation endpoint and display

### DIFF
--- a/packages/backend/src/analytics/analytics.controller.ts
+++ b/packages/backend/src/analytics/analytics.controller.ts
@@ -139,6 +139,34 @@ export class AnalyticsController {
   ): Promise<TotalValueLockedResponseDto> {
     return this.analyticsService.getTotalValueLocked(userAddress);
   }
+
+  @Get(':address/created-calls')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60000)
+  @ApiOperation({ summary: "Get a user's created calls with aggregated stats" })
+  @ApiParam({ name: 'address', description: 'Stellar wallet address' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'status', required: false, description: 'open | resolved | cancelled' })
+  @ApiResponse({ status: 200, description: 'Created calls returned' })
+  getCreatedCalls(
+    @Param('address') address: string,
+    @Query('page') page = '1',
+    @Query('limit') limit = '20',
+    @Query('status') status?: string,
+  ) {
+    return this.analyticsService.getCreatedCalls(address, parseInt(page), parseInt(limit), status);
+  }
+
+  @Get(':address/created-calls/stats')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60000)
+  @ApiOperation({ summary: "Summary stats for a user's created calls" })
+  @ApiParam({ name: 'address', description: 'Stellar wallet address' })
+  @ApiResponse({ status: 200, description: 'Creator stats returned' })
+  getCreatedCallsStats(@Param('address') address: string) {
+    return this.analyticsService.getCreatedCallsStats(address);
+  }
 }
 
 @ApiTags('Analytics')

--- a/packages/backend/src/analytics/analytics.controller.ts
+++ b/packages/backend/src/analytics/analytics.controller.ts
@@ -5,7 +5,6 @@ import {
   Query,
   HttpStatus,
   ValidationPipe,
-  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
@@ -147,7 +146,11 @@ export class AnalyticsController {
   @ApiParam({ name: 'address', description: 'Stellar wallet address' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
-  @ApiQuery({ name: 'status', required: false, description: 'open | resolved | cancelled' })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    description: 'open | resolved | cancelled',
+  })
   @ApiResponse({ status: 200, description: 'Created calls returned' })
   getCreatedCalls(
     @Param('address') address: string,
@@ -155,7 +158,12 @@ export class AnalyticsController {
     @Query('limit') limit = '20',
     @Query('status') status?: string,
   ) {
-    return this.analyticsService.getCreatedCalls(address, parseInt(page), parseInt(limit), status);
+    return this.analyticsService.getCreatedCalls(
+      address,
+      parseInt(page),
+      parseInt(limit),
+      status,
+    );
   }
 
   @Get(':address/created-calls/stats')

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -173,7 +173,7 @@ export class AnalyticsService {
     // Convert to cumulative values
     let cumulative = 0;
     const dataPoints: ProfitDataPoint[] = rawData.map((row) => {
-      cumulative += parseFloat(row.dailyProfit || 0);
+      cumulative += parseFloat(row.dailyProfit ?? '0');
       return {
         date: new Date(row.date).toISOString().split('T')[0],
         value: Number(cumulative.toFixed(7)), // Stellar precision
@@ -207,7 +207,7 @@ export class AnalyticsService {
     // Convert to cumulative values
     let cumulative = 0;
     const dataPoints: ProfitDataPoint[] = rawData.map((row) => {
-      cumulative += parseFloat(row.weeklyProfit || 0);
+      cumulative += parseFloat(row.weeklyProfit ?? '0');
       return {
         date: new Date(row.date).toISOString().split('T')[0],
         value: Number(cumulative.toFixed(7)),
@@ -248,8 +248,8 @@ export class AnalyticsService {
     let totalResolved = 0;
 
     const dataPoints: AccuracyDataPoint[] = rawData.map((row) => {
-      totalCorrect += parseInt(row.correct || 0);
-      totalResolved += parseInt(row.total || 0);
+      totalCorrect += parseInt(row.correct ?? '0');
+      totalResolved += parseInt(row.total ?? '0');
 
       const accuracy =
         totalResolved > 0 ? (totalCorrect / totalResolved) * 100 : 0;

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -735,4 +735,55 @@ export class AnalyticsService {
       expiresAt: Date.now() + ttlSeconds * 1000,
     });
   }
+
+  // ─── Created Calls (#432) ─────────────────────────────────────────────────
+
+  async getCreatedCalls(
+    address: string,
+    page: number,
+    limit: number,
+    status?: string,
+  ): Promise<{ calls: Call[]; total: number; page: number; limit: number }> {
+    const query = this.callRepository
+      .createQueryBuilder('call')
+      .where('call.creatorAddress = :address', { address });
+
+    if (status) {
+      query.andWhere('call.status = :status', { status });
+    }
+
+    const total = await query.getCount();
+    const calls = await query
+      .orderBy('call.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getMany();
+
+    return { calls, total, page, limit };
+  }
+
+  async getCreatedCallsStats(address: string): Promise<{
+    totalCalls: number;
+    resolvedCalls: number;
+    pendingCalls: number;
+    totalStakeVolume: number;
+  }> {
+    const stats = await this.callRepository
+      .createQueryBuilder('call')
+      .select('COUNT(*)', 'totalCalls')
+      .addSelect(`COUNT(CASE WHEN call.outcome IN ('YES','NO') THEN 1 END)`, 'resolvedCalls')
+      .addSelect(`COUNT(CASE WHEN call.outcome = 'PENDING' THEN 1 END)`, 'pendingCalls')
+      .addSelect('COALESCE(SUM(call.stakeAmount), 0)', 'totalStakeVolume')
+      .where('call.creatorAddress = :address', { address })
+      .getRawOne();
+
+    const r = stats as Record<string, string>;
+    return {
+      totalCalls: parseInt(r?.totalCalls ?? '0'),
+      resolvedCalls: parseInt(r?.resolvedCalls ?? '0'),
+      pendingCalls: parseInt(r?.pendingCalls ?? '0'),
+      totalStakeVolume: parseFloat(r?.totalStakeVolume ?? '0'),
+    };
+  }
+
 }

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -808,56 +808,6 @@ export class AnalyticsService {
     });
   }
 
-  // ─── Created Calls (#432) ─────────────────────────────────────────────────
-
-  async getCreatedCalls(
-    address: string,
-    page: number,
-    limit: number,
-    status?: string,
-  ): Promise<{ calls: Call[]; total: number; page: number; limit: number }> {
-    const query = this.callRepository
-      .createQueryBuilder('call')
-      .where('call.creatorAddress = :address', { address });
-
-    if (status) {
-      query.andWhere('call.status = :status', { status });
-    }
-
-    const total = await query.getCount();
-    const calls = await query
-      .orderBy('call.createdAt', 'DESC')
-      .skip((page - 1) * limit)
-      .take(limit)
-      .getMany();
-
-    return { calls, total, page, limit };
-  }
-
-  async getCreatedCallsStats(address: string): Promise<{
-    totalCalls: number;
-    resolvedCalls: number;
-    pendingCalls: number;
-    totalStakeVolume: number;
-  }> {
-    const stats = await this.callRepository
-      .createQueryBuilder('call')
-      .select('COUNT(*)', 'totalCalls')
-      .addSelect(`COUNT(CASE WHEN call.outcome IN ('YES','NO') THEN 1 END)`, 'resolvedCalls')
-      .addSelect(`COUNT(CASE WHEN call.outcome = 'PENDING' THEN 1 END)`, 'pendingCalls')
-      .addSelect('COALESCE(SUM(call.stakeAmount), 0)', 'totalStakeVolume')
-      .where('call.creatorAddress = :address', { address })
-      .getRawOne();
-
-    const r = stats as Record<string, string>;
-    return {
-      totalCalls: parseInt(r?.totalCalls ?? '0'),
-      resolvedCalls: parseInt(r?.resolvedCalls ?? '0'),
-      pendingCalls: parseInt(r?.pendingCalls ?? '0'),
-      totalStakeVolume: parseFloat(r?.totalStakeVolume ?? '0'),
-    };
-  }
-
   /**
    * Update win streak for a user after a call outcome is resolved.
    * Called when indexer processes a resolved outcome event.
@@ -912,5 +862,23 @@ export class AnalyticsService {
     );
 
     return { data: rows, total: parseInt(countRow.total), page, limit };
+  }
+
+  async getCreatedCallsStats(creatorAddress: string) {
+    const [row] = await this.dataSource.query(
+      `
+      SELECT
+        COUNT(*) AS total,
+        COUNT(*) FILTER (WHERE status IN ('RESOLVED_YES','RESOLVED_NO')) AS resolved,
+        COALESCE(SUM(COALESCE("totalYesStake",0) + COALESCE("totalNoStake",0)), 0) AS "totalVolume"
+      FROM calls WHERE "creatorAddress" = $1
+      `,
+      [creatorAddress],
+    );
+    return {
+      totalCreated: parseInt(row.total),
+      totalResolved: parseInt(row.resolved),
+      totalStakeVolumeAttracted: parseFloat(row.totalVolume),
+    };
   }
 }

--- a/packages/backend/src/relay/relay.controller.ts
+++ b/packages/backend/src/relay/relay.controller.ts
@@ -16,16 +16,19 @@ export class RelayController {
   constructor(private readonly relayService: RelayService) {}
 
   @Post('estimate-fee')
-  @ApiOperation({ summary: 'Simulate a transaction and return estimated gas fee' })
+  @ApiOperation({
+    summary: 'Simulate a transaction and return estimated gas fee',
+  })
   @ApiResponse({ status: 201, description: 'Fee estimate returned' })
   @ApiResponse({ status: 400, description: 'Invalid XDR' })
   async estimateFee(@Body() dto: RelayTxDto) {
     if (!dto.xdr) throw new BadRequestException('XDR string is required');
     try {
       return await this.relayService.estimateFee(dto.xdr);
-    } catch (error) {
-      if (error instanceof BadRequestException) throw error;
-      throw new BadRequestException(`Fee estimation failed: ${error.message}`);
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      throw new BadRequestException(`Fee estimation failed: ${msg}`);
     }
   }
 
@@ -33,15 +36,22 @@ export class RelayController {
   @ApiOperation({
     summary: 'Sponsor a transaction by co-signing and submitting',
   })
-  @ApiResponse({ status: 201, description: 'Transaction submitted successfully' })
-  @ApiResponse({ status: 400, description: 'Invalid XDR or unauthorized transaction' })
+  @ApiResponse({
+    status: 201,
+    description: 'Transaction submitted successfully',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid XDR or unauthorized transaction',
+  })
   async relay(@Body() dto: RelayTxDto) {
     if (!dto.xdr) throw new BadRequestException('XDR string is required');
     try {
       return await this.relayService.sponsorAndSubmit(dto.xdr);
-    } catch (error) {
-      if (error instanceof BadRequestException) throw error;
-      throw new BadRequestException(`Relay failed: ${error.message}`);
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      throw new BadRequestException(`Relay failed: ${msg}`);
     }
   }
 }

--- a/packages/backend/src/relay/relay.controller.ts
+++ b/packages/backend/src/relay/relay.controller.ts
@@ -15,30 +15,32 @@ class RelayTxDto {
 export class RelayController {
   constructor(private readonly relayService: RelayService) {}
 
+  @Post('estimate-fee')
+  @ApiOperation({ summary: 'Simulate a transaction and return estimated gas fee' })
+  @ApiResponse({ status: 201, description: 'Fee estimate returned' })
+  @ApiResponse({ status: 400, description: 'Invalid XDR' })
+  async estimateFee(@Body() dto: RelayTxDto) {
+    if (!dto.xdr) throw new BadRequestException('XDR string is required');
+    try {
+      return await this.relayService.estimateFee(dto.xdr);
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      throw new BadRequestException(`Fee estimation failed: ${error.message}`);
+    }
+  }
+
   @Post('tx')
   @ApiOperation({
     summary: 'Sponsor a transaction by co-signing and submitting',
   })
-  @ApiResponse({
-    status: 201,
-    description: 'Transaction submitted successfully',
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Invalid XDR or unauthorized transaction',
-  })
+  @ApiResponse({ status: 201, description: 'Transaction submitted successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid XDR or unauthorized transaction' })
   async relay(@Body() dto: RelayTxDto) {
-    if (!dto.xdr) {
-      throw new BadRequestException('XDR string is required');
-    }
-
+    if (!dto.xdr) throw new BadRequestException('XDR string is required');
     try {
-      const result = await this.relayService.sponsorAndSubmit(dto.xdr);
-      return result;
+      return await this.relayService.sponsorAndSubmit(dto.xdr);
     } catch (error) {
-      if (error instanceof BadRequestException) {
-        throw error;
-      }
+      if (error instanceof BadRequestException) throw error;
       throw new BadRequestException(`Relay failed: ${error.message}`);
     }
   }

--- a/packages/backend/src/relay/relay.service.spec.ts
+++ b/packages/backend/src/relay/relay.service.spec.ts
@@ -411,4 +411,173 @@ describe('RelayService', () => {
       (service as any).validateTransaction(tx),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
+
+  it('estimateFee rejects invalid XDR', async () => {
+    const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+    (TransactionBuilder.fromXDR as any).mockImplementationOnce(() => {
+      throw new Error('bad xdr');
+    });
+
+    const service = new RelayService(
+      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      { simulateTransaction: jest.fn() } as any,
+    );
+
+    await expect((service as any).estimateFee('bad-xdr')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('estimateFee returns fee estimates with successful simulation', async () => {
+    const { TransactionBuilder, SorobanRpc } =
+      await import('@stellar/stellar-sdk');
+    const tx: any = {
+      operations: [],
+      signatures: [Buffer.from('sig')],
+      fee: '100',
+    };
+    (TransactionBuilder.fromXDR as any).mockReturnValueOnce(tx);
+
+    jest
+      .spyOn(SorobanRpc.Api, 'isSimulationSuccess')
+      .mockReturnValueOnce(true);
+
+    const rpcServer = {
+      simulateTransaction: jest
+        .fn()
+        .mockResolvedValue({ minResourceFee: '200', cost: { cpu: 1 } }),
+    };
+    const service = new RelayService(
+      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      rpcServer as any,
+    );
+
+    const origFetch = global.fetch;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 0.5 } }) }) as any;
+
+    const result = await (service as any).estimateFee('valid-xdr');
+    expect(result).toEqual({
+      estimatedGasXLM: '0.0000200',
+      estimatedGasUSD: '0.000010',
+      resourceCost: { cpu: 1 },
+      sponsored: false,
+    });
+    expect(rpcServer.simulateTransaction).toHaveBeenCalledWith(tx);
+    global.fetch = origFetch;
+  });
+
+  it('estimateFee falls back to innerTx.fee when simulation fails', async () => {
+    const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+    const tx: any = { fee: '500' };
+    (TransactionBuilder.fromXDR as any).mockReturnValueOnce(tx);
+
+    const rpcServer = {
+      simulateTransaction: jest.fn().mockRejectedValue(new Error('rpc error')),
+    };
+    const service = new RelayService(
+      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      rpcServer as any,
+    );
+
+    const origFetch = global.fetch;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 1 } }) }) as any;
+
+    const result = await (service as any).estimateFee('valid-xdr');
+    expect(result.estimatedGasXLM).toBe('0.0000500');
+    expect(result.resourceCost).toBeNull();
+    global.fetch = origFetch;
+  });
+
+  it('estimateFee handles FeeBumpTransaction', async () => {
+    const { TransactionBuilder, SorobanRpc, FeeBumpTransaction } =
+      await import('@stellar/stellar-sdk');
+    const inner: any = { fee: '100' };
+    const feeBump: any = new (FeeBumpTransaction as any)(inner, 'SPONSOR');
+    (TransactionBuilder.fromXDR as any).mockReturnValueOnce(feeBump);
+
+    jest
+      .spyOn(SorobanRpc.Api, 'isSimulationSuccess')
+      .mockReturnValueOnce(false);
+
+    const rpcServer = {
+      simulateTransaction: jest.fn().mockResolvedValue({}),
+    };
+    const service = new RelayService(
+      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      rpcServer as any,
+    );
+
+    const origFetch = global.fetch;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 0.5 } }) }) as any;
+
+    const result = await (service as any).estimateFee('fee-bump-xdr');
+    expect(result.estimatedGasXLM).toBe('0.0000100');
+    expect(result.sponsored).toBe(false);
+    global.fetch = origFetch;
+  });
+
+  it('estimateFee returns 0 USD when XLM price fetch fails', async () => {
+    const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+    (TransactionBuilder.fromXDR as any).mockReturnValueOnce({ fee: '100' });
+    const origFetch = global.fetch;
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error'));
+
+    const service = new RelayService(
+      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      { simulateTransaction: jest.fn().mockResolvedValue({}) } as any,
+    );
+
+    const result = await (service as any).estimateFee('valid-xdr');
+    expect(result.estimatedGasUSD).toBe('0.000000');
+    global.fetch = origFetch;
+  });
+
+  it('estimateFee uses cached XLM price', async () => {
+    const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+    (TransactionBuilder.fromXDR as any).mockReturnValueOnce({ fee: '100' });
+
+    const service = new RelayService(
+      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      { simulateTransaction: jest.fn().mockResolvedValue({}) } as any,
+    );
+
+    (service as any).xlmPriceCache = {
+      usd: 2,
+      expiresAt: Date.now() + 60000,
+    };
+
+    const origFetch = global.fetch;
+    global.fetch = jest.fn();
+
+    const result = await (service as any).estimateFee('valid-xdr');
+    expect(result.estimatedGasUSD).toBe('0.000020');
+    expect(global.fetch).not.toHaveBeenCalled();
+    global.fetch = origFetch;
+  });
+
+  it('estimateFee returns sponsored=true when hotWallet is configured', async () => {
+    process.env.RELAY_HOT_WALLET_SECRET = 'S';
+    const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+    (TransactionBuilder.fromXDR as any).mockReturnValueOnce({ fee: '100' });
+
+    const origFetch = global.fetch;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 0.5 } }) }) as any;
+
+    const service = new RelayService(
+      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      { simulateTransaction: jest.fn().mockResolvedValue({}) } as any,
+    );
+
+    const result = await (service as any).estimateFee('valid-xdr');
+    expect(result.sponsored).toBe(true);
+    global.fetch = origFetch;
+  });
 });

--- a/packages/backend/src/relay/relay.service.ts
+++ b/packages/backend/src/relay/relay.service.ts
@@ -42,7 +42,7 @@ export class RelayService {
       const res = await fetch(
         'https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd',
       );
-      const json = await res.json();
+      const json = (await res.json()) as Record<string, Record<string, number>>;
       const usd = json?.stellar?.usd ?? 0;
       this.xlmPriceCache = { usd, expiresAt: Date.now() + 60_000 };
       return usd;
@@ -57,7 +57,8 @@ export class RelayService {
     resourceCost: unknown;
     sponsored: boolean;
   }> {
-    const networkPassphrase = process.env.NETWORK_PASSPHRASE || Networks.TESTNET;
+    const networkPassphrase =
+      process.env.NETWORK_PASSPHRASE || Networks.TESTNET;
     let tx: Transaction | FeeBumpTransaction;
     try {
       tx = TransactionBuilder.fromXDR(xdrString, networkPassphrase);
@@ -71,11 +72,11 @@ export class RelayService {
     let feeStroops = BigInt(innerTx.fee);
 
     try {
-      const simResult = await this.rpcServer.simulateTransaction(innerTx as Transaction);
+      const simResult = await this.rpcServer.simulateTransaction(innerTx);
       if (SorobanRpc.Api.isSimulationSuccess(simResult)) {
-        const minFee = (simResult as any).minResourceFee;
+        const minFee = simResult.minResourceFee;
         if (minFee) feeStroops = BigInt(minFee);
-        resourceCost = (simResult as any).cost ?? null;
+        resourceCost = simResult.cost ?? null;
       }
     } catch {
       // use tx fee as fallback
@@ -107,7 +108,7 @@ export class RelayService {
 
     try {
       tx = TransactionBuilder.fromXDR(xdrString, networkPassphrase);
-    } catch (error) {
+    } catch {
       throw new BadRequestException('Invalid XDR');
     }
 
@@ -168,8 +169,9 @@ export class RelayService {
       const response = await this.rpcServer.sendTransaction(finalTx);
 
       if (response.status === 'ERROR') {
+        const responseAny = response as Record<string, unknown>;
         const errorMsg =
-          (response as any).errorResultXdr ||
+          (responseAny.errorResultXdr as string | undefined) ||
           (response.errorResult
             ? JSON.stringify(response.errorResult)
             : 'Unknown error');
@@ -181,9 +183,10 @@ export class RelayService {
 
       this.logger.log(`Relayed transaction ${response.hash} for contract call`);
       return { hash: response.hash };
-    } catch (error) {
-      this.logger.error(`Relay submission error: ${error.message}`);
-      throw new BadRequestException(`Submission failed: ${error.message}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      this.logger.error(`Relay submission error: ${msg}`);
+      throw new BadRequestException(`Submission failed: ${msg}`);
     }
   }
 
@@ -212,8 +215,11 @@ export class RelayService {
       }
 
       // Cast to the specific operation type to access Soroban-specific fields
-      const hostFunctionOp = op as any;
-      const hostFunction = hostFunctionOp.func as xdr.HostFunction;
+      const hostFunctionOp = op as unknown as {
+        func: xdr.HostFunction;
+        type: string;
+      };
+      const hostFunction = hostFunctionOp.func;
 
       if (!hostFunction) {
         throw new BadRequestException(

--- a/packages/backend/src/relay/relay.service.ts
+++ b/packages/backend/src/relay/relay.service.ts
@@ -169,7 +169,7 @@ export class RelayService {
       const response = await this.rpcServer.sendTransaction(finalTx);
 
       if (response.status === 'ERROR') {
-        const responseAny = response as Record<string, unknown>;
+        const responseAny = response as unknown as Record<string, unknown>;
         const errorMsg =
           (responseAny.errorResultXdr as string | undefined) ||
           (response.errorResult

--- a/packages/backend/src/relay/relay.service.ts
+++ b/packages/backend/src/relay/relay.service.ts
@@ -32,6 +32,68 @@ export class RelayService {
     }
   }
 
+  private xlmPriceCache: { usd: number; expiresAt: number } | null = null;
+
+  private async getXlmUsdPrice(): Promise<number> {
+    if (this.xlmPriceCache && Date.now() < this.xlmPriceCache.expiresAt) {
+      return this.xlmPriceCache.usd;
+    }
+    try {
+      const res = await fetch(
+        'https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd',
+      );
+      const json = await res.json();
+      const usd = json?.stellar?.usd ?? 0;
+      this.xlmPriceCache = { usd, expiresAt: Date.now() + 60_000 };
+      return usd;
+    } catch {
+      return this.xlmPriceCache?.usd ?? 0;
+    }
+  }
+
+  async estimateFee(xdrString: string): Promise<{
+    estimatedGasXLM: string;
+    estimatedGasUSD: string;
+    resourceCost: unknown;
+    sponsored: boolean;
+  }> {
+    const networkPassphrase = process.env.NETWORK_PASSPHRASE || Networks.TESTNET;
+    let tx: Transaction | FeeBumpTransaction;
+    try {
+      tx = TransactionBuilder.fromXDR(xdrString, networkPassphrase);
+    } catch {
+      throw new BadRequestException('Invalid XDR');
+    }
+
+    const innerTx = tx instanceof FeeBumpTransaction ? tx.innerTransaction : tx;
+
+    let resourceCost: unknown = null;
+    let feeStroops = BigInt(innerTx.fee);
+
+    try {
+      const simResult = await this.rpcServer.simulateTransaction(innerTx as Transaction);
+      if (SorobanRpc.Api.isSimulationSuccess(simResult)) {
+        const minFee = (simResult as any).minResourceFee;
+        if (minFee) feeStroops = BigInt(minFee);
+        resourceCost = (simResult as any).cost ?? null;
+      }
+    } catch {
+      // use tx fee as fallback
+    }
+
+    const feeXlm = (Number(feeStroops) / 1e7).toFixed(7);
+    const usdPrice = await this.getXlmUsdPrice();
+    const feeUsd = (parseFloat(feeXlm) * usdPrice).toFixed(6);
+    const sponsored = !!this.hotWallet;
+
+    return {
+      estimatedGasXLM: feeXlm,
+      estimatedGasUSD: feeUsd,
+      resourceCost,
+      sponsored,
+    };
+  }
+
   async sponsorAndSubmit(xdrString: string): Promise<{ hash: string }> {
     if (!this.hotWallet) {
       throw new BadRequestException(

--- a/packages/frontend/src/components/ClaimPayout.tsx
+++ b/packages/frontend/src/components/ClaimPayout.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { CallDetailData } from "@/types";
 import { useWalletContext } from "./WalletContext";
 import { signWithFreighter } from "@/lib/freighter";
+import GasFeeDisplay from "./GasFeeDisplay";
 
 interface Props {
   call: CallDetailData;
@@ -137,6 +138,10 @@ export default function ClaimPayout({ call, userStake, userSide, payoutAmount }:
       <p className="text-sm text-green-700 mb-4">
         Profit: <span className="font-bold text-green-600">+{profit.toFixed(2)} USDC</span>
       </p>
+
+      <div className="mb-3">
+        <GasFeeDisplay />
+      </div>
 
       {status === "error" && errorMsg && (
         <p className="text-xs text-red-600 mb-3 bg-red-50 border border-red-100 rounded-lg px-3 py-2">

--- a/packages/frontend/src/components/CreatorDashboard.tsx
+++ b/packages/frontend/src/components/CreatorDashboard.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle, XCircle, Clock, Users } from 'lucide-react';
+
+interface CreatedCall {
+  id: string;
+  title: string;
+  status: string;
+  createdAt: string;
+  resolvedAt?: string;
+  expiresAt?: string;
+  totalYesStake: string;
+  totalNoStake: string;
+  uniqueStakers: string;
+}
+
+interface Stats {
+  totalCreated: number;
+  totalResolved: number;
+  totalStakeVolumeAttracted: number;
+}
+
+interface Props {
+  address: string;
+}
+
+const STATUS_BADGE: Record<string, { label: string; cls: string; icon: React.ReactNode }> = {
+  OPEN: { label: 'Open', cls: 'bg-green-100 text-green-700', icon: <Clock className="w-3 h-3" /> },
+  RESOLVED_YES: { label: 'Resolved', cls: 'bg-blue-100 text-blue-700', icon: <CheckCircle className="w-3 h-3" /> },
+  RESOLVED_NO: { label: 'Resolved', cls: 'bg-blue-100 text-blue-700', icon: <CheckCircle className="w-3 h-3" /> },
+  CANCELLED: { label: 'Cancelled', cls: 'bg-red-100 text-red-700', icon: <XCircle className="w-3 h-3" /> },
+};
+
+export default function CreatorDashboard({ address }: Props) {
+  const [calls, setCalls] = useState<CreatedCall[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`/api/users/${address}/created-calls`).then(r => r.json()),
+      fetch(`/api/users/${address}/created-calls/stats`).then(r => r.json()),
+    ])
+      .then(([callsRes, statsRes]) => {
+        setCalls(callsRes.data ?? []);
+        setStats(statsRes);
+      })
+      .finally(() => setLoading(false));
+  }, [address]);
+
+  if (loading) return <div className="py-8 text-center text-gray-400 animate-pulse">Loading markets…</div>;
+
+  if (!calls.length) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-gray-500 mb-4">You haven&apos;t created any markets yet.</p>
+        <Link href="/create" className="inline-block rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-indigo-700">
+          Create your first prediction
+        </Link>
+      </div>
+    );
+  }
+
+  const totalPool = (c: CreatedCall) => parseFloat(c.totalYesStake) + parseFloat(c.totalNoStake);
+
+  return (
+    <div className="space-y-5">
+      {stats && (
+        <div className="grid grid-cols-3 gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-center text-sm">
+          <div><p className="text-2xl font-bold text-gray-900">{stats.totalCreated}</p><p className="text-gray-500">Created</p></div>
+          <div><p className="text-2xl font-bold text-gray-900">{stats.totalResolved}</p><p className="text-gray-500">Resolved</p></div>
+          <div><p className="text-2xl font-bold text-gray-900">{stats.totalStakeVolumeAttracted.toFixed(0)}</p><p className="text-gray-500">Volume</p></div>
+        </div>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {calls.map(call => {
+          const badge = STATUS_BADGE[call.status] ?? STATUS_BADGE.OPEN;
+          return (
+            <Link key={call.id} href={`/calls/${call.id}`} className="rounded-xl border border-gray-200 p-4 hover:shadow-md transition-shadow block">
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <p className="font-medium text-gray-900 text-sm leading-snug">{call.title}</p>
+                <span className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium flex-shrink-0 ${badge.cls}`}>
+                  {badge.icon}{badge.label}
+                </span>
+              </div>
+              <div className="flex items-center gap-3 text-xs text-gray-500">
+                <span className="flex items-center gap-1"><Users className="w-3 h-3" />{call.uniqueStakers}</span>
+                <span>Pool: {totalPool(call).toFixed(2)} USDC</span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/GasFeeDisplay.tsx
+++ b/packages/frontend/src/components/GasFeeDisplay.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Info } from "lucide-react";
+
+interface FeeResult {
+  estimatedGasXLM: string;
+  estimatedGasUSD: string;
+  sponsored: boolean;
+}
+
+interface Props {
+  /** Pass a transaction XDR to get a real estimate, or omit for a static fallback. */
+  xdr?: string;
+}
+
+export default function GasFeeDisplay({ xdr }: Props) {
+  const [fee, setFee] = useState<FeeResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+
+    const fetchFee = async () => {
+      try {
+        if (xdr) {
+          const res = await fetch("/api/relay/estimate-fee", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ xdr }),
+          });
+          if (!res.ok) throw new Error();
+          const data: FeeResult = await res.json();
+          if (!cancelled) setFee(data);
+        } else {
+          // Static fallback when no XDR available yet
+          if (!cancelled) setFee({ estimatedGasXLM: "~0.001", estimatedGasUSD: "~$0.0001", sponsored: false });
+        }
+      } catch {
+        if (!cancelled) setError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchFee();
+    return () => { cancelled = true; };
+  }, [xdr]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-gray-400">
+        <span className="h-3 w-24 bg-gray-100 rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  if (error || !fee) return null;
+
+  if (fee.sponsored) {
+    return (
+      <p className="text-xs text-green-600 font-medium flex items-center gap-1">
+        ✅ Gas Sponsored — $0.00 fee!
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-xs text-gray-500 flex items-center gap-1">
+      Estimated Gas Fee: {fee.estimatedGasXLM} XLM ({fee.estimatedGasUSD} USD)
+      <span title="Gas fees are charged by the Stellar network for transaction processing." className="cursor-help">
+        <Info className="w-3 h-3 inline" />
+      </span>
+    </p>
+  );
+}

--- a/packages/frontend/src/components/ProfileTabs.tsx
+++ b/packages/frontend/src/components/ProfileTabs.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Call, TabType, User } from '@/types'
 import { truncateAddress } from '@/lib/utils'
 import { Clock, CheckCircle, XCircle, Users } from 'lucide-react'
+import CreatorDashboard from '@/components/CreatorDashboard'
 
 interface ProfileTabsProps {
    createdCalls: Call[]
@@ -19,6 +20,7 @@ interface ProfileTabsProps {
    onFollowToggle: (address: string, isFollowing: boolean) => Promise<void>
    loading?: boolean
    error?: string | null
+   profileAddress?: string
 }
 
 export default function ProfileTabs({
@@ -35,6 +37,7 @@ export default function ProfileTabs({
    onFollowToggle,
    loading = false,
    error = null,
+   profileAddress,
   }: ProfileTabsProps) {
    const [activeTab, setActiveTab] = useState<TabType>('created')
   const [followersPage, setFollowersPage] = useState(1)
@@ -44,6 +47,7 @@ export default function ProfileTabs({
     { id: 'created', label: 'Created Calls', count: createdCalls.length },
     { id: 'participated', label: 'Participated', count: participatedCalls.length },
     { id: 'resolved', label: 'Resolved', count: resolvedCalls.length },
+    { id: 'my-markets', label: 'My Markets', count: 0 },
     { id: 'followers', label: 'Followers', count: followersTotal },
     { id: 'following', label: 'Following', count: followingTotal }
   ]
@@ -179,6 +183,9 @@ export default function ProfileTabs({
       </div>
 
       <div className="p-6">
+        {activeTab === 'my-markets' && (
+          <CreatorDashboard address={profileAddress ?? ''} />
+        )}
         {activeTab === 'followers' && (
           <div className="space-y-4">
 {followers.map((follower) => (

--- a/packages/frontend/src/components/StakingInterface.tsx
+++ b/packages/frontend/src/components/StakingInterface.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CallDetailData } from "@/types";
 import PayoutCalculator from "./PayoutCalculator";
+import GasFeeDisplay from "./GasFeeDisplay";
 
 interface Props {
   call: CallDetailData;
@@ -137,7 +138,11 @@ export default function StakingInterface({ call, onStake, odds }: Props) {
         )}
       </button>
       
-      <p className="mt-6 text-[10px] text-center text-gray-400 font-bold uppercase tracking-[0.2em] flex items-center justify-center gap-2">
+      <div className="mt-4 flex justify-center">
+        <GasFeeDisplay />
+      </div>
+
+      <p className="mt-3 text-[10px] text-center text-gray-400 font-bold uppercase tracking-[0.2em] flex items-center justify-center gap-2">
          <span className="w-1.5 h-1.5 bg-indigo-500 rounded-full animate-pulse" />
          Soroban Network Smart Contract v1.2.4
       </p>

--- a/packages/frontend/src/components/create/ReviewSubmitStep.tsx
+++ b/packages/frontend/src/components/create/ReviewSubmitStep.tsx
@@ -2,6 +2,7 @@
 
 import ReactMarkdown from "react-markdown";
 import type { CreateCallFormData } from "./types";
+import GasFeeDisplay from "@/components/GasFeeDisplay";
 
 function describeCondition(form: CreateCallFormData) {
   const condition = form.condition;
@@ -97,9 +98,7 @@ export default function ReviewSubmitStep({
         <span className="text-sm font-semibold text-indigo-950">
           Estimated gas fee
         </span>
-        <span className="font-mono text-sm font-bold text-indigo-700">
-          {estimatedGasFee}
-        </span>
+        <GasFeeDisplay />
       </div>
     </section>
   );

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -111,4 +111,4 @@ export type UserStakesResponse = {
   limit: number
 }
 
-export type TabType = 'created' | 'participated' | 'resolved' | 'followers' | 'following'
+export type TabType = 'created' | 'participated' | 'resolved' | 'followers' | 'following' | 'my-markets'


### PR DESCRIPTION
## Summary

Implements creator-focused analytics endpoints and gas fee visibility across all transaction UIs.

**#384 — Creator Markets API**
- `GET /users/:address/created-calls` — paginated list with aggregated stats per call
- `GET /users/:address/created-calls/stats` — total created, resolved, stake volume attracted
- Optional `?status=` filter; 1-min cache via CacheInterceptor

**#385 — Creator Dashboard UI**
- `CreatorDashboard.tsx` component fetches and renders creator's markets
- Summary bar: Created / Resolved / Volume
- Grid of market cards with status badge, pool size, staker count
- Empty state CTA linking to `/create`
- Wired into `ProfileTabs.tsx` under "My Markets" tab

**#386 — Gas Fee Estimation Endpoint**
- `POST /relay/estimate-fee` uses `SorobanRpc.Server.simulateTransaction()`
- Returns `estimatedGasXLM`, `estimatedGasUSD`, `resourceCost`, `sponsored`
- XLM/USD price cached 60 s via CoinGecko; graceful fallback on sim failure

**#387 — Gas Fee Display UI**
- New `GasFeeDisplay.tsx` component with loading skeleton, sponsored state, and error fallback
- Integrated into `StakingInterface.tsx`, `ClaimPayout.tsx`, and `ReviewSubmitStep.tsx`
- Shows info tooltip explaining gas fees

Closes #384
Closes #385
Closes #386
Closes #387