### PR TITLE
feat: integrate oracle key rotation with dedicated storage keys (#362)

### DIFF
--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -8,6 +8,7 @@ mod events;
 mod fuzz_tests;
 mod storage;
 mod test;
+mod rotation;
 mod verification;
 
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
@@ -906,5 +907,19 @@ impl OutcomeManager {
         weighted_sum
             .checked_div(total_time)
             .unwrap_or_else(|| overflow(&env))
+    }
+
+    pub fn schedule_oracle_removal(env: Env, oracle_pubkey: BytesN<32>, effective_ledger: u32) {
+        require_admin(&env);
+        rotation::schedule_oracle_removal(&env, oracle_pubkey, effective_ledger);
+    }
+
+    pub fn execute_oracle_removal(env: Env, oracle_pubkey: BytesN<32>) {
+        require_admin(&env);
+        rotation::execute_oracle_removal(&env, oracle_pubkey);
+    }
+
+    pub fn is_oracle_active(env: Env, oracle_pubkey: BytesN<32>) -> bool {
+        rotation::is_oracle_active(&env, &oracle_pubkey)
     }
 }

--- a/packages/contracts/outcome_manager/src/rotation.rs
+++ b/packages/contracts/outcome_manager/src/rotation.rs
@@ -1,32 +1,52 @@
-use crate::storage::InstanceKey;
-use soroban_sdk::{contracttype, BytesN, Env, Map};
-
-/// A scheduled oracle removal — oracle remains valid until `effective_ledger`.
-#[contracttype]
-#[derive(Clone)]
-pub struct PendingRemoval {
-    pub oracle_pubkey: BytesN<32>,
-    pub effective_ledger: u32,
-}
-
-const PENDING_REMOVALS_KEY: InstanceKey = InstanceKey::Admin; // placeholder — use a dedicated key in prod
+use crate::storage::{InstanceKey, PersistentKey};
+use soroban_sdk::{BytesN, Env, Map};
 
 /// Schedule an oracle key for removal at a future ledger sequence.
 /// The oracle remains valid for submissions until `effective_ledger` is reached.
 pub fn schedule_oracle_removal(env: &Env, oracle_pubkey: BytesN<32>, effective_ledger: u32) {
-    assert!(effective_ledger > env.ledger().sequence(), "effective_ledger must be in the future");
+    assert!(
+        effective_ledger > env.ledger().sequence(),
+        "effective_ledger must be in the future"
+    );
 
-    let mut pending: Map<BytesN<32>, u32> = env
-        .storage()
-        .instance()
-        .get(&InstanceKey::Quorum) // reuse slot for demo; use a dedicated key in prod
-        .unwrap_or_else(|| Map::new(env));
-
-    pending.set(oracle_pubkey, effective_ledger);
-    env.storage().instance().set(&InstanceKey::Quorum, &pending);
+    env.storage()
+        .persistent()
+        .set(&PersistentKey::PendingOracleRemoval(oracle_pubkey), &effective_ledger);
 }
 
-/// Returns true if the oracle is still valid at the current ledger.
+/// Execute a scheduled oracle removal once the grace period has elapsed.
+/// Panics if no removal is scheduled or the grace period has not passed.
+pub fn execute_oracle_removal(env: &Env, oracle_pubkey: BytesN<32>) {
+    let key = PersistentKey::PendingOracleRemoval(oracle_pubkey.clone());
+
+    let effective_ledger: u32 = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .expect("no removal scheduled for this oracle");
+
+    assert!(
+        env.ledger().sequence() >= effective_ledger,
+        "grace period has not elapsed"
+    );
+
+    // Remove the oracle from the active set
+    let mut oracles: Map<BytesN<32>, bool> = env
+        .storage()
+        .instance()
+        .get(&InstanceKey::Oracles)
+        .unwrap_or_else(|| Map::new(env));
+
+    oracles.remove(oracle_pubkey.clone());
+    env.storage().instance().set(&InstanceKey::Oracles, &oracles);
+
+    // Clean up the dedicated persistent entry
+    env.storage().persistent().remove(&key);
+}
+
+/// Returns true if the oracle is still active at the current ledger.
+/// An oracle is inactive if it is not in the oracle set, or if a removal
+/// is scheduled and the effective ledger has already been reached.
 pub fn is_oracle_active(env: &Env, oracle_pubkey: &BytesN<32>) -> bool {
     let oracles: Map<BytesN<32>, bool> = env
         .storage()
@@ -38,14 +58,12 @@ pub fn is_oracle_active(env: &Env, oracle_pubkey: &BytesN<32>) -> bool {
         return false;
     }
 
-    // Check if a removal is scheduled and the grace period has passed
-    let pending: Map<BytesN<32>, u32> = env
+    let pending: Option<u32> = env
         .storage()
-        .instance()
-        .get(&InstanceKey::Quorum)
-        .unwrap_or_else(|| Map::new(env));
+        .persistent()
+        .get(&PersistentKey::PendingOracleRemoval(oracle_pubkey.clone()));
 
-    if let Some(effective_ledger) = pending.get(oracle_pubkey.clone()) {
+    if let Some(effective_ledger) = pending {
         return env.ledger().sequence() < effective_ledger;
     }
 

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -66,6 +66,10 @@ pub enum InstanceKey {
 #[derive(Clone)]
 pub enum PersistentKey {
     Votes(u64),
+    /// Pending oracle removal: value is the effective_ledger at which removal takes effect.
+    PendingOracleRemoval(BytesN<32>),
+    /// Pending oracle addition: reserved for scheduled oracle onboarding.
+    PendingOracleAdditions(BytesN<32>),
 }
 
 /// A single price data point submitted by an oracle for TWAP calculation

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -3,7 +3,7 @@
 extern crate std;
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, testutils::Address as _, Address, Bytes, BytesN, Env, Map,
+    contract, contractimpl, contracttype, testutils::{Address as _, Ledger as _}, Address, Bytes, BytesN, Env, Map,
     Vec,
 };
 
@@ -978,3 +978,81 @@ fn test_om_version_returns_contract_version() {
     let (_admin, _registry_id, _secret, _pubkey, client) = setup_single_oracle(&env);
     assert_eq!(client.version(), 1u32);
 }
+
+// --- Oracle Rotation Tests ---------------------------------------------------
+
+#[test]
+fn test_schedule_oracle_removal_stores_correctly() {
+    let env = Env::default();
+    let (_admin, _registry_id, _oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    // Oracle is active before any removal is scheduled
+    assert!(client.is_oracle_active(&oracle_pubkey));
+
+    // Schedule removal at ledger 10; current sequence is 0
+    client.schedule_oracle_removal(&oracle_pubkey, &10u32);
+
+    // Still active because effective_ledger has not been reached
+    assert!(client.is_oracle_active(&oracle_pubkey));
+}
+
+#[test]
+fn test_is_oracle_active_false_after_effective_ledger() {
+    let env = Env::default();
+    let (_admin, _registry_id, _oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    client.schedule_oracle_removal(&oracle_pubkey, &10u32);
+
+    // Advance past the effective ledger
+    env.ledger().with_mut(|li| { li.sequence_number = 10; });
+
+    assert!(!client.is_oracle_active(&oracle_pubkey));
+}
+
+#[test]
+fn test_execute_oracle_removal_succeeds_after_grace_period() {
+    let env = Env::default();
+    let (_admin, _registry_id, _oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    client.schedule_oracle_removal(&oracle_pubkey, &10u32);
+
+    env.ledger().with_mut(|li| { li.sequence_number = 10; });
+    client.execute_oracle_removal(&oracle_pubkey);
+
+    // Oracle must be gone from the active oracle set
+    assert!(!client.is_oracle(&oracle_pubkey));
+}
+
+#[test]
+fn test_execute_oracle_removal_fails_before_grace_period() {
+    let env = Env::default();
+    let (_admin, _registry_id, _oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    client.schedule_oracle_removal(&oracle_pubkey, &10u32);
+
+    // Sequence is still 0, grace period has not elapsed
+    let result = client.try_execute_oracle_removal(&oracle_pubkey);
+    assert!(result.is_err(), "premature execution must fail");
+}
+
+#[test]
+fn test_rotation_keys_do_not_collide_with_admin_or_quorum() {
+    let env = Env::default();
+    let (_admin, _registry_id, _oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+
+    let quorum_before = client.get_quorum();
+
+    client.schedule_oracle_removal(&oracle_pubkey, &10u32);
+
+    env.ledger().with_mut(|li| { li.sequence_number = 10; });
+    client.execute_oracle_removal(&oracle_pubkey);
+
+    // Quorum must be unchanged after rotation
+    assert_eq!(client.get_quorum(), quorum_before, "quorum collided with rotation storage");
+
+    // Admin functions must still work, proving Admin key is intact
+    let (_, extra_pubkey) = gen_keypair(&env);
+    client.add_oracle(&extra_pubkey);
+    assert!(client.is_oracle(&extra_pubkey), "admin key corrupted by rotation");
+}
+


### PR DESCRIPTION
- Add PendingOracleRemoval(BytesN<32>) and PendingOracleAdditions(BytesN<32>) to PersistentKey enum
- Rewrite rotation.rs to use dedicated persistent storage keys instead of reusing Quorum/Admin slots
- Add execute_oracle_removal to complete the rotation lifecycle
- Expose schedule_oracle_removal, execute_oracle_removal, is_oracle_active as contract methods
- Add 5 tests: schedule stores correctly, active false after effective ledger, execute after grace period, premature execution fails, keys do not collide with admin or quorum

closes #362 