### PR TITLE
feat(backend): market watchlist bookmarking API (#373)

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { SearchModule } from './search/search.module';
 import { UsersModule } from './user/users.module';
+import { BookmarksModule } from './bookmarks/bookmarks.module';
 import { AuthModule } from './auth/auth.module';
 import { AppThrottlerModule } from './throttler/throttler.module';
 import { OracleSigningModule } from './oracle-signing/oracle.module';
@@ -53,6 +54,7 @@ import { LoggerModule } from './common/logger/logger.module';
     NotificationsModule,
     SearchModule,
     UsersModule,
+    BookmarksModule,
     AuthModule,
     AppThrottlerModule,
     OracleSigningModule,

--- a/packages/backend/src/auth/guards/optional-jwt-auth.guard.ts
+++ b/packages/backend/src/auth/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,35 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { AuthService } from '../auth.service';
+
+/**
+ * Like {@link JwtAuthGuard} but never rejects the request. When a valid
+ * `Bearer` token is present it populates `request.user = { address }`;
+ * otherwise the request proceeds anonymously (no `request.user`).
+ *
+ * Used for public endpoints whose response is enriched for authenticated
+ * callers (e.g. adding `isBookmarked` to calls) while remaining accessible to
+ * anonymous visitors.
+ */
+@Injectable()
+export class OptionalJwtAuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers: Record<string, string | undefined>;
+      user?: { address: string };
+    }>();
+    const authHeader = request.headers['authorization'];
+
+    if (authHeader?.startsWith('Bearer ')) {
+      try {
+        const payload = this.authService.validateToken(authHeader.slice(7));
+        request.user = { address: payload.sub };
+      } catch {
+        // Invalid/expired token → treat as anonymous; do not throw.
+      }
+    }
+
+    return true;
+  }
+}

--- a/packages/backend/src/bookmarks/bookmarks.controller.ts
+++ b/packages/backend/src/bookmarks/bookmarks.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Post,
+  Delete,
+  Get,
+  Body,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  DefaultValuePipe,
+  ParseIntPipe,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { BookmarksService } from './bookmarks.service';
+import { CreateBookmarkDto } from './dto/create-bookmark.dto';
+
+@ApiTags('bookmarks')
+@Controller('users')
+export class BookmarksController {
+  constructor(private readonly bookmarksService: BookmarksService) {}
+
+  @Post(':address/bookmarks')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Bookmark a market/call for a user' })
+  @ApiParam({ name: 'address', description: 'Wallet address of the user' })
+  @ApiResponse({ status: 201, description: 'Bookmark created.' })
+  @ApiResponse({ status: 404, description: 'Call not found.' })
+  @ApiResponse({ status: 409, description: 'Market already bookmarked.' })
+  @UsePipes(new ValidationPipe({ whitelist: true }))
+  async addBookmark(
+    @Param('address') address: string,
+    @Body() dto: CreateBookmarkDto,
+  ) {
+    return this.bookmarksService.addBookmark(address, dto.callId);
+  }
+
+  @Delete(':address/bookmarks/:callId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a bookmark' })
+  @ApiParam({ name: 'address', description: 'Wallet address of the user' })
+  @ApiParam({ name: 'callId', description: 'Id of the bookmarked call' })
+  @ApiResponse({ status: 204, description: 'Bookmark removed.' })
+  @ApiResponse({ status: 404, description: 'Bookmark not found.' })
+  async removeBookmark(
+    @Param('address') address: string,
+    @Param('callId') callId: string,
+  ) {
+    await this.bookmarksService.removeBookmark(address, callId);
+  }
+
+  @Get(':address/bookmarks')
+  @ApiOperation({
+    summary: "Paginated list of a user's bookmarked calls (full call data)",
+  })
+  @ApiParam({ name: 'address', description: 'Wallet address of the user' })
+  @ApiResponse({ status: 200, description: 'Bookmarks retrieved.' })
+  async getBookmarks(
+    @Param('address') address: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.bookmarksService.getBookmarks(address, page, limit);
+  }
+}

--- a/packages/backend/src/bookmarks/bookmarks.entity.ts
+++ b/packages/backend/src/bookmarks/bookmarks.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+  Index,
+} from 'typeorm';
+import { Call } from '../calls/entities/call.entity';
+
+/**
+ * A user's saved (bookmarked) market/call. Lets users track markets they are
+ * interested in without staking. Unique per (userAddress, callId) so a market
+ * cannot be bookmarked twice by the same user.
+ */
+@Entity('bookmarks')
+@Unique('UQ_bookmarks_user_call', ['userAddress', 'callId'])
+export class Bookmark {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Wallet address of the user who created the bookmark. */
+  @Index()
+  @Column({ type: 'varchar', length: 64 })
+  userAddress: string;
+
+  /** Id of the bookmarked call (FK to the `calls` table). */
+  @Column({ type: 'uuid' })
+  callId: string;
+
+  /** Joined call data, loaded on demand for the bookmark list. */
+  @ManyToOne(() => Call, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'callId' })
+  call: Call;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/bookmarks/bookmarks.module.ts
+++ b/packages/backend/src/bookmarks/bookmarks.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Bookmark } from './bookmarks.entity';
+import { Call } from '../calls/entities/call.entity';
+import { BookmarksService } from './bookmarks.service';
+import { BookmarksController } from './bookmarks.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Bookmark, Call])],
+  controllers: [BookmarksController],
+  providers: [BookmarksService],
+  exports: [BookmarksService],
+})
+export class BookmarksModule {}

--- a/packages/backend/src/bookmarks/bookmarks.service.spec.ts
+++ b/packages/backend/src/bookmarks/bookmarks.service.spec.ts
@@ -1,0 +1,200 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { BookmarksService } from './bookmarks.service';
+import { Bookmark } from './bookmarks.entity';
+import { Call } from '../calls/entities/call.entity';
+
+const USER = 'GUSER000000000000000000000000000000000000000000000000000';
+const CALL_ID = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
+
+describe('BookmarksService', () => {
+  let service: BookmarksService;
+
+  const bookmarksRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+    findAndCount: jest.fn(),
+    count: jest.fn(),
+    find: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const callsRepo = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookmarksService,
+        { provide: getRepositoryToken(Bookmark), useValue: bookmarksRepo },
+        { provide: getRepositoryToken(Call), useValue: callsRepo },
+      ],
+    }).compile();
+
+    service = module.get<BookmarksService>(BookmarksService);
+  });
+
+  describe('addBookmark', () => {
+    it('creates a bookmark when the call exists and is not already bookmarked', async () => {
+      callsRepo.findOne.mockResolvedValue({ id: CALL_ID });
+      bookmarksRepo.findOne.mockResolvedValue(null);
+      const created = { userAddress: USER, callId: CALL_ID };
+      bookmarksRepo.create.mockReturnValue(created);
+      bookmarksRepo.save.mockResolvedValue({ id: 'bm-1', ...created });
+
+      const result = await service.addBookmark(USER, CALL_ID);
+
+      expect(bookmarksRepo.create).toHaveBeenCalledWith({
+        userAddress: USER,
+        callId: CALL_ID,
+      });
+      expect(bookmarksRepo.save).toHaveBeenCalledWith(created);
+      expect(result).toEqual({ id: 'bm-1', ...created });
+    });
+
+    it('throws NotFoundException when the call does not exist', async () => {
+      callsRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.addBookmark(USER, CALL_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(bookmarksRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException (409) on a duplicate bookmark', async () => {
+      callsRepo.findOne.mockResolvedValue({ id: CALL_ID });
+      bookmarksRepo.findOne.mockResolvedValue({ id: 'bm-existing' });
+
+      await expect(service.addBookmark(USER, CALL_ID)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(bookmarksRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeBookmark', () => {
+    it('removes an existing bookmark', async () => {
+      const bookmark = { id: 'bm-1', userAddress: USER, callId: CALL_ID };
+      bookmarksRepo.findOne.mockResolvedValue(bookmark);
+      bookmarksRepo.remove.mockResolvedValue(bookmark);
+
+      await service.removeBookmark(USER, CALL_ID);
+
+      expect(bookmarksRepo.remove).toHaveBeenCalledWith(bookmark);
+    });
+
+    it('throws NotFoundException when the bookmark does not exist', async () => {
+      bookmarksRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.removeBookmark(USER, CALL_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(bookmarksRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getBookmarks', () => {
+    it('returns a paginated list with joined call data', async () => {
+      const rows = [{ id: 'bm-1', callId: CALL_ID, call: { id: CALL_ID } }];
+      bookmarksRepo.findAndCount.mockResolvedValue([rows, 1]);
+
+      const result = await service.getBookmarks(USER, 2, 10);
+
+      expect(bookmarksRepo.findAndCount).toHaveBeenCalledWith({
+        where: { userAddress: USER },
+        relations: ['call'],
+        order: { createdAt: 'DESC' },
+        skip: 10, // (page 2 - 1) * limit 10
+        take: 10,
+      });
+      expect(result).toEqual({ data: rows, total: 1, page: 2, limit: 10 });
+    });
+
+    it('clamps invalid page/limit to safe defaults', async () => {
+      bookmarksRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.getBookmarks(USER, 0, 0);
+
+      expect(bookmarksRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 20 }),
+      );
+      expect(result).toEqual({ data: [], total: 0, page: 1, limit: 20 });
+    });
+  });
+
+  describe('getBookmarkCount', () => {
+    it('counts bookmarks for a call', async () => {
+      bookmarksRepo.count.mockResolvedValue(5);
+      await expect(service.getBookmarkCount(CALL_ID)).resolves.toBe(5);
+      expect(bookmarksRepo.count).toHaveBeenCalledWith({
+        where: { callId: CALL_ID },
+      });
+    });
+  });
+
+  describe('getBookmarkCounts', () => {
+    it('returns an empty map for an empty input', async () => {
+      await expect(service.getBookmarkCounts([])).resolves.toEqual({});
+      expect(bookmarksRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('aggregates counts per callId', async () => {
+      const qb = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { callId: 'a', count: '3' },
+          { callId: 'b', count: '1' },
+        ]),
+      };
+      bookmarksRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(service.getBookmarkCounts(['a', 'b'])).resolves.toEqual({
+        a: 3,
+        b: 1,
+      });
+    });
+  });
+
+  describe('isBookmarked', () => {
+    it('returns true when a bookmark exists', async () => {
+      bookmarksRepo.count.mockResolvedValue(1);
+      await expect(service.isBookmarked(USER, CALL_ID)).resolves.toBe(true);
+    });
+
+    it('returns false when none exists', async () => {
+      bookmarksRepo.count.mockResolvedValue(0);
+      await expect(service.isBookmarked(USER, CALL_ID)).resolves.toBe(false);
+    });
+
+    it('returns false for an empty/unauthenticated address without querying', async () => {
+      await expect(service.isBookmarked('', CALL_ID)).resolves.toBe(false);
+      expect(bookmarksRepo.count).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getBookmarkedCallIds', () => {
+    it('returns the set of bookmarked callIds for a user', async () => {
+      bookmarksRepo.find.mockResolvedValue([{ callId: 'a' }, { callId: 'c' }]);
+      const result = await service.getBookmarkedCallIds(USER, ['a', 'b', 'c']);
+      expect([...result].sort()).toEqual(['a', 'c']);
+    });
+
+    it('returns an empty set when address or ids are empty', async () => {
+      await expect(service.getBookmarkedCallIds('', ['a'])).resolves.toEqual(
+        new Set(),
+      );
+      await expect(service.getBookmarkedCallIds(USER, [])).resolves.toEqual(
+        new Set(),
+      );
+      expect(bookmarksRepo.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/bookmarks/bookmarks.service.ts
+++ b/packages/backend/src/bookmarks/bookmarks.service.ts
@@ -1,0 +1,139 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Bookmark } from './bookmarks.entity';
+import { Call } from '../calls/entities/call.entity';
+
+export interface PaginatedBookmarks {
+  data: Bookmark[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+@Injectable()
+export class BookmarksService {
+  constructor(
+    @InjectRepository(Bookmark)
+    private readonly bookmarksRepo: Repository<Bookmark>,
+    @InjectRepository(Call)
+    private readonly callsRepo: Repository<Call>,
+  ) {}
+
+  /**
+   * Adds a bookmark for `userAddress` on `callId`.
+   * @throws NotFoundException when the call does not exist.
+   * @throws ConflictException (409) when the bookmark already exists.
+   */
+  async addBookmark(userAddress: string, callId: string): Promise<Bookmark> {
+    const call = await this.callsRepo.findOne({ where: { id: callId } });
+    if (!call) {
+      throw new NotFoundException('Call not found');
+    }
+
+    const existing = await this.bookmarksRepo.findOne({
+      where: { userAddress, callId },
+    });
+    if (existing) {
+      throw new ConflictException('Market already bookmarked');
+    }
+
+    return this.bookmarksRepo.save(
+      this.bookmarksRepo.create({ userAddress, callId }),
+    );
+  }
+
+  /**
+   * Removes a user's bookmark for a call.
+   * @throws NotFoundException when no such bookmark exists.
+   */
+  async removeBookmark(userAddress: string, callId: string): Promise<void> {
+    const bookmark = await this.bookmarksRepo.findOne({
+      where: { userAddress, callId },
+    });
+    if (!bookmark) {
+      throw new NotFoundException('Bookmark not found');
+    }
+    await this.bookmarksRepo.remove(bookmark);
+  }
+
+  /**
+   * Paginated list of a user's bookmarks with full joined call data,
+   * most-recent first.
+   */
+  async getBookmarks(
+    userAddress: string,
+    page = 1,
+    limit = 20,
+  ): Promise<PaginatedBookmarks> {
+    const safePage = page < 1 ? 1 : page;
+    const safeLimit = limit < 1 ? 20 : limit;
+
+    const [data, total] = await this.bookmarksRepo.findAndCount({
+      where: { userAddress },
+      relations: ['call'],
+      order: { createdAt: 'DESC' },
+      skip: (safePage - 1) * safeLimit,
+      take: safeLimit,
+    });
+
+    return { data, total, page: safePage, limit: safeLimit };
+  }
+
+  /** Number of users who have bookmarked a call. */
+  async getBookmarkCount(callId: string): Promise<number> {
+    return this.bookmarksRepo.count({ where: { callId } });
+  }
+
+  /** Bookmark counts for several calls at once, keyed by callId. */
+  async getBookmarkCounts(callIds: string[]): Promise<Record<string, number>> {
+    const counts: Record<string, number> = {};
+    if (callIds.length === 0) {
+      return counts;
+    }
+    const rows = await this.bookmarksRepo
+      .createQueryBuilder('bookmark')
+      .select('bookmark.callId', 'callId')
+      .addSelect('COUNT(*)', 'count')
+      .where('bookmark.callId IN (:...callIds)', { callIds })
+      .groupBy('bookmark.callId')
+      .getRawMany<{ callId: string; count: string }>();
+    for (const row of rows) {
+      counts[row.callId] = Number(row.count);
+    }
+    return counts;
+  }
+
+  /** Whether `userAddress` has bookmarked `callId`. */
+  async isBookmarked(userAddress: string, callId: string): Promise<boolean> {
+    if (!userAddress) {
+      return false;
+    }
+    const count = await this.bookmarksRepo.count({
+      where: { userAddress, callId },
+    });
+    return count > 0;
+  }
+
+  /**
+   * Subset of `callIds` that `userAddress` has bookmarked. Useful for tagging a
+   * list of calls with `isBookmarked` in a single query.
+   */
+  async getBookmarkedCallIds(
+    userAddress: string,
+    callIds: string[],
+  ): Promise<Set<string>> {
+    if (!userAddress || callIds.length === 0) {
+      return new Set();
+    }
+    const rows = await this.bookmarksRepo.find({
+      where: { userAddress, callId: In(callIds) },
+      select: ['callId'],
+    });
+    return new Set(rows.map((row) => row.callId));
+  }
+}

--- a/packages/backend/src/bookmarks/dto/create-bookmark.dto.ts
+++ b/packages/backend/src/bookmarks/dto/create-bookmark.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class CreateBookmarkDto {
+  @ApiProperty({
+    description: 'Id of the call/market to bookmark',
+    example: '7c9e6679-7425-40de-944b-e07fc1f90ae7',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  callId: string;
+}

--- a/packages/backend/src/calls/calls.controller.ts
+++ b/packages/backend/src/calls/calls.controller.ts
@@ -23,24 +23,89 @@ import { ReportCallDto } from './dto/report-call.dto';
 import { QueryCallsDto } from './dto/query-calls.dto';
 import { PrepareCallDto } from './dto/prepare-call.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
+import { BookmarksService } from '../bookmarks/bookmarks.service';
+
+interface Paginated<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+/** Request after JwtAuthGuard — the authenticated user is always present. */
+interface AuthedRequest {
+  user: { address: string };
+}
+
+/** Request after OptionalJwtAuthGuard — user present only when authenticated. */
+interface OptionalAuthedRequest {
+  user?: { address: string };
+}
 
 @ApiTags('calls')
 @Controller('calls')
 export class CallsController {
-  constructor(private readonly callsService: CallsService) {}
+  constructor(
+    private readonly callsService: CallsService,
+    private readonly bookmarksService: BookmarksService,
+  ) {}
 
   @Get('feed')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({ summary: 'Get paginated feed of visible calls' })
   @ApiResponse({ status: 200, description: 'Feed returned successfully' })
-  getFeed(@Query() query: QueryCallsDto) {
-    return this.callsService.getFeed(query);
+  async getFeed(
+    @Query() query: QueryCallsDto,
+    @Request() req: OptionalAuthedRequest,
+  ) {
+    const result = await this.callsService.getFeed(query);
+    return this.withBookmarkInfo(result, req.user?.address);
   }
 
   @Get('search')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({ summary: 'Search calls by title or description' })
   @ApiResponse({ status: 200, description: 'Search results returned' })
-  search(@Query() query: QueryCallsDto) {
-    return this.callsService.search(query);
+  async search(
+    @Query() query: QueryCallsDto,
+    @Request() req: OptionalAuthedRequest,
+  ) {
+    const result = await this.callsService.search(query);
+    return this.withBookmarkInfo(result, req.user?.address);
+  }
+
+  /**
+   * Enriches a paginated call list with `bookmarkCount` (always) and, when the
+   * request is authenticated, `isBookmarked` for the viewer. Both are computed
+   * in two batched queries so the frontend needs no extra round-trips.
+   */
+  private async withBookmarkInfo<T extends { id: string }>(
+    result: Paginated<T>,
+    viewerAddress?: string,
+  ): Promise<Paginated<T & { bookmarkCount: number; isBookmarked?: boolean }>> {
+    const calls = result?.data ?? [];
+    if (calls.length === 0) {
+      return result as Paginated<
+        T & { bookmarkCount: number; isBookmarked?: boolean }
+      >;
+    }
+
+    const ids = calls.map((call) => call.id);
+    const counts = await this.bookmarksService.getBookmarkCounts(ids);
+    const bookmarkedIds = viewerAddress
+      ? await this.bookmarksService.getBookmarkedCallIds(viewerAddress, ids)
+      : null;
+
+    const data = calls.map((call) => ({
+      ...call,
+      bookmarkCount: counts[call.id] ?? 0,
+      ...(bookmarkedIds ? { isBookmarked: bookmarkedIds.has(call.id) } : {}),
+    }));
+
+    return { ...result, data };
   }
 
   @Post('prepare')
@@ -75,7 +140,7 @@ export class CallsController {
   reportCall(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: ReportCallDto,
-    @Request() req: any,
+    @Request() req: AuthedRequest,
   ) {
     return this.callsService.reportCall(id, req.user.address, dto);
   }

--- a/packages/backend/src/calls/calls.module.ts
+++ b/packages/backend/src/calls/calls.module.ts
@@ -6,9 +6,10 @@ import { CallsRepository } from './calls.repository';
 import { Call } from './entities/call.entity';
 import { CallReport } from './entities/call-report.entity';
 import { IpfsService } from '../storage/ipfs.service';
+import { BookmarksModule } from '../bookmarks/bookmarks.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Call, CallReport])],
+  imports: [TypeOrmModule.forFeature([Call, CallReport]), BookmarksModule],
   controllers: [CallsController],
   providers: [CallsService, CallsRepository, IpfsService],
   exports: [CallsService, CallsRepository],


### PR DESCRIPTION
Adds a dedicated bookmarks module so users can save markets/calls without staking.

- bookmarks.entity.ts: Bookmark { id, userAddress, callId, createdAt } with a unique (userAddress, callId) constraint and a ManyToOne join to Call.
- bookmarks.service.ts: addBookmark (404 if call missing, 409 on duplicate), removeBookmark (404 if absent), getBookmarks (paginated, joined call data), plus getBookmarkCount/getBookmarkCounts/isBookmarked/getBookmarkedCallIds.
- bookmarks.controller.ts: POST /users/:address/bookmarks, DELETE /users/:address/bookmarks/:callId, GET /users/:address/bookmarks.
- feed/search now include `bookmarkCount` always and `isBookmarked` when authenticated (two batched queries) via a new OptionalJwtAuthGuard.
- Registered BookmarksModule; CallsModule imports it.

Tests: bookmarks.service.spec.ts (15 cases) all pass; production build and eslint clean on changed files.
closes #373 