### PR TITLE
fix: wire duration enforcement, ThemeProvider, and WebSocketProvider (#360 #364 #365)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - uses: pnpm/action-setup@v2
         with:
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/packages/contracts/call_registry/src/duration.rs
+++ b/packages/contracts/call_registry/src/duration.rs
@@ -1,32 +1,37 @@
-use soroban_sdk::{contracttype, Address, Env};
-use crate::types::ContractConfig;
-use crate::storage::{get_config, set_config};
+use soroban_sdk::{Address, Env, Symbol};
 
 /// Default maximum call duration: 30 days in seconds.
 pub const DEFAULT_MAX_DURATION_SECS: u64 = 2_592_000;
 
-/// Extend ContractConfig with max_duration_secs.
-/// Call this once after initialization to set the constraint.
+const MAX_DURATION_KEY: &str = "max_duration";
+
+/// Set the maximum allowed call duration (admin only). Emits AdminParamsChanged.
 pub fn set_max_duration(env: &Env, admin: Address, max_duration_secs: u64) {
     admin.require_auth();
     assert!(max_duration_secs > 0, "max_duration_secs must be positive");
-
-    // Store as a separate instance key so existing config is unchanged
+    let old = get_max_duration(env);
     env.storage()
         .instance()
-        .set(&crate::storage::DataKey::Config, &max_duration_secs);
+        .set(&Symbol::new(env, MAX_DURATION_KEY), &max_duration_secs);
+    crate::events::emit_admin_params_changed_u64(
+        env,
+        "max_duration_secs",
+        &admin,
+        old,
+        max_duration_secs,
+    );
 }
 
 /// Read the configured max duration, falling back to the default.
 pub fn get_max_duration(env: &Env) -> u64 {
     env.storage()
         .instance()
-        .get::<_, u64>(&crate::storage::DataKey::CallCounter) // placeholder key
+        .get::<_, u64>(&Symbol::new(env, MAX_DURATION_KEY))
         .unwrap_or(DEFAULT_MAX_DURATION_SECS)
 }
 
 /// Assert that `end_ts - now <= max_duration_secs`.
-/// Call this inside `create_call` before persisting the call.
+/// Call this at the top of `create_call` before persisting the call.
 pub fn assert_duration_within_limit(env: &Env, end_ts: u64) {
     let now = env.ledger().timestamp();
     assert!(end_ts > now, "end_ts must be in the future");

--- a/packages/contracts/call_registry/src/fuzz_tests.rs
+++ b/packages/contracts/call_registry/src/fuzz_tests.rs
@@ -310,6 +310,9 @@ fn test_fuzz_large_number_of_iterations() {
 #[test]
 fn test_fuzz_extreme_timestamp_near_max() {
     let (env, client, _admin, _om, stake_token) = setup_fuzz_env();
+    // Ledger timestamp set to 1000; max duration is DEFAULT_MAX_DURATION_SECS = 2_592_000.
+    // All end_ts values must satisfy: end_ts - 1000 <= 2_592_000, i.e. end_ts <= 2_593_000.
+    // Use boundary and near-boundary timestamps within the allowed duration window.
     env.ledger().set_timestamp(1000);
 
     let creator = Address::generate(&env);
@@ -317,7 +320,13 @@ fn test_fuzz_extreme_timestamp_near_max() {
     let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
     let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
 
-    let extreme_timestamps = [u64::MAX - 1, u64::MAX - 100, u64::MAX - 1000, u64::MAX / 2];
+    // Boundary timestamps: exact max, one under max, halfway through max, and 1 second in future
+    let extreme_timestamps = [
+        1000 + 2_592_000,       // exactly at the max duration limit
+        1000 + 2_592_000 - 1,  // one second under the limit
+        1000 + 2_592_000 - 100, // 100 seconds under the limit
+        1000 + 2_592_000 / 2,  // halfway through the max duration
+    ];
 
     for &end_ts in &extreme_timestamps {
         let call = client.create_call(

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -74,6 +74,7 @@ fn transfer_token(env: &Env, stake_token: &Address, from: &Address, to: &Address
 }
 
 mod admin;
+mod duration;
 mod errors;
 mod events;
 mod withdrawal;
@@ -254,6 +255,7 @@ impl CallRegistry {
         if end_ts <= current_timestamp {
             return Err(CallRegistryError::InvalidEndTime);
         }
+        duration::assert_duration_within_limit(&env, end_ts);
 
         let config = get_config(&env).ok_or(CallRegistryError::NotInitialized)?;
         // Native XLM (sentinel address) is always allowed; SAC tokens must be whitelisted.
@@ -779,6 +781,17 @@ impl CallRegistry {
     /// Pass `0` to disable the cutoff.
     pub fn set_staking_cutoff(env: Env, new_cutoff: u64) {
         admin::set_staking_cutoff(env, new_cutoff);
+    }
+
+    /// Set the maximum allowed call duration in seconds (admin only).
+    /// Defaults to 30 days (2_592_000 s). Emits AdminParamsChanged.
+    pub fn set_max_duration(env: Env, admin: Address, max_duration_secs: u64) {
+        duration::set_max_duration(&env, admin, max_duration_secs);
+    }
+
+    /// Get the current maximum allowed call duration in seconds.
+    pub fn get_max_duration(env: Env) -> u64 {
+        duration::get_max_duration(&env)
     }
 
     /// Resolve a call with an outcome (outcome_manager only).

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -3050,4 +3050,90 @@ mod sep10_tests {
         let user = Address::generate(&env);
         assert_eq!(client.get_sep10_home_domain(&user), None);
     }
+
+    // ── Duration enforcement tests ─────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "call duration exceeds maximum allowed")]
+    fn test_create_call_exceeds_max_duration_panics() {
+        let (env, client, admin, _) = setup();
+        let creator = Address::generate(&env);
+        let token = env.register(MockToken, ());
+        let token_addr = Address::from_contract_id(&token);
+
+        client.whitelist_token(&token_addr);
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+
+        // 1 day max, but call runs 2 days → should panic
+        client.set_max_duration(&admin, &86_400u64);
+
+        let end_ts: u64 = 1000 + 2 * 86_400; // 2 days from now
+        let ipfs_cid = Bytes::from_slice(&env, b"QmTest");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let pair_id = Bytes::from_slice(&env, b"BTC/USDC");
+
+        client.create_call(
+            &creator,
+            &crate::types::CallInitArgs {
+                stake_token: token_addr,
+                stake_amount: TEST_MIN_STAKE,
+                start_price: TEST_START_PRICE,
+                end_ts,
+                token_address: Address::generate(&env),
+                pair_id,
+                ipfs_cid,
+                metadata_hash,
+                condition: crate::types::ConditionType::TargetAbove(100_000_000),
+                outcome_count: 2,
+            },
+        );
+    }
+
+    #[test]
+    fn test_create_call_at_exact_max_duration_succeeds() {
+        let (env, client, admin, _) = setup();
+        let creator = Address::generate(&env);
+        let token = env.register(MockToken, ());
+        let token_addr = Address::from_contract_id(&token);
+
+        client.whitelist_token(&token_addr);
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+
+        // 1 day max, call ends exactly at 1 day → should succeed
+        client.set_max_duration(&admin, &86_400u64);
+
+        let end_ts: u64 = 1000 + 86_400;
+        let ipfs_cid = Bytes::from_slice(&env, b"QmTest");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let pair_id = Bytes::from_slice(&env, b"BTC/USDC");
+
+        let call = client.create_call(
+            &creator,
+            &crate::types::CallInitArgs {
+                stake_token: token_addr,
+                stake_amount: TEST_MIN_STAKE,
+                start_price: TEST_START_PRICE,
+                end_ts,
+                token_address: Address::generate(&env),
+                pair_id,
+                ipfs_cid,
+                metadata_hash,
+                condition: crate::types::ConditionType::TargetAbove(100_000_000),
+                outcome_count: 2,
+            },
+        );
+        assert_eq!(call.end_ts, end_ts);
+    }
+
+    #[test]
+    fn test_admin_can_update_max_duration() {
+        let (env, client, admin, _) = setup();
+
+        // Default is 30 days
+        assert_eq!(client.get_max_duration(), 2_592_000u64);
+
+        // Admin updates to 7 days
+        client.set_max_duration(&admin, &604_800u64);
+        assert_eq!(client.get_max_duration(), 604_800u64);
+    }
 }

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -2555,6 +2555,90 @@ mod call_registry {
         assert!(usage.cpu <= GET_CALL_STAKERS_BUDGET_CPU);
         assert!(usage.mem <= GET_CALL_STAKERS_BUDGET_MEM);
     }
+
+    // ── Duration enforcement tests ─────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "call duration exceeds maximum allowed")]
+    fn test_create_call_exceeds_max_duration_panics() {
+        let (env, client, admin, _) = setup();
+        let creator = Address::generate(&env);
+        let token_addr = env.register(MockToken, ());
+
+        client.whitelist_token(&token_addr);
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+
+        // 1 day max, but call runs 2 days → should panic
+        client.set_max_duration(&admin, &86_400u64);
+
+        let end_ts: u64 = 1000 + 2 * 86_400; // 2 days from now
+        let ipfs_cid = Bytes::from_slice(&env, b"QmTest");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let pair_id = Bytes::from_slice(&env, b"BTC/USDC");
+
+        client.create_call(
+            &creator,
+            &crate::types::CallInitArgs {
+                stake_token: token_addr,
+                stake_amount: TEST_MIN_STAKE,
+                start_price: TEST_START_PRICE,
+                end_ts,
+                token_address: Address::generate(&env),
+                pair_id,
+                ipfs_cid,
+                metadata_hash,
+                condition: ConditionType::TargetAbove(100_000_000),
+                outcome_count: 2,
+            },
+        );
+    }
+
+    #[test]
+    fn test_create_call_at_exact_max_duration_succeeds() {
+        let (env, client, admin, _) = setup();
+        let creator = Address::generate(&env);
+        let token_addr = env.register(MockToken, ());
+
+        client.whitelist_token(&token_addr);
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+
+        // 1 day max, call ends exactly at 1 day → should succeed
+        client.set_max_duration(&admin, &86_400u64);
+
+        let end_ts: u64 = 1000 + 86_400;
+        let ipfs_cid = Bytes::from_slice(&env, b"QmTest");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let pair_id = Bytes::from_slice(&env, b"BTC/USDC");
+
+        let call = client.create_call(
+            &creator,
+            &crate::types::CallInitArgs {
+                stake_token: token_addr,
+                stake_amount: TEST_MIN_STAKE,
+                start_price: TEST_START_PRICE,
+                end_ts,
+                token_address: Address::generate(&env),
+                pair_id,
+                ipfs_cid,
+                metadata_hash,
+                condition: ConditionType::TargetAbove(100_000_000),
+                outcome_count: 2,
+            },
+        );
+        assert_eq!(call.end_ts, end_ts);
+    }
+
+    #[test]
+    fn test_admin_can_update_max_duration() {
+        let (env, client, admin, _) = setup();
+
+        // Default is 30 days
+        assert_eq!(client.get_max_duration(), 2_592_000u64);
+
+        // Admin updates to 7 days
+        client.set_max_duration(&admin, &604_800u64);
+        assert_eq!(client.get_max_duration(), 604_800u64);
+    }
 }
 
 // ── Native XLM staking tests ──────────────────────────────────────────────────
@@ -3051,87 +3135,4 @@ mod sep10_tests {
         assert_eq!(client.get_sep10_home_domain(&user), None);
     }
 
-    // ── Duration enforcement tests ─────────────────────────────────────────
-
-    #[test]
-    #[should_panic(expected = "call duration exceeds maximum allowed")]
-    fn test_create_call_exceeds_max_duration_panics() {
-        let (env, client, admin, _) = setup();
-        let creator = Address::generate(&env);
-        let token_addr = env.register(MockToken, ());
-
-        client.whitelist_token(&token_addr);
-        env.ledger().with_mut(|l| l.timestamp = 1000);
-
-        // 1 day max, but call runs 2 days → should panic
-        client.set_max_duration(&admin, &86_400u64);
-
-        let end_ts: u64 = 1000 + 2 * 86_400; // 2 days from now
-        let ipfs_cid = Bytes::from_slice(&env, b"QmTest");
-        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
-        let pair_id = Bytes::from_slice(&env, b"BTC/USDC");
-
-        client.create_call(
-            &creator,
-            &crate::types::CallInitArgs {
-                stake_token: token_addr,
-                stake_amount: TEST_MIN_STAKE,
-                start_price: TEST_START_PRICE,
-                end_ts,
-                token_address: Address::generate(&env),
-                pair_id,
-                ipfs_cid,
-                metadata_hash,
-                condition: crate::types::ConditionType::TargetAbove(100_000_000),
-                outcome_count: 2,
-            },
-        );
-    }
-
-    #[test]
-    fn test_create_call_at_exact_max_duration_succeeds() {
-        let (env, client, admin, _) = setup();
-        let creator = Address::generate(&env);
-        let token_addr = env.register(MockToken, ());
-
-        client.whitelist_token(&token_addr);
-        env.ledger().with_mut(|l| l.timestamp = 1000);
-
-        // 1 day max, call ends exactly at 1 day → should succeed
-        client.set_max_duration(&admin, &86_400u64);
-
-        let end_ts: u64 = 1000 + 86_400;
-        let ipfs_cid = Bytes::from_slice(&env, b"QmTest");
-        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
-        let pair_id = Bytes::from_slice(&env, b"BTC/USDC");
-
-        let call = client.create_call(
-            &creator,
-            &crate::types::CallInitArgs {
-                stake_token: token_addr,
-                stake_amount: TEST_MIN_STAKE,
-                start_price: TEST_START_PRICE,
-                end_ts,
-                token_address: Address::generate(&env),
-                pair_id,
-                ipfs_cid,
-                metadata_hash,
-                condition: crate::types::ConditionType::TargetAbove(100_000_000),
-                outcome_count: 2,
-            },
-        );
-        assert_eq!(call.end_ts, end_ts);
-    }
-
-    #[test]
-    fn test_admin_can_update_max_duration() {
-        let (env, client, admin, _) = setup();
-
-        // Default is 30 days
-        assert_eq!(client.get_max_duration(), 2_592_000u64);
-
-        // Admin updates to 7 days
-        client.set_max_duration(&admin, &604_800u64);
-        assert_eq!(client.get_max_duration(), 604_800u64);
-    }
 }

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -3058,8 +3058,7 @@ mod sep10_tests {
     fn test_create_call_exceeds_max_duration_panics() {
         let (env, client, admin, _) = setup();
         let creator = Address::generate(&env);
-        let token = env.register(MockToken, ());
-        let token_addr = Address::from_contract_id(&token);
+        let token_addr = env.register(MockToken, ());
 
         client.whitelist_token(&token_addr);
         env.ledger().with_mut(|l| l.timestamp = 1000);
@@ -3093,8 +3092,7 @@ mod sep10_tests {
     fn test_create_call_at_exact_max_duration_succeeds() {
         let (env, client, admin, _) = setup();
         let creator = Address::generate(&env);
-        let token = env.register(MockToken, ());
-        let token_addr = Address::from_contract_id(&token);
+        let token_addr = env.register(MockToken, ());
 
         client.whitelist_token(&token_addr);
         env.ledger().with_mut(|l| l.timestamp = 1000);

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -1,17 +1,29 @@
-:root {
+:root,
+[data-theme="light"] {
   --background: #ffffff;
   --foreground: #171717;
+  --bg-primary: #ffffff;
+  --bg-secondary: #f3f4f6;
+  --text-primary: #111827;
+  --text-secondary: #6b7280;
+  --accent: #3b82f6;
+  --border: #e5e7eb;
+  --card-bg: #ffffff;
+  --input-bg: #f9fafb;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-  }
-
-  html {
-    color-scheme: dark;
-  }
+[data-theme="dark"] {
+  --background: #080b14;
+  --foreground: #f1f5f9;
+  --bg-primary: #080b14;
+  --bg-secondary: #0f172a;
+  --text-primary: #f1f5f9;
+  --text-secondary: #94a3b8;
+  --accent: #3b82f6;
+  --border: #1e293b;
+  --card-bg: #0f172a;
+  --input-bg: #1e293b;
+  color-scheme: dark;
 }
 
 html,
@@ -23,6 +35,7 @@ body {
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.3s, color 0.3s;
 }
 
 * {

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -2,6 +2,8 @@ import "./globals.css";
 import { Inter } from "next/font/google";
 import { WalletProvider } from "@/components/WalletContext";
 import { PlatformConfigProvider } from "@/contexts/PlatformConfigContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { WebSocketProvider } from "@/contexts/WebSocketContext";
 import { NavBar } from "@/components/NavBar";
 import { I18nProvider } from "@/components/I18nProvider";
 
@@ -12,6 +14,10 @@ export const metadata = {
   description: "Decentralized prediction markets on Stellar",
 };
 
+const WS_URL =
+  (process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:3001")
+    .replace(/^http/, "ws") + "/ws";
+
 export default function RootLayout({
   children,
 }: {
@@ -20,18 +26,17 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        {/*
-          WalletProvider must wrap everything so any child can call
-          useWalletContext(). NavBar is a Client Component that reads
-          the live wallet address and passes it to NotificationBell.
-        */}
         <I18nProvider>
-          <WalletProvider>
-            <PlatformConfigProvider>
-              <NavBar />
-              <main>{children}</main>
-            </PlatformConfigProvider>
-          </WalletProvider>
+          <ThemeProvider>
+            <WebSocketProvider url={WS_URL}>
+              <WalletProvider>
+                <PlatformConfigProvider>
+                  <NavBar />
+                  <main>{children}</main>
+                </PlatformConfigProvider>
+              </WalletProvider>
+            </WebSocketProvider>
+          </ThemeProvider>
         </I18nProvider>
       </body>
     </html>

--- a/packages/frontend/src/components/ActivityLog.tsx
+++ b/packages/frontend/src/components/ActivityLog.tsx
@@ -2,9 +2,9 @@
 
 import { Participant } from "@/types";
 import { useEffect, useRef, useState } from "react";
+import { useSocket } from "@/contexts/WebSocketContext";
 
 const PAGE_SIZE = 10;
-const POLL_INTERVAL = 15_000;
 
 function timeAgo(timestamp: string) {
   const s = Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000);
@@ -25,29 +25,36 @@ export default function ActivityLog({ participants, callId }: Props) {
   const [entries, setEntries] = useState<Participant[]>(participants.slice(0, 50));
   const [visible, setVisible] = useState(PAGE_SIZE);
   const [newIds, setNewIds] = useState<Set<string>>(new Set());
-  const prevTxHashes = useRef<Set<string>>(new Set(participants.map(p => p.txHash)));
+  const seenTxHashes = useRef<Set<string>>(new Set(participants.map((p) => p.txHash)));
+  const { status, send } = useSocket();
 
+  // Subscribe to call-specific stake events when connected
   useEffect(() => {
-    const poll = setInterval(async () => {
+    if (status === "connected") {
+      send(JSON.stringify({ event: "call:subscribe", data: { callId } }));
+    }
+  }, [status, callId, send]);
+
+  // Listen for real-time stake events via window message relay from WebSocketContext
+  useEffect(() => {
+    function handleMessage(e: MessageEvent) {
       try {
-        const res = await fetch(`/api/calls/${callId}/stakes/recent`);
-        if (!res.ok) return;
-        const fresh: Participant[] = await res.json();
-        const incoming = fresh.filter(p => !prevTxHashes.current.has(p.txHash));
-        if (incoming.length === 0) return;
-
-        incoming.forEach(p => prevTxHashes.current.add(p.txHash));
-        setNewIds(new Set(incoming.map(p => p.txHash)));
-        setEntries(prev => [...incoming, ...prev].slice(0, 50));
-
-        // Clear slide-in highlight after animation completes
-        setTimeout(() => setNewIds(new Set()), 600);
+        const msg = typeof e.data === "string" ? JSON.parse(e.data) : e.data;
+        if (msg.event === "call:stake" && msg.data?.callId === callId) {
+          const incoming: Participant = msg.data.stake;
+          if (seenTxHashes.current.has(incoming.txHash)) return;
+          seenTxHashes.current.add(incoming.txHash);
+          setNewIds(new Set([incoming.txHash]));
+          setEntries((prev) => [incoming, ...prev].slice(0, 50));
+          setTimeout(() => setNewIds(new Set()), 600);
+        }
       } catch {
-        // silently ignore poll errors
+        // ignore non-JSON messages
       }
-    }, POLL_INTERVAL);
+    }
 
-    return () => clearInterval(poll);
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
   }, [callId]);
 
   return (
@@ -86,7 +93,6 @@ export default function ActivityLog({ participants, callId }: Props) {
               >
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2 min-w-0">
-                    {/* Avatar placeholder */}
                     <div className="w-7 h-7 rounded-full bg-gray-200 flex-shrink-0 flex items-center justify-center text-[10px] font-bold text-gray-500">
                       {entry.address.slice(0, 2).toUpperCase()}
                     </div>
@@ -94,9 +100,7 @@ export default function ActivityLog({ participants, callId }: Props) {
                       {entry.address.slice(0, 6)}…{entry.address.slice(-4)}
                     </span>
                     <span className={`flex-shrink-0 text-xs font-bold px-2 py-0.5 rounded-full ${
-                      isUp
-                        ? "bg-green-100 text-green-700"
-                        : "bg-red-100 text-red-700"
+                      isUp ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
                     }`}>
                       {isUp ? "▲ UP" : "▼ DOWN"}
                     </span>
@@ -122,7 +126,7 @@ export default function ActivityLog({ participants, callId }: Props) {
       {visible < entries.length && (
         <div className="px-4 py-3 border-t border-gray-100 text-center">
           <button
-            onClick={() => setVisible(v => Math.min(v + PAGE_SIZE, entries.length))}
+            onClick={() => setVisible((v) => Math.min(v + PAGE_SIZE, entries.length))}
             className="text-sm text-indigo-600 hover:text-indigo-800 font-medium transition-colors"
           >
             Load more ({entries.length - visible} remaining)

--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -6,16 +6,18 @@ import { useRouter } from "next/navigation";
 import { useWalletContext } from "./WalletContext";
 import { ConnectButton } from "./ConnectButton";
 import { NotificationBell } from "./NotificationBell";
-import { Search, Keyboard, TrendingUp } from "lucide-react";
+import { Search, Keyboard, TrendingUp, Sun, Moon } from "lucide-react";
 import { usePlatformConfig } from "@/contexts/PlatformConfigContext";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { KeyboardShortcutsModal } from "@/components/KeyboardShortcutsModal";
 import { SearchBar } from "@/components/SearchBar";
 import { useTranslation } from "react-i18next";
+import { useTheme } from "@/contexts/ThemeContext";
 
 export function NavBar() {
     const { publicKey } = useWalletContext();
     const { config } = usePlatformConfig();
+    const { theme, toggle: toggleTheme } = useTheme();
     const router = useRouter();
     const { t, i18n } = useTranslation();
     const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -96,6 +98,18 @@ export function NavBar() {
                         className="rounded-2xl border border-white/10 bg-white/5 p-2 text-slate-200 transition hover:border-white/20 hover:bg-white/10"
                     >
                         <Keyboard className="h-5 w-5" aria-hidden="true" />
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={toggleTheme}
+                        aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+                        className="rounded-2xl border border-white/10 bg-white/5 p-2 text-slate-200 transition hover:border-white/20 hover:bg-white/10"
+                    >
+                        {theme === "dark"
+                            ? <Sun className="h-5 w-5" aria-hidden="true" />
+                            : <Moon className="h-5 w-5" aria-hidden="true" />
+                        }
                     </button>
 
                     {config && (

--- a/packages/frontend/src/contexts/WebSocketContext.tsx
+++ b/packages/frontend/src/contexts/WebSocketContext.tsx
@@ -32,18 +32,36 @@ export function WebSocketProvider({ url, children }: { url: string; children: Re
         setStatus("connected");
       };
 
+      ws.onmessage = (event) => {
+        // Relay messages to the window so child components can listen
+        window.postMessage(event.data, "*");
+      };
+
       ws.onclose = () => {
         if (cancelled) return;
         setStatus("disconnected");
-        const delay = Math.min(retryDelay.current, 30000);
+        // Reduce reconnection attempts when tab is not visible
+        const base = document.visibilityState === "hidden" ? Math.min(retryDelay.current * 2, 30000) : retryDelay.current;
+        const delay = Math.min(base, 30000);
         retryDelay.current = delay * 2;
         setTimeout(connect, delay);
       };
     }
 
+    // Pause reconnects when tab is hidden, resume when visible
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible" && !wsRef.current || wsRef.current?.readyState === WebSocket.CLOSED) {
+        retryDelay.current = 1000;
+        connect();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     connect();
+
     return () => {
       cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       wsRef.current?.close();
     };
   }, [url]);
@@ -55,7 +73,11 @@ export function WebSocketProvider({ url, children }: { url: string; children: Re
   return (
     <WebSocketContext.Provider value={{ status, send }}>
       {status === "disconnected" && (
-        <div style={{ background: "#f59e0b", color: "#fff", padding: "4px 12px", fontSize: 12 }}>
+        <div
+          role="alert"
+          aria-live="polite"
+          style={{ background: "#f59e0b", color: "#fff", padding: "4px 12px", fontSize: 12 }}
+        >
           Reconnecting...
         </div>
       )}


### PR DESCRIPTION
## Summary

Resolves #360, 
Resolves #364, 
Resolves #365

### #360 - Wire Duration Constraint Enforcement into `create_call`
- Fixed `duration.rs` storage key (was using wrong DataKey as placeholder).
- Calls `assert_duration_within_limit(&env, end_ts)` at the top of `create_call`.
- Added `set_max_duration` / `get_max_duration` contract entry points with AdminParamsChanged event.
- Tests: exceeds max panics, exact max succeeds, admin can update limit.

### #364 - Wire ThemeProvider into Application Root
- Wraps app with ThemeProvider in layout.tsx.
- Sun/moon toggle in NavBar (keyboard accessible, aria-label).
- Full CSS custom properties in globals.css.
- Smooth transition on theme switch.

### #365 - Wire WebSocket Context into Application Root
- Wraps app with WebSocketProvider in layout.tsx.
- Relays server messages via window.postMessage; tab visibility reduces reconnect attempts.
- ActivityLog subscribes to call:stake WebSocket events instead of 15s HTTP polling.