### PR TITLE
feat(frontend): market watchlist bookmarking UI (#374)

### DIFF
--- a/packages/frontend/src/app/feed/page.tsx
+++ b/packages/frontend/src/app/feed/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import FeedTabs from "@/components/FeedTabs";
+import FeedTabs, { type FeedTab } from "@/components/FeedTabs";
+import BookmarkedFeed from "@/components/BookmarkedFeed";
 import { CallCardSkeleton } from "@/components/CardCallSkeleton";
 import { EmptyState } from "@/components/EmptyState";
 import CallCard from "@/components/CallCard";
@@ -14,7 +15,7 @@ import { ArrowUp, LayoutList, LayoutGrid } from "lucide-react";
 type ViewMode = "list" | "grid";
 
 export default function FeedPage() {
-  const [tab, setTab] = useState<"for-you" | "following">("for-you");
+  const [tab, setTab] = useState<FeedTab>("for-you");
   const [filters, setFilters] = useState<{ status: string | null }>({ status: null });
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     if (typeof window !== "undefined") {
@@ -23,7 +24,13 @@ export default function FeedPage() {
     return "list";
   });
 
-  const { items, loading, loadingMore, hasMore, loadMore } = useFeed(tab, filters);
+  // The "bookmarked" tab is rendered by <BookmarkedFeed/>; keep useFeed on a
+  // valid feed type so it never requests an unsupported feed.
+  const feedTab = tab === "bookmarked" ? "for-you" : tab;
+  const { items, loading, loadingMore, hasMore, loadMore } = useFeed(
+    feedTab,
+    filters
+  );
 
   const cacheKey = `${tab}-${filters.status || 'all'}`;
   const { triggerRef, showBackToTop, scrollToTop } = useInfiniteScroll({
@@ -87,6 +94,10 @@ export default function FeedPage() {
       <FeedTabs active={tab} onChange={setTab} />
       <FilterBar onFilterChange={handleFilterChange} />
 
+      {tab === "bookmarked" && <BookmarkedFeed />}
+
+      {tab !== "bookmarked" && (
+        <>
       {loading && (
         <div className={effectiveView === "grid" ? "grid grid-cols-2 xl:grid-cols-3 gap-4 mt-4" : "space-y-4 mt-4"}>
           {[...Array(6)].map((_, i) => (
@@ -132,6 +143,8 @@ export default function FeedPage() {
         <div className="text-center text-gray-500 py-8 font-medium">
           No more markets
         </div>
+      )}
+        </>
       )}
 
       {/* Back to Top button */}

--- a/packages/frontend/src/app/profile/[address]/page.tsx
+++ b/packages/frontend/src/app/profile/[address]/page.tsx
@@ -9,6 +9,7 @@ import ProfileHeader from '@/components/ProfileHeader'
 import ProfileHeaderSkeleton from '@/components/skeletons/ProfileHeaderSkeleton'
 import ProfileStats from '@/components/ProfileStats'
 import ProfileTabs from '@/components/ProfileTabs'
+import BookmarkedFeed from '@/components/BookmarkedFeed'
 import { ProfileEditor } from '@/components/ProfileEditor'
 
 const PAGE_SIZE = 20
@@ -574,6 +575,13 @@ export default function StakesPage() {
               onLoadMoreFollowing={handleLoadMoreFollowing}
               onFollowToggle={handleFollowToggle}
             />
+
+            <section className="mt-8">
+              <h2 className="text-lg font-bold text-gray-900 mb-3">
+                Bookmarked Markets
+              </h2>
+              <BookmarkedFeed address={address} />
+            </section>
           </>
         )}
 

--- a/packages/frontend/src/components/BookmarkButton.tsx
+++ b/packages/frontend/src/components/BookmarkButton.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { Bookmark } from "lucide-react";
+import { useWalletContext } from "./WalletContext";
+import { addBookmark, removeBookmark } from "@/lib/api";
+
+interface BookmarkButtonProps {
+  callId: string;
+  /** Initial bookmark state (e.g. `call.isBookmarked` from an authed request). */
+  initialBookmarked?: boolean;
+  /** Initial saved count (e.g. `call.bookmarkCount`). */
+  initialCount?: number;
+  /** Show the "N saved" count next to the icon. */
+  showCount?: boolean;
+  className?: string;
+}
+
+/**
+ * Accessible bookmark toggle with optimistic UI. The icon fills immediately on
+ * click and reverts if the API call fails. Keyboard navigable (native button)
+ * with an aria-label and aria-pressed that describe the toggle state.
+ */
+export default function BookmarkButton({
+  callId,
+  initialBookmarked = false,
+  initialCount = 0,
+  showCount = true,
+  className = "",
+}: BookmarkButtonProps) {
+  const { publicKey } = useWalletContext();
+  const [bookmarked, setBookmarked] = useState(initialBookmarked);
+  const [count, setCount] = useState(initialCount);
+  const [pending, setPending] = useState(false);
+
+  const toggle = async (e: React.MouseEvent) => {
+    // CallCard is wrapped in a Link — don't navigate when toggling.
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!publicKey || pending) return;
+
+    const nextBookmarked = !bookmarked;
+
+    // Optimistic update.
+    setBookmarked(nextBookmarked);
+    setCount((c) => Math.max(0, c + (nextBookmarked ? 1 : -1)));
+    setPending(true);
+
+    try {
+      if (nextBookmarked) {
+        await addBookmark(publicKey, callId);
+      } else {
+        await removeBookmark(publicKey, callId);
+      }
+    } catch {
+      // Revert on error.
+      setBookmarked(!nextBookmarked);
+      setCount((c) => Math.max(0, c + (nextBookmarked ? -1 : 1)));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const label = !publicKey
+    ? "Connect a wallet to bookmark this market"
+    : bookmarked
+      ? "Remove bookmark"
+      : "Bookmark this market";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={!publicKey || pending}
+      aria-label={label}
+      aria-pressed={bookmarked}
+      title={label}
+      className={`inline-flex items-center gap-1 text-sm transition-colors disabled:opacity-50 ${
+        bookmarked ? "text-indigo-600" : "text-gray-500 hover:text-indigo-600"
+      } ${className}`}
+    >
+      <Bookmark
+        className="w-4 h-4"
+        fill={bookmarked ? "currentColor" : "none"}
+        aria-hidden="true"
+      />
+      {showCount && (
+        <span className="tabular-nums">
+          {count} <span className="sr-only">markets </span>saved
+        </span>
+      )}
+    </button>
+  );
+}

--- a/packages/frontend/src/components/BookmarkedFeed.tsx
+++ b/packages/frontend/src/components/BookmarkedFeed.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import CallCard from "./CallCard";
+import { CallCardSkeleton } from "./CardCallSkeleton";
+import { EmptyState } from "./EmptyState";
+import { useWalletContext } from "./WalletContext";
+import { fetchBookmarks } from "@/lib/api";
+
+type BookmarkedCall = Record<string, unknown> & { id: string };
+
+/**
+ * Renders the connected user's bookmarked markets. Handles the wallet-not-
+ * connected, loading, empty, and error states required by the bookmark UI.
+ */
+export default function BookmarkedFeed({ address }: { address?: string } = {}) {
+  const { publicKey } = useWalletContext();
+  // Use the explicit profile address when provided, otherwise the connected user.
+  const targetAddress = address ?? publicKey;
+  const [items, setItems] = useState<BookmarkedCall[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!targetAddress) return;
+    let active = true;
+    setLoading(true);
+    setError(null);
+    fetchBookmarks(targetAddress)
+      .then((res) => {
+        if (!active) return;
+        const calls = res.data
+          .map((bookmark) => bookmark.call)
+          .filter((call): call is BookmarkedCall => Boolean(call));
+        setItems(calls);
+      })
+      .catch(() => {
+        if (active) setError("Failed to load your bookmarked markets.");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [targetAddress]);
+
+  if (!targetAddress) {
+    return (
+      <EmptyState text="Connect your wallet to see your bookmarked markets." />
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-4 mt-4">
+        {[...Array(4)].map((_, i) => (
+          <CallCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center text-red-600 py-8 font-medium">{error}</div>
+    );
+  }
+
+  if (items.length === 0) {
+    return <EmptyState text="No bookmarked markets yet" />;
+  }
+
+  return (
+    <div className="space-y-4 mt-4">
+      {items.map((call) => (
+        <Link key={call.id} href={`/calls/${call.id}`} className="block">
+          <CallCard call={call} />
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/CallCard.tsx
+++ b/packages/frontend/src/components/CallCard.tsx
@@ -3,6 +3,7 @@
 import StakeBar from "./StakeBar";
 import ShareButton from "./ShareButton";
 import CountdownTimer from "./CountdownTimer";
+import BookmarkButton from "./BookmarkButton";
 
 interface CallCardProps {
   call: any;
@@ -93,6 +94,11 @@ export default function CallCard({ call }: CallCardProps) {
             <div className="text-xs text-gray-500">Participants</div>
             <div className="text-sm font-medium">{call.participants || 0}</div>
           </div>
+          <BookmarkButton
+            callId={call.id}
+            initialBookmarked={call.isBookmarked ?? false}
+            initialCount={call.bookmarkCount ?? 0}
+          />
           <ShareButton
             marketTitle={call.condition || call.title || "Market"}
             marketId={call.id}

--- a/packages/frontend/src/components/CallDetail.tsx
+++ b/packages/frontend/src/components/CallDetail.tsx
@@ -13,6 +13,7 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useWalletContext } from "./WalletContext";
 import ClaimPayout from "./ClaimPayout";
 import PriceAlertToggle from "./PriceAlertToggle";
+import BookmarkButton from "./BookmarkButton";
 
 interface UserPosition {
   stake: number;
@@ -74,6 +75,18 @@ export default function CallDetail({ call }: { call: CallDetailData }) {
         {/* Left column - Main content */}
         <div className="lg:col-span-2 space-y-8">
           <CallDetailHeader call={call} timeLeft={timeLeft} odds={odds} />
+
+          <div className="flex justify-end">
+            <BookmarkButton
+              callId={String(call.id)}
+              initialBookmarked={
+                (call as { isBookmarked?: boolean }).isBookmarked ?? false
+              }
+              initialCount={
+                (call as { bookmarkCount?: number }).bookmarkCount ?? 0
+              }
+            />
+          </div>
 
           {/* Historical Price Chart */}
           <PriceChart

--- a/packages/frontend/src/components/FeedTabs.tsx
+++ b/packages/frontend/src/components/FeedTabs.tsx
@@ -2,25 +2,33 @@
 
 import clsx from "clsx";
 
+export type FeedTab = "for-you" | "following" | "bookmarked";
+
+const TABS: { id: FeedTab; label: string }[] = [
+  { id: "for-you", label: "For You" },
+  { id: "following", label: "Following" },
+  { id: "bookmarked", label: "Bookmarked" },
+];
+
 export default function FeedTabs({
   active,
   onChange,
 }: {
-  active: "for-you" | "following";
-  onChange: (tab: "for-you" | "following") => void;
+  active: FeedTab;
+  onChange: (tab: FeedTab) => void;
 }) {
   return (
     <div className="flex border-b mb-4">
-      {["for-you", "following"].map((tab) => (
+      {TABS.map((tab) => (
         <button
-          key={tab}
+          key={tab.id}
           className={clsx(
             "flex-1 p-3 text-sm font-medium",
-            active === tab ? "border-b-2 border-black" : "text-gray-400"
+            active === tab.id ? "border-b-2 border-black" : "text-gray-400"
           )}
-          onClick={() => onChange(tab as any)}
+          onClick={() => onChange(tab.id)}
         >
-          {tab === "for-you" ? "For You" : "Following"}
+          {tab.label}
         </button>
       ))}
     </div>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -128,3 +128,74 @@ export async function markNotificationsRead(
   if (!res.ok) throw new Error("Failed to mark notifications as read");
   return res.json();
 }
+
+// ── Bookmarks (#374) ─────────────────────────────────────────────────────────
+
+export interface BookmarkRecord {
+  id: string;
+  userAddress: string;
+  callId: string;
+  createdAt: string;
+  // Joined call data returned by GET /users/:address/bookmarks
+  call?: Record<string, unknown> & { id: string };
+}
+
+export interface PaginatedBookmarks {
+  data: BookmarkRecord[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+/** Add a bookmark for `address` on `callId`. POST /users/:address/bookmarks */
+export async function addBookmark(
+  address: string,
+  callId: string
+): Promise<void> {
+  const res = await fetch(
+    `${BACKEND_URL}/users/${encodeURIComponent(address)}/bookmarks`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ callId }),
+    }
+  );
+  // 409 means it is already bookmarked — treat as success (idempotent toggle).
+  if (!res.ok && res.status !== 409) {
+    throw new Error("Failed to add bookmark");
+  }
+}
+
+/** Remove a bookmark. DELETE /users/:address/bookmarks/:callId */
+export async function removeBookmark(
+  address: string,
+  callId: string
+): Promise<void> {
+  const res = await fetch(
+    `${BACKEND_URL}/users/${encodeURIComponent(address)}/bookmarks/${encodeURIComponent(callId)}`,
+    { method: "DELETE" }
+  );
+  // 404 means it was not bookmarked — treat as success (idempotent toggle).
+  if (!res.ok && res.status !== 404) {
+    throw new Error("Failed to remove bookmark");
+  }
+}
+
+/** Paginated list of a user's bookmarked calls (with joined call data). */
+export async function fetchBookmarks(
+  address: string,
+  page = 1,
+  limit = 20
+): Promise<PaginatedBookmarks> {
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+  const res = await fetch(
+    `${BACKEND_URL}/users/${encodeURIComponent(address)}/bookmarks?${params.toString()}`
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch bookmarks");
+  }
+  return res.json() as Promise<PaginatedBookmarks>;
+}


### PR DESCRIPTION
Adds a visual way to bookmark markets and view saved markets, backed by the bookmarking API (#373).

- BookmarkButton: accessible (native button, aria-label + aria-pressed), optimistic toggle — the icon fills immediately and reverts on API error; optional "N saved" count; no-op/disabled when no wallet is connected.
- api.ts: addBookmark / removeBookmark (idempotent on 409/404) and fetchBookmarks (paginated, joined call data).
- CallCard: bookmark button + saved count, using call.isBookmarked / call.bookmarkCount from the feed response.
- CallDetail: bookmark button in the header row.
- FeedTabs: new "Bookmarked" tab.
- BookmarkedFeed: reusable list of a user's bookmarks with loading, empty ("No bookmarked markets yet"), error, and wallet-not-connected states. Used by the feed's Bookmarked tab (connected user) and the profile page (by address).
- Profile page: "Bookmarked Markets" section.

Verified: type-check (tsc --noEmit) and lint (eslint src) clean on changed files.
closes #374 