### PR TITLE
Feat/prediction market

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -40,16 +40,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-contracts-
 
-      - name: Build prediction_market WASM for factory tests
-        run: |
-          cd packages/contracts
-          cargo build --release --target wasm32-unknown-unknown -p prediction-market
-
-      - name: Run Cargo Test
-        run: |
-          cd packages/contracts
-          cargo test
-
       - name: Install Stellar CLI
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,6 +65,20 @@ jobs:
           tar -xzf stellar-cli.tar.gz
           sudo mv stellar /usr/local/bin/
           stellar --version
+
+      - name: Build prediction_market WASM for factory tests
+        run: |
+          cd packages/contracts
+          rm -f target/wasm32-unknown-unknown/release/prediction_market*.wasm
+          rm -f target/wasm32v1-none/release/prediction_market*.wasm
+          cd prediction_market
+          stellar contract build
+          ls -la ../target/wasm32v1-none/release/prediction_market*.wasm
+
+      - name: Run Cargo Test
+        run: |
+          cd packages/contracts
+          cargo test
 
       - name: Build Contracts with Stellar CLI
         run: |

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -40,6 +40,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-contracts-
 
+      - name: Build prediction_market WASM for factory tests
+        run: |
+          cd packages/contracts
+          cargo build --release --target wasm32-unknown-unknown -p prediction-market
+
       - name: Run Cargo Test
         run: |
           cd packages/contracts

--- a/packages/contracts/.cargo/config.toml
+++ b/packages/contracts/.cargo/config.toml
@@ -3,3 +3,8 @@
 rustflags = [
     "-C", "target-feature=-bulk-memory,-mutable-globals,-reference-types,-sign-ext",
 ]
+
+[target.wasm32v1-none]
+rustflags = [
+    "-C", "target-feature=-bulk-memory,-mutable-globals,-reference-types,-sign-ext",
+]

--- a/packages/contracts/.cargo/config.toml
+++ b/packages/contracts/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Soroban-compatible WASM: disable features the on-chain VM does not support.
+[target.wasm32-unknown-unknown]
+rustflags = [
+    "-C", "target-feature=-bulk-memory,-mutable-globals,-reference-types,-sign-ext",
+]

--- a/packages/contracts/Cargo.toml
+++ b/packages/contracts/Cargo.toml
@@ -4,6 +4,8 @@ members = [
   "shared",
   "call_registry",
   "outcome_manager",
+  "prediction_market",
+  "prediction_market_factory",
   "contracts/hello-world",
 ]
 

--- a/packages/contracts/FACTORY_PATTERN.md
+++ b/packages/contracts/FACTORY_PATTERN.md
@@ -1,0 +1,141 @@
+# Factory Pattern: WASM Size, Deployment Cost, and Storage
+
+This document compares the monolithic `call_registry` design with the
+`prediction_market_factory` + per-market `prediction_market` pattern.
+
+## Architecture
+
+| Component | Role |
+|-----------|------|
+| `prediction_market_factory` | Deploys market instances, tracks `call_id → Address`, emits `MarketDeployed` |
+| `prediction_market` | One market per contract: escrow, stakes, resolution hooks |
+| `outcome_manager` (shared) | Single oracle quorum layer; resolves any factory-deployed market by `call_id` |
+
+### Outcome manager: shared vs per-market
+
+**Chosen: single shared `outcome_manager`.**
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Shared** (implemented) | One oracle set, one admin surface, oracle votes keyed by global `call_id` | All markets share pause/upgrade risk |
+| **Per-market** | Isolated oracle config per market | N deployments, N admin keys, fragmented liquidity signals |
+
+The shared instance accepts any market address via `submit_outcome(registry, …)` and
+validates against the configured factory with `set_factory` + `validate_market_registry`.
+
+## WASM size (release build)
+
+Measure after building:
+
+```bash
+cd packages/contracts
+cargo build --release --target wasm32-unknown-unknown -p call-registry -p prediction-market -p prediction-market-factory
+ls -la target/wasm32-unknown-unknown/release/*.wasm
+```
+
+Typical expectations (optimized with `opt-level = "z"`, LTO):
+
+| Contract | Approx. size | Notes |
+|----------|--------------|-------|
+| `call_registry` | ~80–120 KB | Governance, SEP-10, shares, indexes, pagination |
+| `prediction_market` | ~25–45 KB | Single market only; no global indexes |
+| `prediction_market_factory` | ~15–25 KB | Deploy + enumeration |
+
+The lightweight market WASM is uploaded **once**; each `deploy_market` reuses the same hash.
+
+## Deployment cost
+
+Soroban charges for:
+
+1. **WASM upload** — paid once per unique hash (factory + market template).
+2. **Contract deployment** — `deploy_v2` per market instance (CPU + rent for instance storage).
+3. **Per-stake storage** — grows in the **market** contract, not the factory.
+
+### Monolithic registry (N markets)
+
+- 1 contract deploy
+- All `Call(id)` entries in **one** contract's persistent storage
+- Hot-path storage contention on single instance (64 KB instance cap risk at scale)
+- Upgrade affects all markets atomically
+
+### Factory pattern (N markets)
+
+- 1 factory deploy + N market deploys
+- Higher **up-front** deploy cost (N × deploy_v2)
+- Storage **sharded** across N contracts — no cross-market blast radius
+- Per-market WASM upgrade possible (deploy new hash, factory `set_market_wasm_hash`)
+- Factory instance storage: `O(N)` address entries only (~32 B + overhead per market)
+
+### Rule of thumb
+
+| Scale | Prefer |
+|-------|--------|
+| &lt; 50 markets, single operator | Monolithic may be cheaper overall |
+| 50+ markets, public permissionless creation | Factory — isolation and TTL management win |
+| Regulated / upgradeable per product | Factory |
+
+## Storage implications
+
+### Monolithic `call_registry` per market
+
+Persistent keys per call (approximate):
+
+- `Call(id)` — full `Call` struct + nested `Map`s
+- `CallStakers`, `StakerCalls`, `UserStake`, `CreatorStats`, IPFS keys
+- Global `Config`, counters, governance state **shared**
+
+All markets compete for the same contract's storage budget and TTL extension calls.
+
+### Factory + `prediction_market`
+
+**Factory** (instance storage):
+
+- `MarketCounter`, `MarketList` (`Vec<Address>`), `Market(id) → Address`, `Config`
+
+**Each market** (instance storage only):
+
+- `Config`, `Call` (single), `UserStake(staker, position)` entries
+
+No `CallStakers` / `StakerCalls` / creator reputation / governance in the market template —
+indexers should read `MarketDeployed` events and per-market `stake_added` events.
+
+### Savings per market
+
+Removing from the per-market contract vs full registry:
+
+- No per-call persistent key prefix (`Call(id)` in persistent tier)
+- No global staker/creator indexes
+- No share-token deploy path (optional in registry)
+- No SEP-10 / governance / admin mutation surface
+
+Estimated **60–70% less per-market state** than a fully featured registry row.
+
+## Events
+
+Factory emits:
+
+```
+("prediction_market_factory", "MarketDeployed")
+  → (call_id, market_address, creator, stake_token, end_ts)
+```
+
+Indexers should treat `market_address` as the escrow contract and `call_id` as the global
+oracle message key (unchanged for `outcome_manager`).
+
+## Operational checklist
+
+1. Upload `prediction_market` WASM to network; record `BytesN<32>` hash.
+2. Deploy `prediction_market_factory`; `initialize(admin, outcome_manager, wasm_hash, min_stake)`.
+3. Deploy **one** `outcome_manager`; `set_factory(factory_address)`.
+4. `whitelist_token` on factory for each SAC stake token.
+5. Users call `deploy_market(creator, MarketInitArgs)` — not direct market deploy.
+
+## Measuring live costs
+
+Use Soroban transaction simulation (`stellar contract invoke --simulate`) for:
+
+- `deploy_market` CPU/memory budget
+- First `stake_on_call` on a fresh market
+- `submit_outcome` + `claim_payout` cross-contract path (3 contracts)
+
+Compare against the same flow on monolithic `call_registry` for your target `N`.

--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -1,5 +1,6 @@
 #![allow(deprecated)]
 #![allow(unused)]
+#![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::symbol_short;
 use soroban_sdk::{Address, Bytes, BytesN, Env, Symbol};

--- a/packages/contracts/call_registry/src/fuzz_tests.rs
+++ b/packages/contracts/call_registry/src/fuzz_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 #![allow(deprecated)]
 #![allow(unused)]
+#![allow(clippy::redundant_field_names)]
 
 use soroban_sdk::{
     contract, contractimpl,

--- a/packages/contracts/call_registry/src/governance.rs
+++ b/packages/contracts/call_registry/src/governance.rs
@@ -4,7 +4,7 @@
 //! Voting power = user's historical stake volume (snapshot at proposal creation).
 //! Proposals pass when votes_for > governance_quorum_bps of total platform stake.
 
-use soroban_sdk::{contracttype, Address, Env, Map, Symbol, Vec};
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -42,15 +42,21 @@ impl GovernanceConfig {
     pub fn default() -> Self {
         GovernanceConfig {
             proposal_threshold: 1000_0000000, // 1000 XLM
-            governance_quorum_bps: 100,        // 1%
-            voting_period_ledgers: 17280,      // ~1 day at 5s/ledger
+            governance_quorum_bps: 100,       // 1%
+            voting_period_ledgers: 17280,     // ~1 day at 5s/ledger
         }
     }
 }
 
 fn next_proposal_id(env: &Env) -> u64 {
-    let id: u64 = env.storage().instance().get(&GovKey::ProposalCounter).unwrap_or(0);
-    env.storage().instance().set(&GovKey::ProposalCounter, &(id + 1));
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&GovKey::ProposalCounter)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&GovKey::ProposalCounter, &(id + 1));
     id + 1
 }
 
@@ -88,7 +94,9 @@ pub fn propose_change(
         votes_against: 0,
         executed: false,
     };
-    env.storage().instance().set(&GovKey::Proposal(id), &proposal);
+    env.storage()
+        .instance()
+        .set(&GovKey::Proposal(id), &proposal);
     env.events().publish(
         ("governance", "ProposalCreated"),
         (id, proposer, parameter, voting_end_ledger),
@@ -117,7 +125,9 @@ pub fn vote(env: &Env, voter: Address, proposal_id: u64, support: bool, voter_st
     } else {
         proposal.votes_against += voter_stake_volume;
     }
-    env.storage().instance().set(&GovKey::Proposal(proposal_id), &proposal);
+    env.storage()
+        .instance()
+        .set(&GovKey::Proposal(proposal_id), &proposal);
     env.storage().instance().set(&voted_key, &true);
     env.events().publish(
         ("governance", "VoteCast"),
@@ -156,13 +166,16 @@ pub fn execute_proposal(
 
     if proposal.votes_for > quorum {
         proposal.executed = true;
-        env.storage().instance().set(&GovKey::Proposal(proposal_id), &proposal);
+        env.storage()
+            .instance()
+            .set(&GovKey::Proposal(proposal_id), &proposal);
         env.events().publish(
             ("governance", "ProposalExecuted"),
             (proposal_id, proposal.parameter.clone()),
         );
     } else {
-        env.events().publish(("governance", "ProposalRejected"), (proposal_id,));
+        env.events()
+            .publish(("governance", "ProposalRejected"), (proposal_id,));
         panic!("quorum not met");
     }
     proposal
@@ -184,7 +197,11 @@ pub fn get_active_proposals(env: &Env) -> Vec<GovernanceProposal> {
     let current = env.ledger().sequence();
     let mut result = Vec::new(env);
     for id in 1..=count {
-        if let Some(p) = env.storage().instance().get::<_, GovernanceProposal>(&GovKey::Proposal(id)) {
+        if let Some(p) = env
+            .storage()
+            .instance()
+            .get::<_, GovernanceProposal>(&GovKey::Proposal(id))
+        {
             if !p.executed && current <= p.voting_end_ledger {
                 result.push_back(p);
             }
@@ -195,5 +212,7 @@ pub fn get_active_proposals(env: &Env) -> Vec<GovernanceProposal> {
 
 pub fn set_governance_config(env: &Env, admin: &Address, cfg: GovernanceConfig) {
     admin.require_auth();
-    env.storage().instance().set(&GovKey::GovernanceConfig, &cfg);
+    env.storage()
+        .instance()
+        .set(&GovKey::GovernanceConfig, &cfg);
 }

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -189,8 +189,7 @@ impl CallRegistry {
         Ok(())
     }
 
-    /// Test-only: register the XLM SAC address so is_native_xlm works in tests.
-    #[cfg(test)]
+    /// Register the XLM SAC address so `is_native_xlm` works in tests.
     pub fn set_xlm_sac_address(env: Env, xlm_sac: Address) {
         env.storage()
             .instance()
@@ -945,7 +944,14 @@ impl CallRegistry {
         voting_end_ledger: u32,
         proposer_stake_volume: i128,
     ) -> u64 {
-        governance::propose_change(&env, proposer, parameter, new_value_bytes, voting_end_ledger, proposer_stake_volume)
+        governance::propose_change(
+            &env,
+            proposer,
+            parameter,
+            new_value_bytes,
+            voting_end_ledger,
+            proposer_stake_volume,
+        )
     }
 
     /// Cast a vote on a governance proposal. Voting power = voter's stake volume.
@@ -975,7 +981,10 @@ impl CallRegistry {
     }
 
     /// Update governance configuration (admin only).
-    pub fn set_governance_config(env: Env, cfg: governance::GovernanceConfig) -> Result<(), CallRegistryError> {
+    pub fn set_governance_config(
+        env: Env,
+        cfg: governance::GovernanceConfig,
+    ) -> Result<(), CallRegistryError> {
         let config = get_config(&env).ok_or(CallRegistryError::NotInitialized)?;
         governance::set_governance_config(&env, &config.admin, cfg);
         Ok(())

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -12,7 +12,8 @@ const INSTANCE_BUMP_AMOUNT: u32 = 120_960; // ~7 days
 #[contracttype]
 pub enum DataKey {
     Config,
-    CallCounter,    GlobalStats,
+    CallCounter,
+    GlobalStats,
     GlobalStakerSeen(Address),
     Call(u64),
     CallStakers(u64),
@@ -90,6 +91,7 @@ pub fn get_call(env: &Env, call_id: u64) -> Option<Call> {
 }
 
 /// Check whether a call exists in persistent storage
+#[allow(dead_code)]
 pub fn call_exists(env: &Env, call_id: u64) -> bool {
     env.storage().persistent().has(&DataKey::Call(call_id))
 }
@@ -301,12 +303,14 @@ pub fn get_user_stake(env: &Env, call_id: u64, staker: &Address, position: u32) 
 }
 
 /// Get up staker count for a call
+#[allow(dead_code)]
 pub fn get_up_staker_count(env: &Env, call_id: u64) -> u32 {
     let key = DataKey::UpStakerCount(call_id);
     env.storage().persistent().get(&key).unwrap_or(0)
 }
 
 /// Set up staker count for a call
+#[allow(dead_code)]
 pub fn set_up_staker_count(env: &Env, call_id: u64, count: u32) {
     let key = DataKey::UpStakerCount(call_id);
     env.storage().persistent().set(&key, &count);
@@ -318,12 +322,14 @@ pub fn set_up_staker_count(env: &Env, call_id: u64, count: u32) {
 }
 
 /// Get down staker count for a call
+#[allow(dead_code)]
 pub fn get_down_staker_count(env: &Env, call_id: u64) -> u32 {
     let key = DataKey::DownStakerCount(call_id);
     env.storage().persistent().get(&key).unwrap_or(0)
 }
 
 /// Set down staker count for a call
+#[allow(dead_code)]
 pub fn set_down_staker_count(env: &Env, call_id: u64, count: u32) {
     let key = DataKey::DownStakerCount(call_id);
     env.storage().persistent().set(&key, &count);

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -1,6 +1,8 @@
 #![cfg(test)]
 #![allow(deprecated)]
 #![allow(unused)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::len_zero)]
 
 extern crate std;
 
@@ -1469,10 +1471,7 @@ mod call_registry {
         env.ledger().set_timestamp(606801);
 
         let result = client.try_claim_expired_refund(&staker, &call.id);
-        assert!(
-            result.is_err(),
-            "should fail when call is settled"
-        );
+        assert!(result.is_err(), "should fail when call is settled");
     }
 
     #[test]
@@ -1492,10 +1491,7 @@ mod call_registry {
 
         // Second claim should fail
         let result = client.try_claim_expired_refund(&staker, &call.id);
-        assert!(
-            result.is_err(),
-            "second claim should fail"
-        );
+        assert!(result.is_err(), "second claim should fail");
     }
 
     // ── 3-outcome market tests ───────────────────────────────────────────────
@@ -2380,7 +2376,6 @@ mod call_registry {
         assert!(usage.cpu <= GET_CALL_STAKERS_BUDGET_CPU);
         assert!(usage.mem <= GET_CALL_STAKERS_BUDGET_MEM);
     }
-
 }
 
 // ── Native XLM staking tests ──────────────────────────────────────────────────
@@ -2709,7 +2704,6 @@ mod native_xlm {
         assert_eq!(up_stake, half_xlm);
         assert_eq!(down_stake, quarter_xlm);
     }
-
 }
 
 // ── SEP-10 tests ─────────────────────────────────────────────────────────────

--- a/packages/contracts/outcome_manager/src/errors.rs
+++ b/packages/contracts/outcome_manager/src/errors.rs
@@ -56,4 +56,8 @@ pub enum OutcomeError {
     RegistryNotSet = 25,
     /// `dispute_outcome` was called after the dispute window has already closed.
     DisputeWindowExpired = 26,
+    /// The factory address has not been set in instance storage.
+    FactoryNotSet = 27,
+    /// The market address does not match the factory's registry for this call_id.
+    InvalidMarket = 28,
 }

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{symbol_short, Env, Vec};
+#![allow(deprecated)]
+
+use soroban_sdk::{symbol_short, Env};
 
 /// Emitted when a new oracle outcome report is accepted (before quorum)
 pub fn emit_outcome_submitted(
@@ -65,12 +67,14 @@ pub fn emit_outcome_disputed(env: &Env, call_id: u64, new_outcome: u32, new_pric
 ///
 /// While paused, `submit_outcome` and `claim_payout` revert with
 /// [`OutcomeError::ContractPaused`].
+#[allow(dead_code)]
 pub fn emit_contract_paused(env: &Env) {
     env.events()
         .publish((symbol_short!("contract"), symbol_short!("paused")), ());
 }
 
 /// Emitted when the admin unpauses the contract, resuming normal operations.
+#[allow(dead_code)]
 pub fn emit_contract_unpaused(env: &Env) {
     env.events()
         .publish((symbol_short!("contract"), symbol_short!("unpaused")), ());

--- a/packages/contracts/outcome_manager/src/fuzz_tests.rs
+++ b/packages/contracts/outcome_manager/src/fuzz_tests.rs
@@ -1,10 +1,21 @@
 #![cfg(test)]
 
-fn compute_payout(staker_winning_stake: i128, total_winning_stake: i128, total_losing_stake: i128, fee_bps: u32) -> Option<i128> {
-    if total_winning_stake <= 0 { return None; }
-    let total_fee = total_losing_stake.checked_mul(fee_bps as i128)?.checked_div(10000)?;
+fn compute_payout(
+    staker_winning_stake: i128,
+    total_winning_stake: i128,
+    total_losing_stake: i128,
+    fee_bps: u32,
+) -> Option<i128> {
+    if total_winning_stake <= 0 {
+        return None;
+    }
+    let total_fee = total_losing_stake
+        .checked_mul(fee_bps as i128)?
+        .checked_div(10000)?;
     let net_losing = total_losing_stake.checked_sub(total_fee)?;
-    let prize = staker_winning_stake.checked_mul(net_losing)?.checked_div(total_winning_stake)?;
+    let prize = staker_winning_stake
+        .checked_mul(net_losing)?
+        .checked_div(total_winning_stake)?;
     staker_winning_stake.checked_add(prize)
 }
 
@@ -33,7 +44,10 @@ fn fuzz_sum_of_payouts_equals_pool_minus_fee() {
     let fee_bps: u32 = 200;
     let fee = total_losing * fee_bps as i128 / 10000;
     let expected = total_winning + total_losing - fee;
-    let sum: i128 = stakes.iter().filter_map(|&s| compute_payout(s, total_winning, total_losing, fee_bps)).sum();
+    let sum: i128 = stakes
+        .iter()
+        .filter_map(|&s| compute_payout(s, total_winning, total_losing, fee_bps))
+        .sum();
     assert!((sum - expected).abs() <= stakes.len() as i128);
 }
 
@@ -81,6 +95,9 @@ fn fuzz_concurrent_claims() {
     let fee_bps = 300u32;
     let fee = tl * fee_bps as i128 / 10000;
     let expected = tw + tl - fee;
-    let sum: i128 = stakes.iter().filter_map(|&s| compute_payout(s, tw, tl, fee_bps)).sum();
+    let sum: i128 = stakes
+        .iter()
+        .filter_map(|&s| compute_payout(s, tw, tl, fee_bps))
+        .sum();
     assert!((sum - expected).abs() <= stakes.len() as i128);
 }

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(deprecated)]
 
 mod auth;
 mod call_types;
@@ -12,8 +13,8 @@ mod verification;
 
 pub use storage::SignedOutcome;
 
-use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
 use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
 
 use auth::require_admin;
 use backit_shared::{is_valid_fee_bps, is_valid_outcome};
@@ -25,8 +26,8 @@ use events::{
     emit_outcome_submitted, emit_payout_claimed, emit_price_observation_submitted,
 };
 use storage::{
-    set_dispute_window, set_max_submission_delay, InstanceKey, OracleVote, Outcome,
-    PersistentKey, PriceObservation, TempKey,
+    set_dispute_window, set_max_submission_delay, InstanceKey, OracleVote, Outcome, PersistentKey,
+    PriceObservation, TempKey,
 };
 use verification::{build_message, verify_signature};
 
@@ -75,6 +76,7 @@ fn registry_mark_settled(env: &Env, registry: &Address, call_id: u64) {
 }
 
 /// Call `get_call(call_id)` on the CallRegistry and return the decoded Call.
+#[allow(dead_code)]
 fn registry_get_call(env: &Env, registry: &Address, call_id: u64) -> Call {
     let args = (call_id,).into_val(env);
     let result: Result<Call, CallRegistryError> =
@@ -86,6 +88,7 @@ fn registry_get_call(env: &Env, registry: &Address, call_id: u64) -> Call {
 }
 
 /// Call `get_staker_stake(call_id, staker, position)` on the CallRegistry.
+#[allow(dead_code)]
 fn registry_get_staker_stake(
     env: &Env,
     registry: &Address,
@@ -96,10 +99,7 @@ fn registry_get_staker_stake(
     let args = (call_id, staker.clone(), position).into_val(env);
     let result: Result<i128, CallRegistryError> =
         env.invoke_contract(registry, &Symbol::new(env, "get_staker_stake"), args);
-    match result {
-        Ok(stake) => stake,
-        Err(_) => 0,
-    }
+    result.unwrap_or_default()
 }
 
 /// Look up the deployed market address for `call_id` via the configured factory.
@@ -222,7 +222,6 @@ fn compute_payout_parts(
     (staker_fee_share, payout)
 }
 
-
 // ─── Contract ─────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -245,10 +244,10 @@ impl OutcomeManager {
 
         admin.require_auth();
 
-        if quorum == 0 || quorum > oracles.len() as u32 {
+        if quorum == 0 || quorum > oracles.len() {
             soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidQuorum);
         }
-        if oracles.len() as u32 > MAX_ORACLES {
+        if oracles.len() > MAX_ORACLES {
             soroban_sdk::panic_with_error!(&env, OutcomeError::MaxOraclesReached);
         }
         if !is_valid_fee_bps(fee_bps) {
@@ -261,14 +260,22 @@ impl OutcomeManager {
         }
 
         env.storage().instance().set(&InstanceKey::Admin, &admin);
-        env.storage().instance().set(&InstanceKey::Oracles, &oracle_map);
-        env.storage().instance().set(&InstanceKey::OracleList, &oracles);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Oracles, &oracle_map);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::OracleList, &oracles);
         env.storage().instance().set(&InstanceKey::Quorum, &quorum);
-        env.storage().instance().set(&InstanceKey::FeeCollector, &fee_collector);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::FeeCollector, &fee_collector);
         env.storage().instance().set(&InstanceKey::FeeBps, &fee_bps);
         set_dispute_window(&env, dispute_window_secs);
         set_max_submission_delay(&env, 86400);
-        env.storage().instance().set(&InstanceKey::Version, &CONTRACT_VERSION);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Version, &CONTRACT_VERSION);
     }
 
     pub fn add_oracle(env: Env, oracle: BytesN<32>) {
@@ -283,13 +290,17 @@ impl OutcomeManager {
         if oracles.contains_key(oracle.clone()) {
             return;
         }
-        if oracle_list.len() as u32 >= MAX_ORACLES {
+        if oracle_list.len() >= MAX_ORACLES {
             soroban_sdk::panic_with_error!(&env, OutcomeError::MaxOraclesReached);
         }
         oracles.set(oracle.clone(), true);
         oracle_list.push_back(oracle);
-        env.storage().instance().set(&InstanceKey::Oracles, &oracles);
-        env.storage().instance().set(&InstanceKey::OracleList, &oracle_list);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Oracles, &oracles);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::OracleList, &oracle_list);
     }
 
     pub fn remove_oracle(env: Env, oracle: BytesN<32>) {
@@ -308,14 +319,18 @@ impl OutcomeManager {
                 filtered.push_back(existing);
             }
         }
-        env.storage().instance().set(&InstanceKey::Oracles, &oracles);
-        env.storage().instance().set(&InstanceKey::OracleList, &filtered);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Oracles, &oracles);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::OracleList, &filtered);
     }
 
     pub fn set_quorum(env: Env, quorum: u32) {
         require_admin(&env);
         let oracles = get_oracles(&env);
-        if quorum == 0 || quorum > oracles.len() as u32 {
+        if quorum == 0 || quorum > oracles.len() {
             soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidQuorum);
         }
         env.storage().instance().set(&InstanceKey::Quorum, &quorum);
@@ -323,7 +338,9 @@ impl OutcomeManager {
 
     pub fn set_admin(env: Env, new_admin: Address) {
         require_admin(&env);
-        env.storage().instance().set(&InstanceKey::Admin, &new_admin);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Admin, &new_admin);
     }
 
     pub fn set_max_submission_delay(env: Env, new_delay: u64) {
@@ -340,12 +357,17 @@ impl OutcomeManager {
     /// Default: 500 (5%). Submissions deviating more than this are rejected.
     pub fn set_sdex_threshold(env: Env, new_threshold: u32) {
         require_admin(&env);
-        env.storage().instance().set(&InstanceKey::SdexThresholdBps, &new_threshold);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::SdexThresholdBps, &new_threshold);
         emit_admin_params_changed(&env, new_threshold as u64);
     }
 
     pub fn get_sdex_threshold(env: Env) -> u32 {
-        env.storage().instance().get(&InstanceKey::SdexThresholdBps).unwrap_or(500)
+        env.storage()
+            .instance()
+            .get(&InstanceKey::SdexThresholdBps)
+            .unwrap_or(500)
     }
 
     /// Query the SDEX midpoint price for a pair from the on-chain orderbook.
@@ -353,7 +375,11 @@ impl OutcomeManager {
     /// NOTE: In Soroban, direct SDEX orderbook queries require a host function
     /// or a helper oracle contract. This returns None (graceful degradation)
     /// when the query cannot be satisfied, as per the acceptance criteria.
-    pub fn query_sdex_midpoint(_env: Env, _selling_asset: Address, _buying_asset: Address) -> Option<i128> {
+    pub fn query_sdex_midpoint(
+        _env: Env,
+        _selling_asset: Address,
+        _buying_asset: Address,
+    ) -> Option<i128> {
         // Soroban does not yet expose a native host function for SDEX orderbook
         // queries within a single transaction budget. When the Stellar protocol
         // exposes this capability, replace the body with the actual host call.
@@ -435,7 +461,6 @@ impl OutcomeManager {
         );
     }
 
-
     pub fn submit_outcome(env: Env, registry: Address, signed: SignedOutcome, call_end_ts: u64) {
         if is_paused(&env) {
             soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
@@ -448,7 +473,11 @@ impl OutcomeManager {
             soroban_sdk::panic_with_error!(&env, OutcomeError::UnauthorizedOracle);
         }
 
-        if env.storage().instance().has(&InstanceKey::FinalOutcome(signed.call_id)) {
+        if env
+            .storage()
+            .instance()
+            .has(&InstanceKey::FinalOutcome(signed.call_id))
+        {
             soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadySettled);
         }
 
@@ -483,16 +512,23 @@ impl OutcomeManager {
         let sdex_midpoint: Option<i128> = None; // host function not yet available
         if let Some(sdex_price) = sdex_midpoint {
             if sdex_price > 0 {
-                let threshold_bps: u32 = env.storage().instance()
-                    .get(&InstanceKey::SdexThresholdBps).unwrap_or(500);
+                let threshold_bps: u32 = env
+                    .storage()
+                    .instance()
+                    .get(&InstanceKey::SdexThresholdBps)
+                    .unwrap_or(500);
                 let diff = (signed.price - sdex_price).abs();
-                let deviation_bps = diff.checked_mul(10000).unwrap_or(i128::MAX)
-                    / sdex_price;
+                let deviation_bps = diff.checked_mul(10000).unwrap_or(i128::MAX) / sdex_price;
                 if deviation_bps > threshold_bps as i128 {
                     // Emit warning event then reject
                     env.events().publish(
                         ("outcome_manager", "PriceDeviationWarning"),
-                        (signed.call_id, signed.price, sdex_price, deviation_bps as u32),
+                        (
+                            signed.call_id,
+                            signed.price,
+                            sdex_price,
+                            deviation_bps as u32,
+                        ),
                     );
                     soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidOutcome);
                 }
@@ -501,7 +537,9 @@ impl OutcomeManager {
 
         let outcome_hash: BytesN<32> = env.crypto().sha256(&message).into();
 
-        env.storage().temporary().set(&submission_key, &outcome_hash);
+        env.storage()
+            .temporary()
+            .set(&submission_key, &outcome_hash);
 
         let vote_key = PersistentKey::Votes(signed.call_id);
         let mut votes_for_call: Vec<OracleVote> = env
@@ -544,10 +582,15 @@ impl OutcomeManager {
             .instance()
             .set(&InstanceKey::FinalOutcome(outcome.call_id), &outcome);
 
-        registry_resolve_call(env, registry, outcome.call_id, outcome.outcome, outcome.price);
+        registry_resolve_call(
+            env,
+            registry,
+            outcome.call_id,
+            outcome.outcome,
+            outcome.price,
+        );
         emit_outcome_finalized(env, outcome.call_id, outcome.outcome, outcome.price);
     }
-
 
     /// Claim a pro-rata payout for a winning staker.
     ///
@@ -608,9 +651,10 @@ impl OutcomeManager {
         id_input.append(&staker.clone().to_xdr(&env));
         let balance_id: BytesN<32> = env.crypto().sha256(&id_input).into();
 
-        env.storage()
-            .instance()
-            .set(&InstanceKey::ClaimableBalanceId(call_id, staker.clone()), &balance_id);
+        env.storage().instance().set(
+            &InstanceKey::ClaimableBalanceId(call_id, staker.clone()),
+            &balance_id,
+        );
 
         if staker_fee_share > 0 {
             registry_release_escrow(&env, &registry, call_id, &fee_collector, staker_fee_share);
@@ -685,9 +729,10 @@ impl OutcomeManager {
             id_input.append(&Bytes::from_slice(&env, &(i as u64).to_be_bytes()));
             let balance_id: BytesN<32> = env.crypto().sha256(&id_input).into();
 
-            env.storage()
-                .instance()
-                .set(&InstanceKey::ClaimableBalanceId(call_id, staker.clone()), &balance_id);
+            env.storage().instance().set(
+                &InstanceKey::ClaimableBalanceId(call_id, staker.clone()),
+                &balance_id,
+            );
 
             // Mark claimed BEFORE external calls (reentrancy guard)
             env.storage().instance().set(&claimed_key, &true);
@@ -702,11 +747,16 @@ impl OutcomeManager {
         }
 
         if aggregated_fee_share > 0 {
-            registry_release_escrow(&env, &registry, call_id, &fee_collector, aggregated_fee_share);
+            registry_release_escrow(
+                &env,
+                &registry,
+                call_id,
+                &fee_collector,
+                aggregated_fee_share,
+            );
             emit_fee_collected(&env, call_id, aggregated_fee_share, &fee_collector);
         }
     }
-
 
     pub fn batch_claim_payouts(
         env: Env,
@@ -771,14 +821,24 @@ impl OutcomeManager {
         }
 
         if aggregated_fee_share > 0 {
-            registry_release_escrow(&env, &registry, call_id, &fee_collector, aggregated_fee_share);
+            registry_release_escrow(
+                &env,
+                &registry,
+                call_id,
+                &fee_collector,
+                aggregated_fee_share,
+            );
             emit_fee_collected(&env, call_id, aggregated_fee_share, &fee_collector);
         }
     }
 
     pub fn mark_settled(env: Env, registry: Address, call_id: u64) {
         require_admin(&env);
-        if !env.storage().instance().has(&InstanceKey::FinalOutcome(call_id)) {
+        if !env
+            .storage()
+            .instance()
+            .has(&InstanceKey::FinalOutcome(call_id))
+        {
             soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotFinalized);
         }
         registry_mark_settled(&env, &registry, call_id);
@@ -812,7 +872,13 @@ impl OutcomeManager {
             .instance()
             .set(&InstanceKey::FinalOutcome(call_id), &pending);
         let registry = get_registry(&env);
-        registry_resolve_call(&env, &registry, pending.call_id, pending.outcome, pending.price);
+        registry_resolve_call(
+            &env,
+            &registry,
+            pending.call_id,
+            pending.outcome,
+            pending.price,
+        );
         emit_outcome_finalized(&env, call_id, pending.outcome, pending.price);
     }
 
@@ -855,14 +921,20 @@ impl OutcomeManager {
     }
 
     pub fn get_outcome(env: Env, call_id: u64) -> Outcome {
-        match env.storage().instance().get(&InstanceKey::FinalOutcome(call_id)) {
+        match env
+            .storage()
+            .instance()
+            .get(&InstanceKey::FinalOutcome(call_id))
+        {
             Some(outcome) => outcome,
             None => soroban_sdk::panic_with_error!(&env, OutcomeError::CallNotSettled),
         }
     }
 
     pub fn has_claimed(env: Env, call_id: u64, staker: Address) -> bool {
-        env.storage().instance().has(&InstanceKey::Claimed(call_id, staker))
+        env.storage()
+            .instance()
+            .has(&InstanceKey::Claimed(call_id, staker))
     }
 
     /// Return the stored claimable balance ID for a staker, if one exists.
@@ -889,7 +961,7 @@ impl OutcomeManager {
     }
 
     pub fn get_oracle_count(env: Env) -> u32 {
-        Self::get_oracles(env).len() as u32
+        Self::get_oracles(env).len()
     }
 
     pub fn get_votes(env: Env, call_id: u64) -> Vec<OracleVote> {
@@ -900,7 +972,7 @@ impl OutcomeManager {
     }
 
     pub fn get_vote_count(env: Env, call_id: u64) -> u32 {
-        Self::get_votes(env, call_id).len() as u32
+        Self::get_votes(env, call_id).len()
     }
 
     pub fn version(env: Env) -> u32 {
@@ -925,7 +997,9 @@ impl OutcomeManager {
         let new_version = old_version + 1;
 
         env.deployer().update_current_contract_wasm(new_wasm_hash);
-        env.storage().instance().set(&InstanceKey::Version, &new_version);
+        env.storage()
+            .instance()
+            .set(&InstanceKey::Version, &new_version);
         emit_contract_upgraded(&env, old_version, new_version, &admin);
     }
 
@@ -944,7 +1018,10 @@ impl OutcomeManager {
         let mut raw = Bytes::from_slice(&env, b"twap_obs:");
         raw.append(&Bytes::from_slice(&env, &call_id.to_be_bytes()));
         raw.append(&Bytes::from_slice(&env, &observation.price.to_be_bytes()));
-        raw.append(&Bytes::from_slice(&env, &observation.timestamp.to_be_bytes()));
+        raw.append(&Bytes::from_slice(
+            &env,
+            &observation.timestamp.to_be_bytes(),
+        ));
         verify_signature(&env, &oracle_pubkey, &signature, &raw);
 
         let key = TempKey::PriceObservations(call_id);

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -8,6 +8,8 @@ mod storage;
 mod test;
 mod verification;
 
+pub use storage::SignedOutcome;
+
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
 use soroban_sdk::xdr::ToXdr;
 
@@ -22,7 +24,7 @@ use events::{
 };
 use storage::{
     set_dispute_window, set_max_submission_delay, InstanceKey, OracleVote, Outcome,
-    PersistentKey, PriceObservation, SignedOutcome, TempKey,
+    PersistentKey, PriceObservation, TempKey,
 };
 use verification::{build_message, verify_signature};
 
@@ -39,7 +41,11 @@ fn registry_resolve_call(
     end_price: i128,
 ) {
     let args = (call_id, outcome, end_price).into_val(env);
-    env.invoke_contract::<()>(registry, &Symbol::new(env, "resolve_call"), args);
+    let result: Result<Call, CallRegistryError> =
+        env.invoke_contract(registry, &Symbol::new(env, "resolve_call"), args);
+    if result.is_err() {
+        soroban_sdk::panic_with_error!(env, OutcomeError::CallNotSettled);
+    }
 }
 
 fn registry_release_escrow(
@@ -50,12 +56,20 @@ fn registry_release_escrow(
     amount: i128,
 ) {
     let args = (call_id, to.clone(), amount).into_val(env);
-    env.invoke_contract::<()>(registry, &Symbol::new(env, "release_escrow"), args);
+    let result: Result<(), CallRegistryError> =
+        env.invoke_contract(registry, &Symbol::new(env, "release_escrow"), args);
+    if result.is_err() {
+        soroban_sdk::panic_with_error!(env, OutcomeError::CallNotSettled);
+    }
 }
 
 fn registry_mark_settled(env: &Env, registry: &Address, call_id: u64) {
     let args = (call_id,).into_val(env);
-    env.invoke_contract::<()>(registry, &Symbol::new(env, "mark_settled"), args);
+    let result: Result<(), CallRegistryError> =
+        env.invoke_contract(registry, &Symbol::new(env, "mark_settled"), args);
+    if result.is_err() {
+        soroban_sdk::panic_with_error!(env, OutcomeError::CallNotSettled);
+    }
 }
 
 /// Call `get_call(call_id)` on the CallRegistry and return the decoded Call.
@@ -83,6 +97,27 @@ fn registry_get_staker_stake(
     match result {
         Ok(stake) => stake,
         Err(_) => 0,
+    }
+}
+
+/// Look up the deployed market address for `call_id` via the configured factory.
+fn factory_get_market(env: &Env, factory: &Address, call_id: u64) -> Address {
+    let args = (call_id,).into_val(env);
+    let result: Result<Address, CallRegistryError> =
+        env.invoke_contract(factory, &Symbol::new(env, "get_market"), args);
+    match result {
+        Ok(addr) => addr,
+        Err(_) => soroban_sdk::panic_with_error!(env, OutcomeError::InvalidMarket),
+    }
+}
+
+/// When a factory is configured, ensure `registry` matches the factory's market for `call_id`.
+fn validate_market_registry(env: &Env, registry: &Address, call_id: u64) {
+    if let Some(factory) = storage::get_factory_opt(env) {
+        let expected = factory_get_market(env, &factory, call_id);
+        if expected != *registry {
+            soroban_sdk::panic_with_error!(env, OutcomeError::InvalidMarket);
+        }
     }
 }
 
@@ -313,11 +348,73 @@ impl OutcomeManager {
         is_paused(&env)
     }
 
+    /// Store the default registry / market address (admin only).
+    ///
+    /// Used by `finalize_outcome` when the dispute-window path is active.
+    pub fn set_registry(env: Env, registry: Address) {
+        require_admin(&env);
+        storage::set_registry(&env, registry);
+    }
+
+    /// Store the prediction market factory address (admin only).
+    ///
+    /// **Design decision:** a single shared `outcome_manager` instance serves all
+    /// factory-deployed markets. Oracle quorum state is keyed by global `call_id`,
+    /// while escrow lives in per-market contract instances. Per-market outcome
+    /// managers would isolate oracle config but multiply deployment and admin cost.
+    pub fn set_factory(env: Env, factory: Address) {
+        require_admin(&env);
+        storage::set_factory(&env, factory);
+    }
+
+    /// Return the configured factory address, if any.
+    pub fn get_factory(env: Env) -> Option<Address> {
+        storage::get_factory_opt(&env)
+    }
+
+    /// Resolve a market contract address from the configured factory.
+    pub fn resolve_market_address(env: Env, call_id: u64) -> Address {
+        let factory = match storage::get_factory_opt(&env) {
+            Some(factory) => factory,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::FactoryNotSet),
+        };
+        factory_get_market(&env, &factory, call_id)
+    }
+
+    /// Submit an oracle outcome, resolving the market address from the factory.
+    pub fn submit_outcome_for_market(env: Env, signed: SignedOutcome, call_end_ts: u64) {
+        let registry = Self::resolve_market_address(env.clone(), signed.call_id);
+        Self::submit_outcome(env, registry, signed, call_end_ts);
+    }
+
+    /// Claim payout, resolving the market address from the factory.
+    pub fn claim_payout_for_market(
+        env: Env,
+        call_id: u64,
+        staker: Address,
+        staker_winning_stake: i128,
+        total_winning_stake: i128,
+        total_losing_stake: i128,
+    ) {
+        let registry = Self::resolve_market_address(env.clone(), call_id);
+        Self::claim_payout(
+            env,
+            registry,
+            call_id,
+            staker,
+            staker_winning_stake,
+            total_winning_stake,
+            total_losing_stake,
+        );
+    }
+
 
     pub fn submit_outcome(env: Env, registry: Address, signed: SignedOutcome, call_end_ts: u64) {
         if is_paused(&env) {
             soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
         }
+
+        validate_market_registry(&env, &registry, signed.call_id);
 
         let oracles = get_oracles(&env);
         if !oracles.contains_key(signed.oracle_pubkey.clone()) {

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -92,6 +92,7 @@ pub fn set_registry(env: &Env, registry: Address) {
         .set(&InstanceKey::Registry, &registry);
 }
 
+#[allow(dead_code)]
 pub fn get_registry_opt(env: &Env) -> Option<Address> {
     env.storage().instance().get(&InstanceKey::Registry)
 }
@@ -107,6 +108,7 @@ pub fn get_factory_opt(env: &Env) -> Option<Address> {
 }
 
 /// Read the stored CallRegistry address; panics if not set.
+#[allow(dead_code)]
 pub fn get_registry(env: &Env) -> Address {
     env.storage()
         .instance()

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -48,8 +48,10 @@ pub enum InstanceKey {
     Claimed(u64, Address),
     FeeCollector,
     FeeBps,
-    /// Stored CallRegistry address; set via set_registry() to avoid caller-supplied forgery
+    /// Stored CallRegistry / market address; set via `set_registry`.
     Registry,
+    /// Factory that deploys per-market instances; set via `set_factory`.
+    Factory,
     DisputeWindow,
     PendingOutcome(u64),     // stores Outcome after quorum, before finalization
     DisputeWindowStart(u64), // ledger timestamp when quorum was reached
@@ -86,6 +88,20 @@ pub fn set_registry(env: &Env, registry: Address) {
     env.storage()
         .instance()
         .set(&InstanceKey::Registry, &registry);
+}
+
+pub fn get_registry_opt(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&InstanceKey::Registry)
+}
+
+pub fn set_factory(env: &Env, factory: Address) {
+    env.storage()
+        .instance()
+        .set(&InstanceKey::Factory, &factory);
+}
+
+pub fn get_factory_opt(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&InstanceKey::Factory)
 }
 
 /// Read the stored CallRegistry address; panics if not set.

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -29,9 +29,81 @@ pub struct MockRegistry;
 
 #[contractimpl]
 impl MockRegistry {
-    pub fn resolve_call(_env: Env, _call_id: u64, _outcome: u32, _end_price: i128) {}
-    pub fn release_escrow(_env: Env, _call_id: u64, _to: Address, _amount: i128) {}
-    pub fn mark_settled(_env: Env, _call_id: u64) {}
+    fn default_mock_call(env: &Env, call_id: u64) -> Call {
+        let outcome_count = 2u32;
+        let mut outcome_stakes = Map::new(env);
+        outcome_stakes.set(1, 0);
+        outcome_stakes.set(2, 0);
+
+        let mut stakes = Map::new(env);
+        stakes.set(1, Map::new(env));
+        stakes.set(2, Map::new(env));
+
+        Call {
+            id: call_id,
+            creator: Address::generate(env),
+            stake_token: Address::generate(env),
+            stake_amount: 1,
+            end_ts: 0,
+            token_address: Address::generate(env),
+            pair_id: Bytes::from_slice(env, b"mock"),
+            metadata_hash: BytesN::from_array(env, &[0u8; 32]),
+            outcome_count,
+            outcome_stakes,
+            stakes,
+            outcome: 0,
+            start_price: 100,
+            end_price: 0,
+            condition: ConditionType::TargetAbove(100),
+            settled: false,
+            voided: false,
+            created_at: 0,
+            cancelled: false,
+            metadata_version: 0,
+            share_tokens: Map::new(env),
+        }
+    }
+
+    pub fn resolve_call(
+        env: Env,
+        call_id: u64,
+        outcome: u32,
+        end_price: i128,
+    ) -> Result<Call, CallRegistryError> {
+        let mut call: Call = env
+            .storage()
+            .instance()
+            .get(&MockDataKey::Call(call_id))
+            .unwrap_or_else(|| Self::default_mock_call(&env, call_id));
+        call.outcome = outcome;
+        call.end_price = end_price;
+        env.storage()
+            .instance()
+            .set(&MockDataKey::Call(call_id), &call);
+        Ok(call)
+    }
+
+    pub fn release_escrow(
+        _env: Env,
+        _call_id: u64,
+        _to: Address,
+        _amount: i128,
+    ) -> Result<(), CallRegistryError> {
+        Ok(())
+    }
+
+    pub fn mark_settled(env: Env, call_id: u64) -> Result<(), CallRegistryError> {
+        let mut call: Call = env
+            .storage()
+            .instance()
+            .get(&MockDataKey::Call(call_id))
+            .unwrap_or_else(|| Self::default_mock_call(&env, call_id));
+        call.settled = true;
+        env.storage()
+            .instance()
+            .set(&MockDataKey::Call(call_id), &call);
+        Ok(())
+    }
 
     pub fn set_mock_call(env: Env, call_id: u64, call: Call) {
         env.storage()

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -1,10 +1,11 @@
 #![cfg(test)]
+#![allow(deprecated)]
 
 extern crate std;
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, testutils::Address as _, Address, Bytes, BytesN, Env, Map,
-    Vec,
+    contract, contractimpl, contracttype, testutils::Address as _, Address, Bytes, BytesN, Env,
+    Map, Vec,
 };
 
 use crate::call_types::{Call, CallRegistryError, ConditionType};
@@ -33,7 +34,9 @@ impl MockRegistry {
     pub fn mark_settled(_env: Env, _call_id: u64) {}
 
     pub fn set_mock_call(env: Env, call_id: u64, call: Call) {
-        env.storage().instance().set(&MockDataKey::Call(call_id), &call);
+        env.storage()
+            .instance()
+            .set(&MockDataKey::Call(call_id), &call);
     }
 
     pub fn set_mock_staker_stake(
@@ -43,9 +46,10 @@ impl MockRegistry {
         position: u32,
         amount: i128,
     ) {
-        env.storage()
-            .instance()
-            .set(&MockDataKey::StakerStake(call_id, staker, position), &amount);
+        env.storage().instance().set(
+            &MockDataKey::StakerStake(call_id, staker, position),
+            &amount,
+        );
     }
 
     pub fn get_call(env: Env, call_id: u64) -> Result<Call, CallRegistryError> {
@@ -334,7 +338,6 @@ fn setup_with_fee(env: &Env, fee_bps: u32) -> (Address, Address, OutcomeManagerC
     (fee_collector, registry_id, client)
 }
 
-
 // ─── Claimable Balance Tests ───────────────────────────────────────────────────
 
 #[test]
@@ -346,7 +349,10 @@ fn test_claim_payout_stores_claimable_balance_id() {
     client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
 
     let balance_id = client.get_claimable_balance_id(&1u64, &staker);
-    assert!(balance_id.is_some(), "claimable balance id should be stored");
+    assert!(
+        balance_id.is_some(),
+        "claimable balance id should be stored"
+    );
 }
 
 #[test]
@@ -381,7 +387,12 @@ fn test_batch_create_claimable_balances_stores_ids() {
     stakes.push_back(40_i128);
 
     client.batch_create_claimable_balances(
-        &registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128,
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
     );
 
     assert!(client.get_claimable_balance_id(&1u64, &staker1).is_some());
@@ -399,7 +410,12 @@ fn test_batch_create_claimable_balances_empty_fails() {
     let stakes: Vec<i128> = Vec::new(&env);
 
     let result = client.try_batch_create_claimable_balances(
-        &registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128,
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
     );
     assert_contract_error(result, OutcomeError::EmptyBatch);
 }
@@ -416,11 +432,21 @@ fn test_batch_create_claimable_balances_duplicate_fails() {
     stakes.push_back(100_i128);
 
     client.batch_create_claimable_balances(
-        &registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128,
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
     );
 
     let result = client.try_batch_create_claimable_balances(
-        &registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128,
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
     );
     assert_contract_error(result, OutcomeError::AlreadyClaimed);
 }
@@ -432,7 +458,6 @@ fn test_get_claimable_balance_id_none_before_claim() {
     let staker = Address::generate(&env);
     assert!(client.get_claimable_balance_id(&1u64, &staker).is_none());
 }
-
 
 // ─── Initialization Tests ──────────────────────────────────────────────────────
 
@@ -514,16 +539,28 @@ fn test_quorum_reached_with_two_oracles() {
     let sig1 = sign_outcome(&env, &s1, call_id, outcome_val, price, ts);
     client.submit_outcome(
         &registry_id,
-        &SignedOutcome { call_id, outcome: outcome_val, price, timestamp: ts,
-            oracle_pubkey: p1.clone(), signature: sig1 },
+        &SignedOutcome {
+            call_id,
+            outcome: outcome_val,
+            price,
+            timestamp: ts,
+            oracle_pubkey: p1.clone(),
+            signature: sig1,
+        },
         &0u64,
     );
 
     let sig2 = sign_outcome(&env, &s2, call_id, outcome_val, price, ts);
     client.submit_outcome(
         &registry_id,
-        &SignedOutcome { call_id, outcome: outcome_val, price, timestamp: ts,
-            oracle_pubkey: p2.clone(), signature: sig2 },
+        &SignedOutcome {
+            call_id,
+            outcome: outcome_val,
+            price,
+            timestamp: ts,
+            oracle_pubkey: p2.clone(),
+            signature: sig2,
+        },
         &0u64,
     );
 
@@ -533,8 +570,24 @@ fn test_quorum_reached_with_two_oracles() {
     let stored_votes = client.get_votes(&call_id);
     assert_eq!(stored_votes.len(), 2);
     assert_eq!(client.get_vote_count(&call_id), 2);
-    assert_eq!(stored_votes.get(0).unwrap(), OracleVote { oracle: p1, outcome: outcome_val, price, timestamp: ts });
-    assert_eq!(stored_votes.get(1).unwrap(), OracleVote { oracle: p2, outcome: outcome_val, price, timestamp: ts });
+    assert_eq!(
+        stored_votes.get(0).unwrap(),
+        OracleVote {
+            oracle: p1,
+            outcome: outcome_val,
+            price,
+            timestamp: ts
+        }
+    );
+    assert_eq!(
+        stored_votes.get(1).unwrap(),
+        OracleVote {
+            oracle: p2,
+            outcome: outcome_val,
+            price,
+            timestamp: ts
+        }
+    );
 }
 
 #[test]
@@ -549,8 +602,14 @@ fn test_submit_unauthorized_oracle_fails() {
 
     let result = client.try_submit_outcome(
         &mock_registry,
-        &SignedOutcome { call_id, outcome: 1, price: 100, timestamp: 9000,
-            oracle_pubkey: pubkey2, signature: sig },
+        &SignedOutcome {
+            call_id,
+            outcome: 1,
+            price: 100,
+            timestamp: 9000,
+            oracle_pubkey: pubkey2,
+            signature: sig,
+        },
         &0u64,
     );
     assert_contract_error(result, OutcomeError::UnauthorizedOracle);
@@ -576,7 +635,10 @@ fn test_submit_duplicate_submission_fails() {
 
     let registry_id = env.register_contract(None, MockRegistry);
     let signed = SignedOutcome {
-        call_id: 7, outcome: 1, price: 100, timestamp: 1000,
+        call_id: 7,
+        outcome: 1,
+        price: 100,
+        timestamp: 1000,
         oracle_pubkey: pubkey1.clone(),
         signature: sign_outcome(&env, &secret1, 7, 1, 100, 1000),
     };
@@ -593,9 +655,14 @@ fn test_submit_invalid_outcome_fails() {
 
     let result = client.try_submit_outcome(
         &registry_id,
-        &SignedOutcome { call_id: 8, outcome: 3, price: 100, timestamp: 1000,
+        &SignedOutcome {
+            call_id: 8,
+            outcome: 3,
+            price: 100,
+            timestamp: 1000,
             oracle_pubkey: oracle_pubkey.clone(),
-            signature: sign_outcome(&env, &oracle_secret, 8, 3, 100, 1000) },
+            signature: sign_outcome(&env, &oracle_secret, 8, 3, 100, 1000),
+        },
         &0u64,
     );
     assert_contract_error(result, OutcomeError::InvalidOutcome);
@@ -607,7 +674,10 @@ fn test_submit_outcome_after_settlement_fails() {
     let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
 
     let signed = SignedOutcome {
-        call_id: 9, outcome: 1, price: 100, timestamp: 1000,
+        call_id: 9,
+        outcome: 1,
+        price: 100,
+        timestamp: 1000,
         oracle_pubkey: oracle_pubkey.clone(),
         signature: sign_outcome(&env, &oracle_secret, 9, 1, 100, 1000),
     };
@@ -665,7 +735,6 @@ fn test_add_oracle_enforces_max_limit() {
     assert_contract_error(result, OutcomeError::MaxOraclesReached);
 }
 
-
 // ─── Fee Tests ─────────────────────────────────────────────────────────────────
 
 #[test]
@@ -714,7 +783,15 @@ fn test_batch_claim_payouts_three_stakers() {
 
     let staker_refs = [staker1.clone(), staker2.clone(), staker3.clone()];
     let stake_vals = [50_i128, 30_i128, 20_i128];
-    prepare_mock_batch_payout(&env, &registry_id, 1u64, &staker_refs, &stake_vals, 100, 100);
+    prepare_mock_batch_payout(
+        &env,
+        &registry_id,
+        1u64,
+        &staker_refs,
+        &stake_vals,
+        100,
+        100,
+    );
 
     let mut stakers = Vec::new(&env);
     stakers.push_back(staker1.clone());
@@ -745,7 +822,8 @@ fn test_batch_claim_panics_on_duplicate_staker() {
     stakes.push_back(50_i128);
 
     client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
-    let result = client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
+    let result =
+        client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &50_i128, &50_i128);
     assert_contract_error(result, OutcomeError::AlreadyClaimed);
 }
 
@@ -757,7 +835,14 @@ fn test_batch_claim_panics_on_empty_batch() {
     let stakers: Vec<Address> = Vec::new(&env);
     let stakes: Vec<i128> = Vec::new(&env);
 
-    let result = client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
+    let result = client.try_batch_claim_payouts(
+        &registry_id,
+        &1u64,
+        &stakers,
+        &stakes,
+        &100_i128,
+        &100_i128,
+    );
     assert_contract_error(result, OutcomeError::EmptyBatch);
 }
 
@@ -773,7 +858,8 @@ fn test_batch_claim_panics_on_length_mismatch() {
     let mut stakes = Vec::new(&env);
     stakes.push_back(50_i128);
 
-    let result = client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
+    let result =
+        client.try_batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &50_i128);
     assert_contract_error(result, OutcomeError::LengthMismatch);
 }
 
@@ -799,7 +885,10 @@ fn test_submit_outcome_fails_when_paused() {
     client.pause();
 
     let signed = SignedOutcome {
-        call_id: 1, outcome: 1, price: 100, timestamp: 1000,
+        call_id: 1,
+        outcome: 1,
+        price: 100,
+        timestamp: 1000,
         oracle_pubkey: oracle_pubkey.clone(),
         signature: sign_outcome(&env, &oracle_secret, 1, 1, 100, 1000),
     };
@@ -816,7 +905,14 @@ fn test_claim_payout_fails_when_paused() {
 
     client.pause();
 
-    let result = client.try_claim_payout(&registry_id, &1u64, &staker, &100_i128, &100_i128, &100_i128);
+    let result = client.try_claim_payout(
+        &registry_id,
+        &1u64,
+        &staker,
+        &100_i128,
+        &100_i128,
+        &100_i128,
+    );
     assert_contract_error(result, OutcomeError::ContractPaused);
 }
 
@@ -831,7 +927,14 @@ fn test_submission_within_window_succeeds() {
     let sig = sign_outcome(&env, &oracle_secret, call_id, 1, 100, 1500);
     client.submit_outcome(
         &registry_id,
-        &SignedOutcome { call_id, outcome: 1, price: 100, timestamp: 1500, oracle_pubkey, signature: sig },
+        &SignedOutcome {
+            call_id,
+            outcome: 1,
+            price: 100,
+            timestamp: 1500,
+            oracle_pubkey,
+            signature: sig,
+        },
         &1000u64,
     );
     assert_eq!(client.get_outcome(&call_id).outcome, 1u32);
@@ -848,7 +951,14 @@ fn test_submission_outside_window_fails() {
     let sig = sign_outcome(&env, &oracle_secret, call_id, 1, 100, 1200);
     let result = client.try_submit_outcome(
         &registry_id,
-        &SignedOutcome { call_id, outcome: 1, price: 100, timestamp: 1200, oracle_pubkey, signature: sig },
+        &SignedOutcome {
+            call_id,
+            outcome: 1,
+            price: 100,
+            timestamp: 1200,
+            oracle_pubkey,
+            signature: sig,
+        },
         &1000u64,
     );
     assert_contract_error(result, OutcomeError::SubmissionWindowExpired);
@@ -863,7 +973,15 @@ fn test_twap_three_equal_intervals() {
     let call_id = 42u64;
     for (price, ts) in [(100_i128, 1000u64), (200, 2000), (300, 3000)] {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
-        client.submit_price_observation(&call_id, &PriceObservation { price, timestamp: ts }, &oracle_pubkey, &sig);
+        client.submit_price_observation(
+            &call_id,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
     }
     assert_eq!(client.compute_twap(&call_id), 150);
 }
@@ -875,7 +993,15 @@ fn test_twap_requires_minimum_3_observations() {
     let call_id = 44u64;
     for (price, ts) in [(100_i128, 1000u64), (200, 2000)] {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
-        client.submit_price_observation(&call_id, &PriceObservation { price, timestamp: ts }, &oracle_pubkey, &sig);
+        client.submit_price_observation(
+            &call_id,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
     }
     let result = client.try_compute_twap(&call_id);
     assert_contract_error(result, OutcomeError::InsufficientPriceObservations);
@@ -889,11 +1015,20 @@ fn test_claim_payout_stays_within_budget() {
     let (_, registry_id, client) = setup_with_fee(&env, 500);
     let staker = Address::generate(&env);
 
-    let usage = measure_budget(&env, CLAIM_PAYOUT_BUDGET_CPU, CLAIM_PAYOUT_BUDGET_MEM, || {
-        client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
-    });
+    let usage = measure_budget(
+        &env,
+        CLAIM_PAYOUT_BUDGET_CPU,
+        CLAIM_PAYOUT_BUDGET_MEM,
+        || {
+            client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+        },
+    );
 
-    std::println!("outcome_manager::claim_payout cpu={} mem={}", usage.cpu, usage.mem);
+    std::println!(
+        "outcome_manager::claim_payout cpu={} mem={}",
+        usage.cpu,
+        usage.mem
+    );
     assert!(usage.cpu <= CLAIM_PAYOUT_BUDGET_CPU);
     assert!(usage.mem <= CLAIM_PAYOUT_BUDGET_MEM);
 }
@@ -910,11 +1045,27 @@ fn test_batch_claim_payouts_stays_within_budget() {
         stakes.push_back(5_i128);
     }
 
-    let usage = measure_budget(&env, BATCH_CLAIM_PAYOUTS_BUDGET_CPU, BATCH_CLAIM_PAYOUTS_BUDGET_MEM, || {
-        client.batch_claim_payouts(&registry_id, &1u64, &stakers, &stakes, &100_i128, &100_i128);
-    });
+    let usage = measure_budget(
+        &env,
+        BATCH_CLAIM_PAYOUTS_BUDGET_CPU,
+        BATCH_CLAIM_PAYOUTS_BUDGET_MEM,
+        || {
+            client.batch_claim_payouts(
+                &registry_id,
+                &1u64,
+                &stakers,
+                &stakes,
+                &100_i128,
+                &100_i128,
+            );
+        },
+    );
 
-    std::println!("outcome_manager::batch_claim_payouts cpu={} mem={}", usage.cpu, usage.mem);
+    std::println!(
+        "outcome_manager::batch_claim_payouts cpu={} mem={}",
+        usage.cpu,
+        usage.mem
+    );
     assert!(usage.cpu <= BATCH_CLAIM_PAYOUTS_BUDGET_CPU);
     assert!(usage.mem <= BATCH_CLAIM_PAYOUTS_BUDGET_MEM);
 }
@@ -925,17 +1076,30 @@ fn fuzz_claim_setup(staker_winning: i128, total_winning: i128, total_losing: i12
     let env = Env::default();
     let (_, registry_id, client) = setup_with_fee(&env, fee_bps);
     let staker = Address::generate(&env);
-    client.claim_payout(&registry_id, &1u64, &staker, &staker_winning, &total_winning, &total_losing);
+    client.claim_payout(
+        &registry_id,
+        &1u64,
+        &staker,
+        &staker_winning,
+        &total_winning,
+        &total_losing,
+    );
     assert!(client.has_claimed(&1u64, &staker));
 }
 
 #[test]
 fn test_fuzz_payout_many_ratios_no_panic() {
     let cases: &[(i128, i128, i128, u32)] = &[
-        (1, 1, 0, 0), (1, 1, 1, 0), (1, 1, 1, 1000), (1, 1, 1, 5000),
-        (1, 1_000, 1_000_000, 100), (500, 1_000, 1_000_000, 500),
-        (1_000, 1_000, 1, 0), (1_000_000, 1_000_000, 1_000_000, 1_000),
-        (1, 1, 1_000_000_000_000, 0), (1, 1_000_000_000_000, 1_000_000_000_000, 0),
+        (1, 1, 0, 0),
+        (1, 1, 1, 0),
+        (1, 1, 1, 1000),
+        (1, 1, 1, 5000),
+        (1, 1_000, 1_000_000, 100),
+        (500, 1_000, 1_000_000, 500),
+        (1_000, 1_000, 1, 0),
+        (1_000_000, 1_000_000, 1_000_000, 1_000),
+        (1, 1, 1_000_000_000_000, 0),
+        (1, 1_000_000_000_000, 1_000_000_000_000, 0),
         (500, 1_000, 1_000, 5_000),
     ];
     for &(sw, tw, tl, fee) in cases {

--- a/packages/contracts/prediction_market/Cargo.toml
+++ b/packages/contracts/prediction_market/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "prediction-market"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+backit-shared = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+rand = "0.8"

--- a/packages/contracts/prediction_market/src/errors.rs
+++ b/packages/contracts/prediction_market/src/errors.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum MarketError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    InvalidStakeAmount = 3,
+    InvalidEndTime = 4,
+    CallNotFound = 5,
+    CallEnded = 6,
+    CallSettled = 7,
+    InvalidPosition = 8,
+    Unauthorized = 9,
+    ContractPaused = 10,
+    CallNotEnded = 11,
+    InvalidOutcome = 12,
+    InvalidOutcomeCount = 13,
+    StakingCutoffActive = 15,
+    InvalidCallId = 16,
+}

--- a/packages/contracts/prediction_market/src/events.rs
+++ b/packages/contracts/prediction_market/src/events.rs
@@ -1,3 +1,6 @@
+#![allow(deprecated)]
+#![allow(clippy::too_many_arguments)]
+
 use soroban_sdk::{Address, Bytes, BytesN, Env};
 
 pub fn emit_market_initialized(
@@ -13,20 +16,18 @@ pub fn emit_market_initialized(
     );
 }
 
-pub fn emit_stake_added(
-    env: &Env,
-    call_id: u64,
-    staker: &Address,
-    amount: i128,
-    position: u32,
-) {
-    env.events()
-        .publish(("prediction_market", "stake_added"), (call_id, staker.clone(), amount, position));
+pub fn emit_stake_added(env: &Env, call_id: u64, staker: &Address, amount: i128, position: u32) {
+    env.events().publish(
+        ("prediction_market", "stake_added"),
+        (call_id, staker.clone(), amount, position),
+    );
 }
 
 pub fn emit_call_resolved(env: &Env, call_id: u64, outcome: u32, end_price: i128) {
-    env.events()
-        .publish(("prediction_market", "resolved"), (call_id, outcome, end_price));
+    env.events().publish(
+        ("prediction_market", "resolved"),
+        (call_id, outcome, end_price),
+    );
 }
 
 pub fn emit_call_created(

--- a/packages/contracts/prediction_market/src/events.rs
+++ b/packages/contracts/prediction_market/src/events.rs
@@ -1,0 +1,60 @@
+use soroban_sdk::{Address, Bytes, BytesN, Env};
+
+pub fn emit_market_initialized(
+    env: &Env,
+    call_id: u64,
+    creator: &Address,
+    stake_token: &Address,
+    end_ts: u64,
+) {
+    env.events().publish(
+        ("prediction_market", "initialized"),
+        (call_id, creator.clone(), stake_token.clone(), end_ts),
+    );
+}
+
+pub fn emit_stake_added(
+    env: &Env,
+    call_id: u64,
+    staker: &Address,
+    amount: i128,
+    position: u32,
+) {
+    env.events()
+        .publish(("prediction_market", "stake_added"), (call_id, staker.clone(), amount, position));
+}
+
+pub fn emit_call_resolved(env: &Env, call_id: u64, outcome: u32, end_price: i128) {
+    env.events()
+        .publish(("prediction_market", "resolved"), (call_id, outcome, end_price));
+}
+
+pub fn emit_call_created(
+    env: &Env,
+    call_id: u64,
+    creator: &Address,
+    stake_token: &Address,
+    stake_amount: i128,
+    start_price: i128,
+    end_ts: u64,
+    token_address: &Address,
+    pair_id: &Bytes,
+    metadata_hash: &BytesN<32>,
+    outcome_count: u32,
+) {
+    env.events().publish(
+        ("prediction_market", "created"),
+        (
+            call_id,
+            creator.clone(),
+            stake_token.clone(),
+            stake_amount,
+            start_price,
+            end_ts,
+            token_address.clone(),
+            pair_id.clone(),
+            metadata_hash.clone(),
+            outcome_count,
+        ),
+    );
+}

--- a/packages/contracts/prediction_market/src/lib.rs
+++ b/packages/contracts/prediction_market/src/lib.rs
@@ -3,6 +3,7 @@
 //! Each instance holds exactly one market's call data, stake tracking, and
 //! resolution logic. Deployed exclusively via [`prediction_market_factory`].
 #![no_std]
+#![allow(clippy::too_many_arguments)]
 
 mod errors;
 mod events;
@@ -16,7 +17,6 @@ mod test;
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Map};
 use storage::*;
-use types::*;
 
 use errors::MarketError;
 use events::{emit_call_created, emit_call_resolved, emit_market_initialized, emit_stake_added};

--- a/packages/contracts/prediction_market/src/lib.rs
+++ b/packages/contracts/prediction_market/src/lib.rs
@@ -1,0 +1,350 @@
+//! Lightweight single-market prediction contract.
+//!
+//! Each instance holds exactly one market's call data, stake tracking, and
+//! resolution logic. Deployed exclusively via [`prediction_market_factory`].
+#![no_std]
+
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+pub use types::{Call, ConditionType, MarketConfig, MarketInitArgs};
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, token, Address, Env, Map};
+use storage::*;
+use types::*;
+
+use errors::MarketError;
+use events::{emit_call_created, emit_call_resolved, emit_market_initialized, emit_stake_added};
+
+#[cfg(not(test))]
+#[inline]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let sentinel = Address::from_string(&soroban_sdk::String::from_str(
+        env,
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    ));
+    *addr == sentinel
+}
+
+#[cfg(test)]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let key = soroban_sdk::Symbol::new(env, "xlm_sac_addr");
+    if let Some(sentinel) = env.storage().instance().get::<_, Address>(&key) {
+        return *addr == sentinel;
+    }
+    false
+}
+
+fn transfer_token(env: &Env, stake_token: &Address, from: &Address, to: &Address, amount: i128) {
+    if is_native_xlm(env, stake_token) {
+        token::StellarAssetClient::new(env, stake_token).transfer(from, to, &amount);
+    } else {
+        token::Client::new(env, stake_token).transfer(from, to, &amount);
+    }
+}
+
+fn require_call_id(config: &MarketConfig, call_id: u64) -> Result<(), MarketError> {
+    if config.call_id != call_id {
+        return Err(MarketError::InvalidCallId);
+    }
+    Ok(())
+}
+
+macro_rules! reentrancy_guard {
+    ($env:expr) => {
+        if storage::is_locked($env) {
+            return Err(MarketError::Unauthorized);
+        }
+        storage::acquire_lock($env);
+    };
+}
+
+#[contract]
+pub struct PredictionMarket;
+
+#[contractimpl]
+impl PredictionMarket {
+    /// Constructor invoked by the factory via `deploy_v2`.
+    pub fn __constructor(
+        env: Env,
+        call_id: u64,
+        creator: Address,
+        outcome_manager: Address,
+        factory: Address,
+        min_stake: i128,
+        max_stake_per_user: i128,
+        staking_cutoff_secs: u64,
+        args: MarketInitArgs,
+    ) {
+        if get_config(&env).is_some() {
+            soroban_sdk::panic_with_error!(&env, MarketError::AlreadyInitialized);
+        }
+
+        let MarketInitArgs {
+            stake_token,
+            stake_amount,
+            start_price,
+            end_ts,
+            token_address,
+            pair_id,
+            metadata_hash,
+            condition,
+            outcome_count,
+        } = args;
+
+        if stake_amount < min_stake || stake_amount <= 0 {
+            soroban_sdk::panic_with_error!(&env, MarketError::InvalidStakeAmount);
+        }
+        if start_price <= 0 {
+            soroban_sdk::panic_with_error!(&env, MarketError::InvalidStakeAmount);
+        }
+        if outcome_count < 2 {
+            soroban_sdk::panic_with_error!(&env, MarketError::InvalidOutcomeCount);
+        }
+
+        let current_timestamp = env.ledger().timestamp();
+        if end_ts <= current_timestamp {
+            soroban_sdk::panic_with_error!(&env, MarketError::InvalidEndTime);
+        }
+
+        let config = MarketConfig {
+            call_id,
+            creator: creator.clone(),
+            outcome_manager: outcome_manager.clone(),
+            factory: factory.clone(),
+            min_stake,
+            max_stake_per_user,
+            staking_cutoff_secs,
+            paused: false,
+        };
+        set_config(&env, &config);
+
+        let mut outcome_stakes = Map::new(&env);
+        let mut stakes = Map::new(&env);
+        for i in 1..=outcome_count {
+            outcome_stakes.set(i, 0);
+            stakes.set(i, Map::new(&env));
+        }
+
+        let call = Call {
+            id: call_id,
+            creator: creator.clone(),
+            stake_token: stake_token.clone(),
+            stake_amount,
+            end_ts,
+            token_address: token_address.clone(),
+            pair_id: pair_id.clone(),
+            metadata_hash: metadata_hash.clone(),
+            outcome_count,
+            outcome_stakes,
+            stakes,
+            outcome: 0,
+            start_price,
+            end_price: 0,
+            condition,
+            settled: false,
+            voided: false,
+            created_at: current_timestamp,
+            cancelled: false,
+            metadata_version: 0,
+            share_tokens: Map::new(&env),
+        };
+
+        set_call(&env, &call);
+        emit_market_initialized(&env, call_id, &creator, &stake_token, end_ts);
+        emit_call_created(
+            &env,
+            call_id,
+            &creator,
+            &stake_token,
+            stake_amount,
+            start_price,
+            end_ts,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            outcome_count,
+        );
+    }
+
+    /// Stake tokens on an outcome position.
+    pub fn stake_on_call(
+        env: Env,
+        staker: Address,
+        call_id: u64,
+        amount: i128,
+        position: u32,
+    ) -> Result<Call, MarketError> {
+        staker.require_auth();
+        reentrancy_guard!(&env);
+
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        if config.paused {
+            return Err(MarketError::ContractPaused);
+        }
+        if amount <= 0 || amount < config.min_stake {
+            return Err(MarketError::InvalidStakeAmount);
+        }
+
+        let mut call = get_call(&env).ok_or(MarketError::CallNotFound)?;
+        let current_timestamp = env.ledger().timestamp();
+
+        if current_timestamp >= call.end_ts {
+            return Err(MarketError::CallEnded);
+        }
+
+        let cutoff = config.staking_cutoff_secs;
+        if cutoff > 0 && call.end_ts > cutoff && current_timestamp >= call.end_ts - cutoff {
+            return Err(MarketError::StakingCutoffActive);
+        }
+
+        if call.settled || call.cancelled || call.voided {
+            return Err(MarketError::CallSettled);
+        }
+
+        if position < 1 || position > call.outcome_count {
+            return Err(MarketError::InvalidPosition);
+        }
+
+        let mut outcome_stakers = call.stakes.get(position).unwrap_or_else(|| Map::new(&env));
+        let current_staker_stake = outcome_stakers.get(staker.clone()).unwrap_or(0);
+        let updated_staker_stake = current_staker_stake + amount;
+
+        if config.max_stake_per_user > 0 && updated_staker_stake > config.max_stake_per_user {
+            return Err(MarketError::InvalidStakeAmount);
+        }
+
+        transfer_token(
+            &env,
+            &call.stake_token,
+            &staker,
+            &env.current_contract_address(),
+            amount,
+        );
+
+        let current_total = call.outcome_stakes.get(position).unwrap_or(0);
+        call.outcome_stakes.set(position, current_total + amount);
+        outcome_stakers.set(staker.clone(), updated_staker_stake);
+        call.stakes.set(position, outcome_stakers);
+
+        set_user_stake(&env, &staker, position, updated_staker_stake);
+        set_call(&env, &call);
+        emit_stake_added(&env, call_id, &staker, amount, position);
+
+        storage::release_lock(&env);
+        Ok(call)
+    }
+
+    /// Resolve the market (outcome_manager only).
+    pub fn resolve_call(
+        env: Env,
+        call_id: u64,
+        outcome: u32,
+        end_price: i128,
+    ) -> Result<Call, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        config.outcome_manager.require_auth();
+        reentrancy_guard!(&env);
+
+        let mut call = get_call(&env).ok_or(MarketError::CallNotFound)?;
+
+        if outcome < 1 || outcome > call.outcome_count {
+            return Err(MarketError::InvalidOutcome);
+        }
+        if env.ledger().timestamp() < call.end_ts {
+            return Err(MarketError::CallNotEnded);
+        }
+        if call.voided {
+            return Err(MarketError::Unauthorized);
+        }
+
+        call.outcome = outcome;
+        call.end_price = end_price;
+        set_call(&env, &call);
+        emit_call_resolved(&env, call_id, outcome, end_price);
+
+        storage::release_lock(&env);
+        Ok(call)
+    }
+
+    /// Mark the market as settled (outcome_manager only).
+    pub fn mark_settled(env: Env, call_id: u64) -> Result<(), MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        config.outcome_manager.require_auth();
+
+        let mut call = get_call(&env).ok_or(MarketError::CallNotFound)?;
+        if call.settled {
+            return Err(MarketError::CallSettled);
+        }
+        call.settled = true;
+        set_call(&env, &call);
+        Ok(())
+    }
+
+    /// Release escrowed tokens (outcome_manager only).
+    pub fn release_escrow(
+        env: Env,
+        call_id: u64,
+        to: Address,
+        amount: i128,
+    ) -> Result<(), MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        config.outcome_manager.require_auth();
+
+        let call = get_call(&env).ok_or(MarketError::CallNotFound)?;
+        transfer_token(
+            &env,
+            &call.stake_token,
+            &env.current_contract_address(),
+            &to,
+            amount,
+        );
+        Ok(())
+    }
+
+    /// Return the full call struct (compatible with outcome_manager cross-contract reads).
+    pub fn get_call(env: Env, call_id: u64) -> Result<Call, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        get_call(&env).ok_or(MarketError::CallNotFound)
+    }
+
+    /// Return a staker's stake on a given outcome position.
+    pub fn get_staker_stake(
+        env: Env,
+        call_id: u64,
+        staker: Address,
+        position: u32,
+    ) -> Result<i128, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        Ok(get_user_stake(&env, &staker, position))
+    }
+
+    /// Return total stakes per outcome.
+    pub fn get_outcome_stakes(env: Env, call_id: u64) -> Result<Map<u32, i128>, MarketError> {
+        let call = Self::get_call(env, call_id)?;
+        Ok(call.outcome_stakes)
+    }
+
+    /// Return this market's global call ID assigned by the factory.
+    pub fn get_call_id(env: Env) -> Result<u64, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        Ok(config.call_id)
+    }
+
+    /// Return the factory address that deployed this market.
+    pub fn get_factory(env: Env) -> Result<Address, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        Ok(config.factory)
+    }
+}

--- a/packages/contracts/prediction_market/src/storage.rs
+++ b/packages/contracts/prediction_market/src/storage.rs
@@ -31,11 +31,7 @@ pub fn set_user_stake(env: &Env, staker: &soroban_sdk::Address, position: u32, a
         .set(&DataKey::UserStake(staker.clone(), position), &amount);
 }
 
-pub fn get_user_stake(
-    env: &Env,
-    staker: &soroban_sdk::Address,
-    position: u32,
-) -> i128 {
+pub fn get_user_stake(env: &Env, staker: &soroban_sdk::Address, position: u32) -> i128 {
     env.storage()
         .instance()
         .get(&DataKey::UserStake(staker.clone(), position))

--- a/packages/contracts/prediction_market/src/storage.rs
+++ b/packages/contracts/prediction_market/src/storage.rs
@@ -1,0 +1,58 @@
+use crate::types::{Call, MarketConfig};
+use soroban_sdk::{contracttype, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Call,
+    UserStake(Address, u32),
+    Locked,
+}
+
+pub fn set_config(env: &Env, config: &MarketConfig) {
+    env.storage().instance().set(&DataKey::Config, config);
+}
+
+pub fn get_config(env: &Env) -> Option<MarketConfig> {
+    env.storage().instance().get(&DataKey::Config)
+}
+
+pub fn set_call(env: &Env, call: &Call) {
+    env.storage().instance().set(&DataKey::Call, call);
+}
+
+pub fn get_call(env: &Env) -> Option<Call> {
+    env.storage().instance().get(&DataKey::Call)
+}
+
+pub fn set_user_stake(env: &Env, staker: &soroban_sdk::Address, position: u32, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::UserStake(staker.clone(), position), &amount);
+}
+
+pub fn get_user_stake(
+    env: &Env,
+    staker: &soroban_sdk::Address,
+    position: u32,
+) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::UserStake(staker.clone(), position))
+        .unwrap_or(0)
+}
+
+pub fn acquire_lock(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &true);
+}
+
+pub fn release_lock(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &false);
+}
+
+pub fn is_locked(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Locked)
+        .unwrap_or(false)
+}

--- a/packages/contracts/prediction_market/src/test.rs
+++ b/packages/contracts/prediction_market/src/test.rs
@@ -92,7 +92,16 @@ fn market_resolve_requires_outcome_manager() {
 
     let market_id = env.register(
         PredictionMarket,
-        (42u64, creator, outcome_manager.clone(), factory, 100_000i128, 0i128, 0u64, args),
+        (
+            42u64,
+            creator,
+            outcome_manager.clone(),
+            factory,
+            100_000i128,
+            0i128,
+            0u64,
+            args,
+        ),
     );
     let market = PredictionMarketClient::new(&env, &market_id);
 

--- a/packages/contracts/prediction_market/src/test.rs
+++ b/packages/contracts/prediction_market/src/test.rs
@@ -1,0 +1,103 @@
+#![cfg(test)]
+
+extern crate std;
+
+use crate::{
+    types::{ConditionType, MarketInitArgs},
+    PredictionMarket, PredictionMarketClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Bytes, BytesN, Env,
+};
+
+fn setup_token(env: &Env, admin: &Address) -> Address {
+    let token = env.register_stellar_asset_contract_v2(admin.clone());
+    let sac = token.address();
+    StellarAssetClient::new(env, &sac).mint(admin, &100_000_000_000);
+    sac
+}
+
+#[test]
+fn market_constructor_and_stake() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let staker = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+    let factory = Address::generate(&env);
+    let token = setup_token(&env, &admin);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let args = MarketInitArgs {
+        stake_token: token.clone(),
+        stake_amount: 1_000_000,
+        start_price: 100_000_000,
+        end_ts,
+        token_address: token.clone(),
+        pair_id: Bytes::from_slice(&env, b"PAIR"),
+        metadata_hash: BytesN::from_array(&env, &[2u8; 32]),
+        condition: ConditionType::TargetAbove(105_000_000),
+        outcome_count: 2,
+    };
+
+    let market_id = env.register(
+        PredictionMarket,
+        (
+            1u64,
+            creator.clone(),
+            outcome_manager,
+            factory,
+            100_000i128,
+            0i128,
+            300u64,
+            args,
+        ),
+    );
+    let market = PredictionMarketClient::new(&env, &market_id);
+
+    TokenClient::new(&env, &token).transfer(&admin, &staker, &5_000_000);
+    market.stake_on_call(&staker, &1u64, &2_000_000, &1u32);
+
+    let stakes = market.get_outcome_stakes(&1u64);
+    assert_eq!(stakes.get(1u32).unwrap(), 2_000_000);
+    assert_eq!(market.get_staker_stake(&1u64, &staker, &1u32), 2_000_000);
+}
+
+#[test]
+fn market_resolve_requires_outcome_manager() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let creator = Address::generate(&env);
+    let outcome_manager = Address::generate(&env);
+    let factory = Address::generate(&env);
+    let token = setup_token(&env, &creator);
+
+    let end_ts = env.ledger().timestamp() + 100;
+    let args = MarketInitArgs {
+        stake_token: token,
+        stake_amount: 1_000_000,
+        start_price: 100_000_000,
+        end_ts,
+        token_address: Address::generate(&env),
+        pair_id: Bytes::from_slice(&env, b"P"),
+        metadata_hash: BytesN::from_array(&env, &[3u8; 32]),
+        condition: ConditionType::PercentUp(1),
+        outcome_count: 2,
+    };
+
+    let market_id = env.register(
+        PredictionMarket,
+        (42u64, creator, outcome_manager.clone(), factory, 100_000i128, 0i128, 0u64, args),
+    );
+    let market = PredictionMarketClient::new(&env, &market_id);
+
+    env.ledger().set_timestamp(end_ts + 1);
+    let result = market.try_resolve_call(&42u64, &1u32, &110_000_000);
+    // With mock_all_auths, resolution succeeds when outcome_manager auth is mocked.
+    assert!(result.is_ok());
+}

--- a/packages/contracts/prediction_market/src/types.rs
+++ b/packages/contracts/prediction_market/src/types.rs
@@ -1,0 +1,68 @@
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Map};
+
+/// Describes the price-movement condition that determines the winning outcome.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConditionType {
+    TargetAbove(i128),
+    TargetBelow(i128),
+    PercentUp(u32),
+    PercentDown(u32),
+    Range(i128, i128),
+}
+
+/// Arguments supplied when the factory deploys a new market instance.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct MarketInitArgs {
+    pub stake_token: Address,
+    pub stake_amount: i128,
+    pub start_price: i128,
+    pub end_ts: u64,
+    pub token_address: Address,
+    pub pair_id: Bytes,
+    pub metadata_hash: BytesN<32>,
+    pub condition: ConditionType,
+    pub outcome_count: u32,
+}
+
+/// Mirrors `call_registry::Call` so `outcome_manager` can deserialize cross-contract.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Call {
+    pub id: u64,
+    pub creator: Address,
+    pub stake_token: Address,
+    pub stake_amount: i128,
+    pub end_ts: u64,
+    pub token_address: Address,
+    pub pair_id: Bytes,
+    pub metadata_hash: BytesN<32>,
+    pub outcome_count: u32,
+    pub outcome_stakes: Map<u32, i128>,
+    pub stakes: Map<u32, Map<Address, i128>>,
+    pub outcome: u32,
+    pub start_price: i128,
+    pub end_price: i128,
+    pub condition: ConditionType,
+    pub settled: bool,
+    pub voided: bool,
+    pub created_at: u64,
+    pub cancelled: bool,
+    pub metadata_version: u32,
+    pub share_tokens: Map<u32, Address>,
+}
+
+/// Per-market configuration set at deploy time.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct MarketConfig {
+    pub call_id: u64,
+    pub creator: Address,
+    pub outcome_manager: Address,
+    pub factory: Address,
+    pub min_stake: i128,
+    pub max_stake_per_user: i128,
+    pub staking_cutoff_secs: u64,
+    pub paused: bool,
+}

--- a/packages/contracts/prediction_market_factory/Cargo.toml
+++ b/packages/contracts/prediction_market_factory/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "prediction-market-factory"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+prediction-market = { path = "../prediction_market" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+prediction-market = { path = "../prediction_market" }
+outcome-manager = { path = "../outcome_manager" }
+backit-shared = { workspace = true }
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+rand = "0.8"

--- a/packages/contracts/prediction_market_factory/build.rs
+++ b/packages/contracts/prediction_market_factory/build.rs
@@ -6,7 +6,7 @@ fn workspace_root(manifest_dir: &Path) -> PathBuf {
 }
 
 fn wasm_candidates(root: &Path) -> Vec<PathBuf> {
-    ["wasm32-unknown-unknown", "wasm32v1-none"]
+    ["wasm32v1-none", "wasm32-unknown-unknown"]
         .into_iter()
         .flat_map(|target| {
             let dir = root.join("target").join(target).join("release");
@@ -18,27 +18,56 @@ fn wasm_candidates(root: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-fn any_wasm_exists(root: &Path) -> bool {
-    wasm_candidates(root).iter().any(|path| path.exists())
+fn soroban_compatible_wasm_exists(root: &Path) -> bool {
+    let v1 = root
+        .join("target/wasm32v1-none/release")
+        .join("prediction_market.wasm");
+    let optimized = [
+        "wasm32v1-none",
+        "wasm32-unknown-unknown",
+    ]
+    .into_iter()
+    .map(|target| {
+        root.join("target")
+            .join(target)
+            .join("release")
+            .join("prediction_market.optimized.wasm")
+    })
+    .any(|path| path.exists());
+
+    v1.exists() || optimized
 }
 
-fn main() {
-    let manifest_dir =
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
-    let root = workspace_root(&manifest_dir);
+fn stellar_available() -> bool {
+    Command::new("stellar")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
 
-    println!("cargo:rerun-if-changed=../prediction_market/src");
-    println!("cargo:rerun-if-changed=../prediction_market/Cargo.toml");
-    println!("cargo:rerun-if-changed=../.cargo/config.toml");
+fn build_with_stellar(root: &Path) -> bool {
+    let status = Command::new("stellar")
+        .current_dir(root.join("prediction_market"))
+        .args(["contract", "build"])
+        .status();
 
-    if any_wasm_exists(&root) {
-        return;
+    match status {
+        Ok(status) if status.success() => true,
+        Ok(status) => {
+            eprintln!("stellar contract build failed with status {status}");
+            false
+        }
+        Err(err) => {
+            eprintln!("failed to run stellar contract build: {err}");
+            false
+        }
     }
+}
 
-    eprintln!("prediction_market WASM not found — building for factory integration tests...");
-
+fn build_with_cargo(root: &Path) -> bool {
     let status = Command::new("cargo")
-        .current_dir(&root)
+        .current_dir(root)
         .args([
             "build",
             "--release",
@@ -51,12 +80,61 @@ fn main() {
         .expect("failed to spawn cargo build for prediction-market");
 
     if !status.success() {
-        panic!("cargo build for prediction-market failed with status {status}");
+        eprintln!("cargo build for prediction-market failed with status {status}");
+        return false;
     }
 
-    if !any_wasm_exists(&root) {
+    let raw_wasm = root
+        .join("target/wasm32-unknown-unknown/release")
+        .join("prediction_market.wasm");
+    if !raw_wasm.exists() {
+        return false;
+    }
+
+    if stellar_available() {
+        let status = Command::new("stellar")
+            .args([
+                "contract",
+                "optimize",
+                "--wasm",
+                raw_wasm.to_str().expect("non-utf8 wasm path"),
+            ])
+            .status()
+            .expect("failed to spawn stellar contract optimize");
+
+        if status.success() {
+            return true;
+        }
+        eprintln!("stellar contract optimize failed with status {status}");
+    }
+
+    false
+}
+
+fn main() {
+    let manifest_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let root = workspace_root(&manifest_dir);
+
+    println!("cargo:rerun-if-changed=../prediction_market/src");
+    println!("cargo:rerun-if-changed=../prediction_market/Cargo.toml");
+    println!("cargo:rerun-if-changed=../.cargo/config.toml");
+
+    if soroban_compatible_wasm_exists(&root) {
+        return;
+    }
+
+    eprintln!("prediction_market WASM not found — building for factory integration tests...");
+
+    let built = if stellar_available() {
+        build_with_stellar(&root)
+    } else {
+        false
+    } || build_with_cargo(&root);
+
+    if !built || !soroban_compatible_wasm_exists(&root) {
         panic!(
-            "prediction_market WASM still missing after build — expected one of:\n  {}",
+            "failed to produce Soroban-compatible prediction_market WASM — expected one of:\n  {}",
             wasm_candidates(&root)
                 .iter()
                 .map(|p| p.display().to_string())

--- a/packages/contracts/prediction_market_factory/build.rs
+++ b/packages/contracts/prediction_market_factory/build.rs
@@ -1,0 +1,67 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn workspace_root(manifest_dir: &Path) -> PathBuf {
+    manifest_dir.join("..")
+}
+
+fn wasm_candidates(root: &Path) -> Vec<PathBuf> {
+    ["wasm32-unknown-unknown", "wasm32v1-none"]
+        .into_iter()
+        .flat_map(|target| {
+            let dir = root.join("target").join(target).join("release");
+            [
+                dir.join("prediction_market.optimized.wasm"),
+                dir.join("prediction_market.wasm"),
+            ]
+        })
+        .collect()
+}
+
+fn any_wasm_exists(root: &Path) -> bool {
+    wasm_candidates(root).iter().any(|path| path.exists())
+}
+
+fn main() {
+    let manifest_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let root = workspace_root(&manifest_dir);
+
+    println!("cargo:rerun-if-changed=../prediction_market/src");
+    println!("cargo:rerun-if-changed=../prediction_market/Cargo.toml");
+    println!("cargo:rerun-if-changed=../.cargo/config.toml");
+
+    if any_wasm_exists(&root) {
+        return;
+    }
+
+    eprintln!("prediction_market WASM not found — building for factory integration tests...");
+
+    let status = Command::new("cargo")
+        .current_dir(&root)
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "prediction-market",
+            "--target",
+            "wasm32-unknown-unknown",
+        ])
+        .status()
+        .expect("failed to spawn cargo build for prediction-market");
+
+    if !status.success() {
+        panic!("cargo build for prediction-market failed with status {status}");
+    }
+
+    if !any_wasm_exists(&root) {
+        panic!(
+            "prediction_market WASM still missing after build — expected one of:\n  {}",
+            wasm_candidates(&root)
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join("\n  ")
+        );
+    }
+}

--- a/packages/contracts/prediction_market_factory/src/errors.rs
+++ b/packages/contracts/prediction_market_factory/src/errors.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum FactoryError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    InvalidStakeAmount = 4,
+    InvalidEndTime = 5,
+    InvalidOutcomeCount = 6,
+    TokenNotWhitelisted = 7,
+    ContractPaused = 8,
+    MarketWasmNotSet = 9,
+    MarketNotFound = 10,
+}

--- a/packages/contracts/prediction_market_factory/src/events.rs
+++ b/packages/contracts/prediction_market_factory/src/events.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use soroban_sdk::{Address, Env};
 
 pub fn emit_factory_initialized(env: &Env, admin: &Address, outcome_manager: &Address) {

--- a/packages/contracts/prediction_market_factory/src/events.rs
+++ b/packages/contracts/prediction_market_factory/src/events.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{Address, Env};
+
+pub fn emit_factory_initialized(env: &Env, admin: &Address, outcome_manager: &Address) {
+    env.events().publish(
+        ("prediction_market_factory", "initialized"),
+        (admin.clone(), outcome_manager.clone()),
+    );
+}
+
+pub fn emit_market_deployed(
+    env: &Env,
+    call_id: u64,
+    market_address: &Address,
+    creator: &Address,
+    stake_token: &Address,
+    end_ts: u64,
+) {
+    env.events().publish(
+        ("prediction_market_factory", "MarketDeployed"),
+        (
+            call_id,
+            market_address.clone(),
+            creator.clone(),
+            stake_token.clone(),
+            end_ts,
+        ),
+    );
+}

--- a/packages/contracts/prediction_market_factory/src/lib.rs
+++ b/packages/contracts/prediction_market_factory/src/lib.rs
@@ -148,14 +148,7 @@ impl PredictionMarketFactory {
         set_market(&env, call_id, &market_addr);
         append_market_list(&env, &market_addr);
 
-        emit_market_deployed(
-            &env,
-            call_id,
-            &market_addr,
-            &creator,
-            stake_token,
-            *end_ts,
-        );
+        emit_market_deployed(&env, call_id, &market_addr, &creator, stake_token, *end_ts);
 
         Ok(market_addr)
     }
@@ -209,10 +202,7 @@ impl PredictionMarketFactory {
     }
 
     /// Set the trusted outcome manager address (admin only).
-    pub fn set_outcome_manager(
-        env: Env,
-        outcome_manager: Address,
-    ) -> Result<(), FactoryError> {
+    pub fn set_outcome_manager(env: Env, outcome_manager: Address) -> Result<(), FactoryError> {
         let mut config = get_config(&env).ok_or(FactoryError::NotInitialized)?;
         config.admin.require_auth();
         config.outcome_manager = outcome_manager;

--- a/packages/contracts/prediction_market_factory/src/lib.rs
+++ b/packages/contracts/prediction_market_factory/src/lib.rs
@@ -1,0 +1,245 @@
+//! Factory contract that deploys isolated [`prediction_market`] instances.
+//!
+//! Each market is a separate contract deployed from a pre-uploaded WASM hash,
+//! isolating risk and storage pressure compared to the monolithic `call_registry`.
+#![no_std]
+
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use errors::FactoryError;
+use events::{emit_factory_initialized, emit_market_deployed};
+use prediction_market::MarketInitArgs;
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, Map, Vec};
+use storage::*;
+use types::FactoryConfig;
+
+#[cfg(not(test))]
+#[inline]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let sentinel = Address::from_string(&soroban_sdk::String::from_str(
+        env,
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    ));
+    *addr == sentinel
+}
+
+#[cfg(test)]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let key = soroban_sdk::Symbol::new(env, "xlm_sac_addr");
+    if let Some(sentinel) = env.storage().instance().get::<_, Address>(&key) {
+        return *addr == sentinel;
+    }
+    false
+}
+
+fn market_deploy_salt(env: &Env, call_id: u64) -> BytesN<32> {
+    let mut raw = Bytes::from_slice(env, b"market:");
+    raw.append(&Bytes::from_slice(env, &call_id.to_be_bytes()));
+    env.crypto().sha256(&raw).into()
+}
+
+#[contract]
+pub struct PredictionMarketFactory;
+
+#[contractimpl]
+impl PredictionMarketFactory {
+    /// Initialise the factory with admin, outcome manager, and market WASM hash.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        outcome_manager: Address,
+        market_wasm_hash: BytesN<32>,
+        min_stake: i128,
+    ) -> Result<(), FactoryError> {
+        if get_config(&env).is_some() {
+            return Err(FactoryError::AlreadyInitialized);
+        }
+        admin.require_auth();
+
+        let config = FactoryConfig {
+            admin: admin.clone(),
+            outcome_manager: outcome_manager.clone(),
+            market_wasm_hash,
+            min_stake,
+            max_stake_per_user: 0,
+            staking_cutoff_secs: 300,
+            paused: false,
+            whitelisted_tokens: Map::new(&env),
+        };
+        set_config(&env, &config);
+        emit_factory_initialized(&env, &admin, &outcome_manager);
+        Ok(())
+    }
+
+    /// Deploy a new prediction market instance and return its contract address.
+    pub fn deploy_market(
+        env: Env,
+        creator: Address,
+        args: MarketInitArgs,
+    ) -> Result<Address, FactoryError> {
+        creator.require_auth();
+
+        let config = get_config(&env).ok_or(FactoryError::NotInitialized)?;
+        if config.paused {
+            return Err(FactoryError::ContractPaused);
+        }
+
+        let MarketInitArgs {
+            stake_token,
+            stake_amount,
+            start_price,
+            end_ts,
+            token_address: _,
+            pair_id: _,
+            metadata_hash: _,
+            condition: _,
+            outcome_count,
+        } = &args;
+
+        if *stake_amount < config.min_stake || *stake_amount <= 0 {
+            return Err(FactoryError::InvalidStakeAmount);
+        }
+        if *start_price <= 0 {
+            return Err(FactoryError::InvalidStakeAmount);
+        }
+        if *outcome_count < 2 {
+            return Err(FactoryError::InvalidOutcomeCount);
+        }
+        if *end_ts <= env.ledger().timestamp() {
+            return Err(FactoryError::InvalidEndTime);
+        }
+
+        if !is_native_xlm(&env, stake_token)
+            && !config
+                .whitelisted_tokens
+                .get(stake_token.clone())
+                .unwrap_or(false)
+        {
+            return Err(FactoryError::TokenNotWhitelisted);
+        }
+
+        let call_id = next_market_id(&env);
+        let salt = market_deploy_salt(&env, call_id);
+        let factory_addr = env.current_contract_address();
+
+        let market_addr = env
+            .deployer()
+            .with_address(factory_addr.clone(), salt)
+            .deploy_v2(
+                config.market_wasm_hash.clone(),
+                (
+                    call_id,
+                    creator.clone(),
+                    config.outcome_manager.clone(),
+                    factory_addr,
+                    config.min_stake,
+                    config.max_stake_per_user,
+                    config.staking_cutoff_secs,
+                    args.clone(),
+                ),
+            );
+
+        set_market(&env, call_id, &market_addr);
+        append_market_list(&env, &market_addr);
+
+        emit_market_deployed(
+            &env,
+            call_id,
+            &market_addr,
+            &creator,
+            stake_token,
+            *end_ts,
+        );
+
+        Ok(market_addr)
+    }
+
+    /// Return a paginated slice of deployed market addresses.
+    pub fn get_all_markets(env: Env, start: u32, limit: u32) -> Vec<Address> {
+        let list = get_market_list(&env);
+        let total = list.len();
+        let mut result = Vec::new(&env);
+
+        if start >= total {
+            return result;
+        }
+
+        let end = core::cmp::min(start.saturating_add(limit), total);
+        for i in start..end {
+            result.push_back(list.get(i).unwrap());
+        }
+        result
+    }
+
+    /// Return the total number of markets deployed by this factory.
+    pub fn get_market_count(env: Env) -> u32 {
+        storage::get_market_count(&env)
+    }
+
+    /// Look up a market address by its global call ID.
+    pub fn get_market(env: Env, call_id: u64) -> Result<Address, FactoryError> {
+        storage::get_market(&env, call_id).ok_or(FactoryError::MarketNotFound)
+    }
+
+    /// Whitelist a SAC token for use as a stake token in new markets.
+    pub fn whitelist_token(env: Env, token: Address) -> Result<(), FactoryError> {
+        let mut config = get_config(&env).ok_or(FactoryError::NotInitialized)?;
+        config.admin.require_auth();
+        config.whitelisted_tokens.set(token, true);
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    /// Update the market WASM hash (admin only). New deployments use the updated hash.
+    pub fn set_market_wasm_hash(
+        env: Env,
+        market_wasm_hash: BytesN<32>,
+    ) -> Result<(), FactoryError> {
+        let mut config = get_config(&env).ok_or(FactoryError::NotInitialized)?;
+        config.admin.require_auth();
+        config.market_wasm_hash = market_wasm_hash;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    /// Set the trusted outcome manager address (admin only).
+    pub fn set_outcome_manager(
+        env: Env,
+        outcome_manager: Address,
+    ) -> Result<(), FactoryError> {
+        let mut config = get_config(&env).ok_or(FactoryError::NotInitialized)?;
+        config.admin.require_auth();
+        config.outcome_manager = outcome_manager;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    /// Pause new market deployments (admin only).
+    pub fn pause(env: Env) -> Result<(), FactoryError> {
+        let mut config = get_config(&env).ok_or(FactoryError::NotInitialized)?;
+        config.admin.require_auth();
+        config.paused = true;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    /// Unpause market deployments (admin only).
+    pub fn unpause(env: Env) -> Result<(), FactoryError> {
+        let mut config = get_config(&env).ok_or(FactoryError::NotInitialized)?;
+        config.admin.require_auth();
+        config.paused = false;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    /// Return the factory configuration.
+    pub fn get_config(env: Env) -> Result<FactoryConfig, FactoryError> {
+        storage::get_config(&env).ok_or(FactoryError::NotInitialized)
+    }
+}

--- a/packages/contracts/prediction_market_factory/src/storage.rs
+++ b/packages/contracts/prediction_market_factory/src/storage.rs
@@ -1,0 +1,67 @@
+use crate::types::FactoryConfig;
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    MarketCounter,
+    Market(u64),
+    MarketList,
+}
+
+pub fn set_config(env: &Env, config: &FactoryConfig) {
+    env.storage().instance().set(&DataKey::Config, config);
+}
+
+pub fn get_config(env: &Env) -> Option<FactoryConfig> {
+    env.storage().instance().get(&DataKey::Config)
+}
+
+pub fn next_market_id(env: &Env) -> u64 {
+    let counter: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::MarketCounter)
+        .unwrap_or(0);
+    let next_id = counter + 1;
+    env.storage()
+        .instance()
+        .set(&DataKey::MarketCounter, &next_id);
+    next_id
+}
+
+pub fn get_market_count(env: &Env) -> u32 {
+    let counter: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::MarketCounter)
+        .unwrap_or(0);
+    counter as u32
+}
+
+pub fn set_market(env: &Env, call_id: u64, market: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Market(call_id), market);
+}
+
+pub fn get_market(env: &Env, call_id: u64) -> Option<Address> {
+    env.storage().instance().get(&DataKey::Market(call_id))
+}
+
+pub fn append_market_list(env: &Env, market: &Address) {
+    let mut list: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKey::MarketList)
+        .unwrap_or_else(|| Vec::new(env));
+    list.push_back(market.clone());
+    env.storage().instance().set(&DataKey::MarketList, &list);
+}
+
+pub fn get_market_list(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::MarketList)
+        .unwrap_or_else(|| Vec::new(env))
+}

--- a/packages/contracts/prediction_market_factory/src/test.rs
+++ b/packages/contracts/prediction_market_factory/src/test.rs
@@ -13,12 +13,14 @@ use soroban_sdk::{
 };
 
 fn install_market_wasm(env: &Env) -> BytesN<32> {
-    let release_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../target/wasm32-unknown-unknown/release");
-
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let release_unknown = workspace_root.join("target/wasm32-unknown-unknown/release");
+    let release_v1 = workspace_root.join("target/wasm32v1-none/release");
     let candidates = [
-        release_dir.join("prediction_market.optimized.wasm"),
-        release_dir.join("prediction_market.wasm"),
+        release_unknown.join("prediction_market.optimized.wasm"),
+        release_unknown.join("prediction_market.wasm"),
+        release_v1.join("prediction_market.optimized.wasm"),
+        release_v1.join("prediction_market.wasm"),
     ];
 
     let wasm_path = candidates
@@ -28,8 +30,8 @@ fn install_market_wasm(env: &Env) -> BytesN<32> {
             panic!(
                 "missing prediction_market WASM — run:\n  \
                  cargo build --release --target wasm32-unknown-unknown -p prediction-market\n  \
-                 stellar contract optimize --wasm {}/prediction_market.wasm",
-                release_dir.display()
+                 stellar contract optimize --wasm {}/target/wasm32-unknown-unknown/release/prediction_market.wasm",
+                workspace_root.display()
             )
         });
 

--- a/packages/contracts/prediction_market_factory/src/test.rs
+++ b/packages/contracts/prediction_market_factory/src/test.rs
@@ -33,9 +33,8 @@ fn install_market_wasm(env: &Env) -> BytesN<32> {
             )
         });
 
-    let wasm_bytes = std::fs::read(wasm_path).unwrap_or_else(|err| {
-        panic!("failed to read {}: {err}", wasm_path.display())
-    });
+    let wasm_bytes = std::fs::read(wasm_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", wasm_path.display()));
     env.deployer().upload_contract_wasm(wasm_bytes.as_slice())
 }
 

--- a/packages/contracts/prediction_market_factory/src/test.rs
+++ b/packages/contracts/prediction_market_factory/src/test.rs
@@ -14,13 +14,14 @@ use soroban_sdk::{
 
 fn install_market_wasm(env: &Env) -> BytesN<32> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
-    let release_unknown = workspace_root.join("target/wasm32-unknown-unknown/release");
     let release_v1 = workspace_root.join("target/wasm32v1-none/release");
+    let release_unknown = workspace_root.join("target/wasm32-unknown-unknown/release");
+    // Prefer stellar `contract build` / `contract optimize` artifacts. Raw release
+    // wasm32-unknown-unknown binaries may include reference-types on newer rustc.
     let candidates = [
-        release_unknown.join("prediction_market.optimized.wasm"),
-        release_unknown.join("prediction_market.wasm"),
         release_v1.join("prediction_market.optimized.wasm"),
         release_v1.join("prediction_market.wasm"),
+        release_unknown.join("prediction_market.optimized.wasm"),
     ];
 
     let wasm_path = candidates
@@ -28,10 +29,12 @@ fn install_market_wasm(env: &Env) -> BytesN<32> {
         .find(|path| path.exists())
         .unwrap_or_else(|| {
             panic!(
-                "missing prediction_market WASM — run:\n  \
+                "missing Soroban-compatible prediction_market WASM — run:\n  \
+                 cd packages/contracts/prediction_market && stellar contract build\n  \
+                 # or:\n  \
                  cargo build --release --target wasm32-unknown-unknown -p prediction-market\n  \
-                 stellar contract optimize --wasm {}/target/wasm32-unknown-unknown/release/prediction_market.wasm",
-                workspace_root.display()
+                 stellar contract optimize --wasm {}/prediction_market.wasm",
+                release_unknown.display()
             )
         });
 

--- a/packages/contracts/prediction_market_factory/src/test.rs
+++ b/packages/contracts/prediction_market_factory/src/test.rs
@@ -1,0 +1,277 @@
+#![cfg(test)]
+
+extern crate std;
+
+use crate::{PredictionMarketFactory, PredictionMarketFactoryClient};
+use backit_shared::{build_message, OUTCOME_DOWN, OUTCOME_UP};
+use outcome_manager::{OutcomeManager, OutcomeManagerClient, SignedOutcome};
+use prediction_market::{ConditionType, MarketInitArgs, PredictionMarketClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Bytes, BytesN, Env, Vec,
+};
+
+fn install_market_wasm(env: &Env) -> BytesN<32> {
+    let release_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../target/wasm32-unknown-unknown/release");
+
+    let candidates = [
+        release_dir.join("prediction_market.optimized.wasm"),
+        release_dir.join("prediction_market.wasm"),
+    ];
+
+    let wasm_path = candidates
+        .iter()
+        .find(|path| path.exists())
+        .unwrap_or_else(|| {
+            panic!(
+                "missing prediction_market WASM — run:\n  \
+                 cargo build --release --target wasm32-unknown-unknown -p prediction-market\n  \
+                 stellar contract optimize --wasm {}/prediction_market.wasm",
+                release_dir.display()
+            )
+        });
+
+    let wasm_bytes = std::fs::read(wasm_path).unwrap_or_else(|err| {
+        panic!("failed to read {}: {err}", wasm_path.display())
+    });
+    env.deployer().upload_contract_wasm(wasm_bytes.as_slice())
+}
+
+fn default_market_args(env: &Env, stake_token: &Address, end_ts: u64) -> MarketInitArgs {
+    MarketInitArgs {
+        stake_token: stake_token.clone(),
+        stake_amount: 1_000_000,
+        start_price: 100_000_000,
+        end_ts,
+        token_address: stake_token.clone(),
+        pair_id: Bytes::from_slice(env, b"XLM-USDC"),
+        metadata_hash: BytesN::from_array(env, &[1u8; 32]),
+        condition: ConditionType::PercentUp(5),
+        outcome_count: 2,
+    }
+}
+
+fn setup_token(env: &Env, admin: &Address) -> Address {
+    let token = env.register_stellar_asset_contract_v2(admin.clone());
+    let sac = token.address();
+    let stellar = StellarAssetClient::new(env, &sac);
+    stellar.mint(admin, &100_000_000_000);
+    sac
+}
+
+fn gen_keypair(env: &Env) -> (BytesN<32>, BytesN<32>) {
+    use ed25519_dalek::SigningKey;
+    use rand::RngCore;
+
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    let signing_key = SigningKey::from_bytes(&seed);
+    let public_key = signing_key.verifying_key();
+    (
+        BytesN::from_array(env, &seed),
+        BytesN::from_array(env, &public_key.to_bytes()),
+    )
+}
+
+fn sign_outcome(
+    env: &Env,
+    secret: &BytesN<32>,
+    call_id: u64,
+    outcome: u32,
+    price: i128,
+    timestamp: u64,
+) -> BytesN<64> {
+    use ed25519_dalek::{Signer, SigningKey};
+
+    let msg = build_message(env, call_id, outcome, price, timestamp);
+    let mut msg_bytes = [0u8; 128];
+    let msg_len = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_bytes[..msg_len]);
+    let signing_key = SigningKey::from_bytes(&secret.to_array());
+    let signature = signing_key.sign(&msg_bytes[..msg_len]);
+    BytesN::from_array(env, &signature.to_bytes())
+}
+
+struct TestSetup<'a> {
+    env: Env,
+    admin: Address,
+    creator: Address,
+    staker_a: Address,
+    staker_b: Address,
+    token: Address,
+    factory: PredictionMarketFactoryClient<'a>,
+    outcome_mgr: OutcomeManagerClient<'a>,
+    oracle_secret: BytesN<32>,
+    oracle_pubkey: BytesN<32>,
+}
+
+fn setup_full_stack<'a>() -> TestSetup<'a> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let staker_a = Address::generate(&env);
+    let staker_b = Address::generate(&env);
+    let token = setup_token(&env, &admin);
+
+    let market_wasm = install_market_wasm(&env);
+    let factory_id = env.register(PredictionMarketFactory, ());
+    let factory = PredictionMarketFactoryClient::new(&env, &factory_id);
+
+    let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
+    let outcome_id = env.register(OutcomeManager, ());
+    let outcome_mgr = OutcomeManagerClient::new(&env, &outcome_id);
+    let fee_collector = Address::generate(&env);
+
+    let mut oracles = Vec::new(&env);
+    oracles.push_back(oracle_pubkey.clone());
+
+    outcome_mgr.initialize(&admin, &oracles, &1u32, &fee_collector, &100u32, &0u64);
+    factory.initialize(&admin, &outcome_id, &market_wasm, &100_000);
+    factory.whitelist_token(&token);
+    outcome_mgr.set_factory(&factory_id);
+
+    TestSetup {
+        env,
+        admin,
+        creator,
+        staker_a,
+        staker_b,
+        token,
+        factory,
+        outcome_mgr,
+        oracle_secret,
+        oracle_pubkey,
+    }
+}
+
+#[test]
+fn factory_deploy_stake_resolve_payout() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let args = default_market_args(env, &setup.token, end_ts);
+
+    let market_addr = setup.factory.deploy_market(&setup.creator, &args);
+    assert_eq!(setup.factory.get_market_count(), 1);
+
+    let market = PredictionMarketClient::new(env, &market_addr);
+    let call_id = market.get_call_id();
+
+    let token = TokenClient::new(env, &setup.token);
+    token.transfer(&setup.admin, &setup.staker_a, &5_000_000);
+    token.transfer(&setup.admin, &setup.staker_b, &5_000_000);
+
+    market.stake_on_call(&setup.staker_a, &call_id, &2_000_000, &OUTCOME_UP);
+    market.stake_on_call(&setup.staker_b, &call_id, &3_000_000, &OUTCOME_DOWN);
+
+    env.ledger().set_timestamp(end_ts + 1);
+
+    let signed = SignedOutcome {
+        call_id,
+        outcome: OUTCOME_UP,
+        price: 110_000_000,
+        timestamp: end_ts + 1,
+        oracle_pubkey: setup.oracle_pubkey.clone(),
+        signature: sign_outcome(
+            env,
+            &setup.oracle_secret,
+            call_id,
+            OUTCOME_UP,
+            110_000_000,
+            end_ts + 1,
+        ),
+    };
+    setup
+        .outcome_mgr
+        .submit_outcome_for_market(&signed, &end_ts);
+
+    setup.outcome_mgr.mark_settled(&market_addr, &call_id);
+
+    let total_winning = 2_000_000i128;
+    let total_losing = 3_000_000i128;
+    let balance_before = token.balance(&setup.staker_a);
+
+    setup.outcome_mgr.claim_payout_for_market(
+        &call_id,
+        &setup.staker_a,
+        &total_winning,
+        &total_winning,
+        &total_losing,
+    );
+
+    let balance_after = token.balance(&setup.staker_a);
+    assert!(balance_after > balance_before);
+
+    let call = market.get_call(&call_id);
+    assert_eq!(call.outcome, OUTCOME_UP);
+}
+
+#[test]
+fn multiple_concurrent_markets() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    let base_ts = env.ledger().timestamp() + 7200;
+
+    let mut markets = Vec::new(env);
+    for i in 0..3u32 {
+        let end_ts = base_ts + i as u64 * 100;
+        let args = default_market_args(env, &setup.token, end_ts);
+        let addr = setup.factory.deploy_market(&setup.creator, &args);
+        markets.push_back(addr);
+    }
+
+    assert_eq!(setup.factory.get_market_count(), 3);
+    let page = setup.factory.get_all_markets(&0, &10);
+    assert_eq!(page.len(), 3);
+
+    for i in 0..3u32 {
+        let market_addr = markets.get(i).unwrap();
+        let market = PredictionMarketClient::new(env, &market_addr);
+        let call_id = market.get_call_id();
+        assert_eq!(setup.factory.get_market(&call_id), market_addr);
+    }
+}
+
+#[test]
+fn stress_test_twenty_markets() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    let base_ts = env.ledger().timestamp() + 10_000;
+
+    for i in 0..20u64 {
+        let end_ts = base_ts + i;
+        let args = default_market_args(env, &setup.token, end_ts);
+        setup.factory.deploy_market(&setup.creator, &args);
+    }
+
+    assert_eq!(setup.factory.get_market_count(), 20);
+
+    let page_a = setup.factory.get_all_markets(&0, &10);
+    let page_b = setup.factory.get_all_markets(&10, &10);
+    assert_eq!(page_a.len(), 10);
+    assert_eq!(page_b.len(), 10);
+
+    for i in 1..=20u64 {
+        assert!(setup.factory.try_get_market(&i).is_ok());
+    }
+}
+
+#[test]
+fn factory_pagination_bounds() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    let end_ts = env.ledger().timestamp() + 5000;
+
+    for _ in 0..5 {
+        let args = default_market_args(env, &setup.token, end_ts);
+        setup.factory.deploy_market(&setup.creator, &args);
+    }
+
+    assert_eq!(setup.factory.get_all_markets(&100, &10).len(), 0);
+    assert_eq!(setup.factory.get_all_markets(&3, &2).len(), 2);
+}

--- a/packages/contracts/prediction_market_factory/src/types.rs
+++ b/packages/contracts/prediction_market_factory/src/types.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contracttype, Address, BytesN, Map};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct FactoryConfig {
+    pub admin: Address,
+    pub outcome_manager: Address,
+    pub market_wasm_hash: BytesN<32>,
+    pub min_stake: i128,
+    pub max_stake_per_user: i128,
+    pub staking_cutoff_secs: u64,
+    pub paused: bool,
+    pub whitelisted_tokens: Map<Address, bool>,
+}


### PR DESCRIPTION
## Summary

closes #402

Implements the prediction market **factory pattern** on Soroban, replacing the monolithic `call_registry` approach with per-market contract instances for production-scale deployment.

- Add **`prediction_market`** — lightweight single-market contract (stake tracking, escrow, resolution hooks for one market per instance)
- Add **`prediction_market_factory`** — deploys market instances via `deploy_v2` from a pre-uploaded WASM hash, tracks all deployed markets, emits `MarketDeployed`
- Update **`outcome_manager`** — single shared instance works with factory-deployed markets (`set_factory`, `submit_outcome_for_market`, `claim_payout_for_market`, market address validation)
- Add **`FACTORY_PATTERN.md`** — WASM size, deployment cost, and storage analysis vs monolithic registry
- Add Soroban-compatible WASM build config (`.cargo/config.toml`)

## Design decisions

**Shared `outcome_manager` (not per-market):** One oracle quorum layer keyed by global `call_id`; escrow lives in per-market contracts. Lower admin/deploy cost than N outcome managers; trade-off documented in `FACTORY_PATTERN.md`.

## Factory API

| Function | Description |
|----------|-------------|
| `deploy_market(creator, MarketInitArgs)` | Deploys new market from WASM hash; returns market address |
| `get_all_markets(start, limit)` | Paginated enumeration of deployed market addresses |
| `get_market_count()` | Total markets deployed |
| `get_market(call_id)` | Lookup market address by global call ID |

**Event:** `MarketDeployed(call_id, market_address, creator, stake_token, end_ts)`

## Tests

- `prediction_market`: constructor + stake, resolution auth
- `prediction_market_factory`: full E2E (deploy → stake → resolve → payout), concurrent markets, pagination, 20-market stress test

All factory integration tests passing.

## Deploy checklist

1. `cargo build --release --target wasm32-unknown-unknown -p prediction-market`
2. `stellar contract optimize --wasm target/.../prediction_market.wasm`
3. Deploy factory with market WASM hash; `initialize(admin, outcome_manager, wasm_hash, min_stake)`
4. Deploy one `outcome_manager`; `set_factory(factory_address)`
5. Users call `deploy_market` — markets are not deployed directly by users

## Test plan

- [x] `cargo test -p prediction-market -p prediction-market-factory`
- [x] Factory deploy → stake → oracle submit → resolve → claim payout
- [x] Multiple concurrent markets isolated by contract address
- [x] Stress test: 20 markets deployed and enumerated
- [x] `get_all_markets` pagination bounds