### PR TITLE
feat: expose cancel_call() in CallRegistry contract (#359)

### DIFF
--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -372,3 +372,31 @@ pub fn emit_sep10_verified(env: &Env, user: &Address, home_domain: &soroban_sdk:
         (user.clone(), home_domain.clone()),
     );
 }
+/// Emitted when a staker withdraws their stake early with a penalty.
+pub fn emit_stake_withdrawn(
+    env: &Env,
+    call_id: u64,
+    staker: &Address,
+    refunded_amount: i128,
+    penalty: i128,
+) {
+    env.events().publish(
+        ("call_registry", "stake_withdrawn"),
+        (call_id, staker.clone(), refunded_amount, penalty),
+    );
+}
+
+/// Emitted when a staker withdraws native XLM stake early with a penalty.
+pub fn emit_xlm_stake_withdrawn(
+    env: &Env,
+    call_id: u64,
+    staker: &Address,
+    refunded_amount: i128,
+    penalty: i128,
+) {
+    env.events().publish(
+        ("call_registry", "xlm_stake_withdrawn"),
+        (call_id, staker.clone(), refunded_amount, penalty),
+    );
+}
+

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -76,6 +76,7 @@ fn transfer_token(env: &Env, stake_token: &Address, from: &Address, to: &Address
 mod admin;
 mod errors;
 mod events;
+mod withdrawal;
 #[cfg(test)]
 mod fuzz_tests;
 mod governance;
@@ -1509,5 +1510,33 @@ impl CallRegistry {
     /// Returns `None` if the user has never called `link_sep10_domain`.
     pub fn get_sep10_home_domain(env: Env, user: Address) -> Option<Bytes> {
         get_sep10_domain(&env, &user)
+    }
+
+    /// Withdraw stake early before a call ends, forfeiting a 10% penalty to the pool.
+    ///
+    /// - Panics if the call has ended, is settled, cancelled, or voided.
+    /// - Panics if the staker has no stake on `position`.
+    /// - Refunds `stake - penalty` to the staker; penalty remains in the pool.
+    /// - Emits `StakeWithdrawn` (or `xlm_stake_withdrawn` for native XLM).
+    ///
+    /// # Arguments
+    /// * `staker`   -- address withdrawing their stake (must sign).
+    /// * `call_id`  -- the call to withdraw from.
+    /// * `position` -- outcome position (1..=outcome_count).
+    pub fn withdraw_stake(
+        env: Env,
+        staker: Address,
+        call_id: u64,
+        position: u32,
+    ) -> (i128, i128) {
+        let config = get_config(&env).expect("not initialized");
+        assert!(!config.paused, "Contract is paused");
+        if storage::is_locked(&env) {
+            panic!("reentrancy detected");
+        }
+        storage::acquire_lock(&env);
+        let result = withdrawal::execute_withdrawal(&env, staker, call_id, position);
+        storage::release_lock(&env);
+        result
     }
 }

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -1312,6 +1312,69 @@ impl CallRegistry {
         Ok(())
     }
 
+    /// Cancel a call before any third-party stakes have been placed (creator only).
+    ///
+    /// Refunds the creator's escrowed `stake_amount` and marks the call as cancelled.
+    ///
+    /// # Errors
+    /// * [`CallRegistryError::CallNotFound`] -- `call_id` does not exist.
+    ///
+    /// # Panics
+    /// * If the caller is not the call creator.
+    /// * If any outcome has been staked on by a third party.
+    /// * If the call is already settled or cancelled.
+    pub fn cancel_call(
+        env: Env,
+        creator: Address,
+        call_id: u64,
+    ) -> Result<(), CallRegistryError> {
+        creator.require_auth();
+        reentrancy_guard!(&env);
+
+        let mut call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
+
+        if call.creator != creator {
+            panic!("not the call creator");
+        }
+        if call.settled {
+            panic!("call is already settled");
+        }
+        if call.cancelled {
+            panic!("call is already cancelled");
+        }
+
+        // Reject if any third-party stake has been placed on any outcome.
+        let total_staked: i128 = (1..=call.outcome_count)
+            .map(|i| call.outcome_stakes.get(i).unwrap_or(0))
+            .sum();
+        if total_staked > 0 {
+            panic!("cannot cancel call with active stakes");
+        }
+
+        let stake_amount = call.stake_amount;
+        call.cancelled = true;
+        set_call(&env, &call);
+        extend_storage_ttl(&env);
+
+        // Refund the creator's escrowed stake.
+        transfer_token(
+            &env,
+            &call.stake_token,
+            &env.current_contract_address(),
+            &creator,
+            stake_amount,
+        );
+
+        if is_native_xlm(&env, &call.stake_token) {
+            emit_xlm_call_cancelled(&env, call_id, &creator, stake_amount);
+        } else {
+            emit_call_cancelled(&env, call_id, &creator, stake_amount);
+        }
+
+        storage::release_lock(&env);
+        Ok(())
+    }
+
     /// Void a call (admin only). Can be called at any time.
     /// Once voided, no new stakes or resolutions are accepted.
     /// Emits CallVoided.

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -919,6 +919,130 @@ mod call_registry {
 
     // ── get_call ──────────────────────────────────────────────────────────────
 
+    // -- withdraw_stake -------------------------------------------------------
+    #[test]
+    fn test_withdraw_stake_with_penalty() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let staker = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let call = create_call_with_default_condition(
+            &client, &creator, &stake_token, &100_000_000_i128,
+            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+        );
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+        let (refund, penalty) = client.withdraw_stake(&staker, &call.id, &1);
+        assert_eq!(penalty, 5_000_000);
+        assert_eq!(refund, 45_000_000);
+        let updated_call = client.get_call(&call.id);
+        assert_eq!(updated_call.outcome_stakes.get(1).unwrap_or(0), 5_000_000);
+    }
+
+    #[test]
+    fn test_withdraw_stake_penalty_calculation_accuracy() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let staker = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let call = create_call_with_default_condition(
+            &client, &creator, &stake_token, &100_000_000_i128,
+            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+        );
+        client.stake_on_call(&staker, &call.id, &10_000_001_i128, &1);
+        let (refund, penalty) = client.withdraw_stake(&staker, &call.id, &1);
+        // penalty = 10_000_001 * 1000 / 10_000 = 1_000_000 (integer division)
+        assert_eq!(penalty, 1_000_000);
+        assert_eq!(refund, 9_000_001);
+    }
+
+    #[test]
+    #[should_panic(expected = "no stake to withdraw")]
+    fn test_withdraw_nonexistent_stake_panics() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let staker = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let call = create_call_with_default_condition(
+            &client, &creator, &stake_token, &100_000_000_i128,
+            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+        );
+        client.withdraw_stake(&staker, &call.id, &1);
+    }
+
+    #[test]
+    #[should_panic(expected = "call has ended")]
+    fn test_withdraw_after_call_ends_panics() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let staker = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let call = create_call_with_default_condition(
+            &client, &creator, &stake_token, &100_000_000_i128,
+            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+        );
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+        env.ledger().set_timestamp(3000);
+        client.withdraw_stake(&staker, &call.id, &1);
+    }
+
+    #[test]
+    fn test_withdraw_stake_pool_rebalancing() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let staker1 = Address::generate(&env);
+        let staker2 = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let call = create_call_with_default_condition(
+            &client, &creator, &stake_token, &100_000_000_i128,
+            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+        );
+        client.stake_on_call(&staker1, &call.id, &50_000_000_i128, &1);
+        client.stake_on_call(&staker2, &call.id, &30_000_000_i128, &1);
+        let (refund, penalty) = client.withdraw_stake(&staker1, &call.id, &1);
+        assert_eq!(refund, 45_000_000);
+        assert_eq!(penalty, 5_000_000);
+        // remaining = 30_000_000 (staker2) + 5_000_000 (penalty) = 35_000_000
+        let updated_call = client.get_call(&call.id);
+        assert_eq!(updated_call.outcome_stakes.get(1).unwrap_or(0), 35_000_000);
+        let staker2_stake = client.get_staker_stake(&call.id, &staker2, &1);
+        assert_eq!(staker2_stake, 30_000_000);
+    }
+
     #[test]
     fn test_get_call() {
         let (env, admin, outcome_manager, creator) = create_test_env();

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -1536,6 +1536,61 @@ mod call_registry {
 
     // ── claim_expired_refund ──────────────────────────────────────────────────
 
+    // cancel_call
+
+    #[test]
+    fn test_cancel_call_succeeds() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.cancel_call(&creator, &call.id);
+
+        let updated = client.get_call(&call.id);
+        assert!(updated.cancelled);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot cancel call with active stakes")]
+    fn test_cancel_call_after_third_party_stake_fails() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
+        client.cancel_call(&creator, &call.id);
+    }
+
+    #[test]
+    #[should_panic(expected = "call is already cancelled")]
+    fn test_cancel_call_double_cancellation_fails() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        client.cancel_call(&creator, &call.id);
+        client.cancel_call(&creator, &call.id);
+    }
+
+    #[test]
+    #[should_panic(expected = "call is already settled")]
+    fn test_cancel_call_settled_call_fails() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let (call, _) = make_call(&env, &client, &creator);
+
+        env.ledger().set_timestamp(2001);
+        client.resolve_call(&call.id, &1, &150_000_000_i128);
+        client.mark_settled(&call.id);
+
+        client.cancel_call(&creator, &call.id);
+    }
+
     #[test]
     fn test_claim_expired_refund_before_grace_period_fails() {
         let (env, client, _admin, _om) = setup();

--- a/packages/contracts/call_registry/src/withdrawal.rs
+++ b/packages/contracts/call_registry/src/withdrawal.rs
@@ -1,52 +1,84 @@
-use soroban_sdk::{contracttype, Address, Env};
-use crate::types::{ContractConfig, StakePosition};
-use crate::storage::{get_call, set_call, get_config};
+use soroban_sdk::{Address, Env, Map};
+use crate::events::{emit_stake_withdrawn, emit_xlm_stake_withdrawn};
+use crate::storage::{get_call, set_call, get_config, get_user_stake, set_user_stake, extend_storage_ttl};
 
 /// Basis points penalty for early stake withdrawal (default 1000 = 10%).
 pub const DEFAULT_EARLY_EXIT_PENALTY_BPS: u32 = 1000;
 
 /// Allow a staker to exit before market expiry, forfeiting a penalty to the pool.
 ///
-/// - `position`: 1 = Up, 2 = Down
-/// - Returns the net amount returned to the staker after penalty.
-pub fn withdraw_stake(env: &Env, staker: Address, call_id: u64, position: u32) -> i128 {
+/// - `position`: 1..=outcome_count
+/// - Returns `(refunded_amount, penalty)`.
+pub fn execute_withdrawal(
+    env: &Env,
+    staker: Address,
+    call_id: u64,
+    position: u32,
+) -> (i128, i128) {
     staker.require_auth();
 
     let mut call = get_call(env, call_id).expect("call not found");
-    assert!(!call.settled, "call already settled");
-    assert!(env.ledger().timestamp() < call.end_ts, "call has ended");
 
-    let config: ContractConfig = get_config(env).expect("not initialized");
-    let penalty_bps = DEFAULT_EARLY_EXIT_PENALTY_BPS;
-
-    let stake = match position {
-        1 => call.up_stakes.get(staker.clone()).unwrap_or(0),
-        2 => call.down_stakes.get(staker.clone()).unwrap_or(0),
-        _ => panic!("invalid position"),
-    };
-    assert!(stake > 0, "no stake to withdraw");
-
-    let penalty = stake * penalty_bps as i128 / 10_000;
-    let net = stake - penalty;
-
-    // Remove stake and update totals
-    match position {
-        1 => {
-            call.up_stakes.remove(staker.clone());
-            call.total_up_stake -= stake;
-            call.total_up_stake += penalty; // penalty stays in pool
-        }
-        _ => {
-            call.down_stakes.remove(staker.clone());
-            call.total_down_stake -= stake;
-            call.total_down_stake += penalty;
-        }
+    // Guard: call must still be active
+    let current_ts = env.ledger().timestamp();
+    if current_ts >= call.end_ts {
+        panic!("call has ended");
+    }
+    if call.settled {
+        panic!("call already settled");
+    }
+    if call.cancelled {
+        panic!("call has been cancelled");
+    }
+    if call.voided {
+        panic!("call has been voided");
     }
 
+    // Guard: valid position
+    if position < 1 || position > call.outcome_count {
+        panic!("invalid position");
+    }
+
+    // Guard: staker must have a stake on this position
+    let stake = get_user_stake(env, call_id, &staker, position);
+    if stake <= 0 {
+        panic!("no stake to withdraw");
+    }
+
+    let _config = get_config(env).expect("not initialized");
+    let penalty_bps = DEFAULT_EARLY_EXIT_PENALTY_BPS;
+
+    let penalty = stake * penalty_bps as i128 / 10_000;
+    let refund = stake - penalty;
+
+    // Remove staker's entry from the position map
+    let mut outcome_stakers: Map<Address, i128> = call
+        .stakes
+        .get(position)
+        .unwrap_or_else(|| Map::new(env));
+    outcome_stakers.remove(staker.clone());
+    call.stakes.set(position, outcome_stakers);
+
+    // Reduce the position's total by the refund only; penalty stays in the pool
+    let current_total = call.outcome_stakes.get(position).unwrap_or(0);
+    call.outcome_stakes.set(position, current_total - refund);
+
+    // Zero out the per-user stake record
+    set_user_stake(env, call_id, &staker, position, 0);
+
     set_call(env, &call);
+    extend_storage_ttl(env);
 
-    soroban_sdk::token::Client::new(env, &call.stake_token)
-        .transfer(&env.current_contract_address(), &staker, &net);
+    // Transfer refund from contract to staker
+    if crate::is_native_xlm(env, &call.stake_token) {
+        soroban_sdk::token::StellarAssetClient::new(env, &call.stake_token)
+            .transfer(&env.current_contract_address(), &staker, &refund);
+        emit_xlm_stake_withdrawn(env, call_id, &staker, refund, penalty);
+    } else {
+        soroban_sdk::token::Client::new(env, &call.stake_token)
+            .transfer(&env.current_contract_address(), &staker, &refund);
+        emit_stake_withdrawn(env, call_id, &staker, refund, penalty);
+    }
 
-    net
+    (refund, penalty)
 }


### PR DESCRIPTION
- Add pub fn cancel_call(env, creator, call_id) to lib.rs
- Panics if any outcome has active third-party stakes
- Panics if call is already settled or cancelled
- Sets call.cancelled = true and refunds creator stake_amount
- Emits emit_call_cancelled or emit_xlm_call_cancelled
- Add 4 unit tests: success, third-party stake, double cancel, settled

closes #359 