### PR TITLE
feat(backend): market "closing soon" notification cron job (#375)

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,4 +1,6 @@
 import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { CacheModule } from '@nestjs/cache-manager';
@@ -29,6 +31,8 @@ import { LoggerModule } from './common/logger/logger.module';
   imports: [
     ConfigModule.forRoot({ isGlobal: true, envFilePath: '.env' }),
     CacheModule.register({ isGlobal: true }),
+    ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot(),
     LoggerModule,
     TypeOrmModule.forRoot({
       type: 'postgres',

--- a/packages/backend/src/calls/entities/call.entity.ts
+++ b/packages/backend/src/calls/entities/call.entity.ts
@@ -44,6 +44,13 @@ export class Call {
   })
   status: CallStatus;
 
+  /**
+   * Scheduled close/expiry time of the market. Used by the "closing soon"
+   * notification cron (#375) to find open calls approaching their deadline.
+   */
+  @Column({ type: 'timestamp', nullable: true })
+  endsAt: Date | null;
+
   // ─── resolution ───────────────────────────────────────────────────────────
 
   @Column({ type: 'timestamp', nullable: true })

--- a/packages/backend/src/notifications/closing-soon.service.spec.ts
+++ b/packages/backend/src/notifications/closing-soon.service.spec.ts
@@ -1,0 +1,171 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ClosingSoonService } from './closing-soon.service';
+import { Call, CallStatus } from '../calls/entities/call.entity';
+import { Stake } from '../analytics/entities/stake.entity';
+import { NotificationsService } from './notifications.service';
+import { NotificationPreferencesService } from './notification-preferences.service';
+import { NotificationType } from './notification-type.enum';
+
+const NOW = new Date('2026-01-01T12:00:00.000Z');
+
+function makeCall(minutesLeft: number, overrides: Partial<Call> = {}): Call {
+  return {
+    id: `call-${minutesLeft}`,
+    title: 'BTC > 100k',
+    status: CallStatus.OPEN,
+    endsAt: new Date(NOW.getTime() + minutesLeft * 60_000),
+    totalYesStake: '30',
+    totalNoStake: '10',
+    ...overrides,
+  } as Call;
+}
+
+function makeStake(userAddress: string, position: 'YES' | 'NO'): Stake {
+  return {
+    id: `s-${userAddress}`,
+    callId: 'x',
+    userAddress,
+    position,
+  } as Stake;
+}
+
+describe('ClosingSoonService', () => {
+  let service: ClosingSoonService;
+
+  const callsRepo = { find: jest.fn() };
+  const stakesRepo = { find: jest.fn() };
+  const notificationsService = { createNotification: jest.fn() };
+  const preferencesService = { checkPreference: jest.fn() };
+  const eventEmitter = { emit: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    preferencesService.checkPreference.mockResolvedValue(true);
+    stakesRepo.find.mockResolvedValue([]);
+    callsRepo.find.mockResolvedValue([]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClosingSoonService,
+        { provide: getRepositoryToken(Call), useValue: callsRepo },
+        { provide: getRepositoryToken(Stake), useValue: stakesRepo },
+        { provide: NotificationsService, useValue: notificationsService },
+        {
+          provide: NotificationPreferencesService,
+          useValue: preferencesService,
+        },
+        { provide: EventEmitter2, useValue: eventEmitter },
+      ],
+    }).compile();
+
+    service = module.get(ClosingSoonService);
+  });
+
+  it('notifies stakers of a call closing in the standard (1h) window', async () => {
+    callsRepo.find.mockResolvedValue([makeCall(45)]);
+    stakesRepo.find.mockResolvedValue([makeStake('GUSER1', 'YES')]);
+
+    await service.handleClosingSoon(NOW);
+
+    expect(notificationsService.createNotification).toHaveBeenCalledWith(
+      'GUSER1',
+      NotificationType.CALL_CLOSING,
+      "Call 'BTC > 100k' ends in 45 minutes — your stake is on UP.",
+      'call-45',
+    );
+  });
+
+  it('maps a NO position to DOWN and fires the urgent (<=15m) wave', async () => {
+    callsRepo.find.mockResolvedValue([makeCall(10)]);
+    stakesRepo.find.mockResolvedValue([makeStake('GUSER2', 'NO')]);
+
+    await service.handleClosingSoon(NOW);
+
+    expect(notificationsService.createNotification).toHaveBeenCalledWith(
+      'GUSER2',
+      NotificationType.CALL_CLOSING,
+      expect.stringContaining('your stake is on DOWN'),
+      'call-10',
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'call.closing-soon',
+      expect.objectContaining({
+        wave: 'urgent',
+        minutesLeft: 10,
+        position: 'DOWN',
+        oddsRatio: 3,
+      }),
+    );
+  });
+
+  it('emits call.closing-soon with odds + position for WebSocket broadcast', async () => {
+    callsRepo.find.mockResolvedValue([makeCall(30)]);
+    stakesRepo.find.mockResolvedValue([makeStake('GUSER3', 'YES')]);
+
+    await service.handleClosingSoon(NOW);
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'call.closing-soon',
+      expect.objectContaining({
+        callId: 'call-30',
+        userAddress: 'GUSER3',
+        wave: 'standard',
+        oddsRatio: 3,
+        position: 'UP',
+      }),
+    );
+  });
+
+  it('deduplicates: the same user+call+wave is not alerted twice', async () => {
+    callsRepo.find.mockResolvedValue([makeCall(30)]);
+    stakesRepo.find.mockResolvedValue([makeStake('GUSER4', 'YES')]);
+
+    await service.handleClosingSoon(NOW);
+    await service.handleClosingSoon(NOW); // second run, same window
+
+    expect(notificationsService.createNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips users who disabled CALL_CLOSING notifications', async () => {
+    callsRepo.find.mockResolvedValue([makeCall(30)]);
+    stakesRepo.find.mockResolvedValue([makeStake('GUSER5', 'YES')]);
+    preferencesService.checkPreference.mockResolvedValue(false);
+
+    await service.handleClosingSoon(NOW);
+
+    expect(notificationsService.createNotification).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('sends both waves across time as a call approaches expiry', async () => {
+    const stakes = [makeStake('GUSER6', 'YES')];
+    stakesRepo.find.mockResolvedValue(stakes);
+
+    // First run: 40 minutes out → standard wave.
+    callsRepo.find.mockResolvedValue([makeCall(40, { id: 'call-x' })]);
+    await service.handleClosingSoon(NOW);
+
+    // Later run: 8 minutes out → urgent wave (distinct dedupe key).
+    callsRepo.find.mockResolvedValue([
+      makeCall(8, {
+        id: 'call-x',
+        endsAt: new Date(NOW.getTime() + 8 * 60_000),
+      }),
+    ]);
+    await service.handleClosingSoon(NOW);
+
+    expect(notificationsService.createNotification).toHaveBeenCalledTimes(2);
+    const waves = (eventEmitter.emit.mock.calls as unknown[][]).map(
+      (c) => (c[1] as { wave: string }).wave,
+    );
+    expect(waves).toEqual(['standard', 'urgent']);
+  });
+
+  it('does nothing when no calls are closing soon', async () => {
+    callsRepo.find.mockResolvedValue([]);
+    await service.handleClosingSoon(NOW);
+    expect(notificationsService.createNotification).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/notifications/closing-soon.service.ts
+++ b/packages/backend/src/notifications/closing-soon.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, Repository } from 'typeorm';
+import { Call, CallStatus } from '../calls/entities/call.entity';
+import { Stake } from '../analytics/entities/stake.entity';
+import { NotificationsService } from './notifications.service';
+import { NotificationPreferencesService } from './notification-preferences.service';
+import { NotificationType } from './notification-type.enum';
+import { NotificationChannel } from './notification-channel.enum';
+
+/** Window before close in which the first (standard) alert fires. */
+const CLOSING_WINDOW_MINUTES = 60;
+/** Threshold at/below which the second (urgent) alert fires. */
+const URGENT_WINDOW_MINUTES = 15;
+
+type AlertWave = 'standard' | 'urgent';
+
+export interface ClosingSoonEvent {
+  callId: string;
+  title: string;
+  userAddress: string;
+  position: 'UP' | 'DOWN';
+  minutesLeft: number;
+  oddsRatio: number;
+  wave: AlertWave;
+}
+
+@Injectable()
+export class ClosingSoonService {
+  private readonly logger = new Logger(ClosingSoonService.name);
+
+  /**
+   * Remembers `${callId}:${user}:${wave}` alerts already sent so the same
+   * closing alert is never sent twice for the same user + call + wave.
+   */
+  private readonly sentAlerts = new Set<string>();
+
+  constructor(
+    @InjectRepository(Call)
+    private readonly callsRepo: Repository<Call>,
+    @InjectRepository(Stake)
+    private readonly stakesRepo: Repository<Stake>,
+    private readonly notificationsService: NotificationsService,
+    private readonly preferencesService: NotificationPreferencesService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /** Runs every 5 minutes; dispatches closing-soon alerts. */
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async handleClosingSoon(now: Date = new Date()): Promise<void> {
+    const horizon = new Date(now.getTime() + CLOSING_WINDOW_MINUTES * 60_000);
+
+    const calls = await this.callsRepo.find({
+      where: {
+        status: CallStatus.OPEN,
+        endsAt: Between(now, horizon),
+      },
+    });
+
+    for (const call of calls) {
+      try {
+        await this.processCall(call, now);
+      } catch (err) {
+        this.logger.error(
+          `Failed processing closing-soon for call ${call.id}`,
+          err as Error,
+        );
+      }
+    }
+  }
+
+  private async processCall(call: Call, now: Date): Promise<void> {
+    if (!call.endsAt) return;
+
+    const minutesLeft = Math.max(
+      0,
+      Math.round((new Date(call.endsAt).getTime() - now.getTime()) / 60_000),
+    );
+    // Urgent (15-min) wave for high urgency, otherwise the standard 1-hour wave.
+    const wave: AlertWave =
+      minutesLeft <= URGENT_WINDOW_MINUTES ? 'urgent' : 'standard';
+    const oddsRatio = this.computeOddsRatio(call);
+
+    const stakes = await this.stakesRepo.find({ where: { callId: call.id } });
+
+    for (const stake of stakes) {
+      const key = `${call.id}:${stake.userAddress}:${wave}`;
+      if (this.sentAlerts.has(key)) continue; // dedupe
+
+      // Respect user preferences — skip if CALL_CLOSING is disabled.
+      const enabled = await this.preferencesService.checkPreference(
+        stake.userAddress,
+        NotificationType.CALL_CLOSING,
+        NotificationChannel.IN_APP,
+      );
+      if (!enabled) {
+        this.sentAlerts.add(key); // don't re-check every run
+        continue;
+      }
+
+      const position: 'UP' | 'DOWN' = stake.position === 'YES' ? 'UP' : 'DOWN';
+      const message = `Call '${call.title}' ends in ${minutesLeft} minutes — your stake is on ${position}.`;
+
+      await this.notificationsService.createNotification(
+        stake.userAddress,
+        NotificationType.CALL_CLOSING,
+        message,
+        call.id,
+      );
+
+      const payload: ClosingSoonEvent = {
+        callId: call.id,
+        title: call.title,
+        userAddress: stake.userAddress,
+        position,
+        minutesLeft,
+        oddsRatio,
+        wave,
+      };
+      this.eventEmitter.emit('call.closing-soon', payload);
+
+      this.sentAlerts.add(key);
+    }
+  }
+
+  /** Current odds ratio (YES stake : NO stake). Returns 0 when no NO stake. */
+  private computeOddsRatio(call: Call): number {
+    const yes = Number(call.totalYesStake ?? 0);
+    const no = Number(call.totalNoStake ?? 0);
+    if (no <= 0) return 0;
+    return Number((yes / no).toFixed(4));
+  }
+}

--- a/packages/backend/src/notifications/notification-type.enum.ts
+++ b/packages/backend/src/notifications/notification-type.enum.ts
@@ -5,4 +5,6 @@ export enum NotificationType {
   NEW_FOLLOWER = 'NEW_FOLLOWER',
   CALL_RESOLVED = 'CALL_RESOLVED',
   STAKE_UPDATE = 'STAKE_UPDATE',
+  /** A call/market the user staked on is about to close (#375). */
+  CALL_CLOSING = 'CALL_CLOSING',
 }

--- a/packages/backend/src/notifications/notifications.module.ts
+++ b/packages/backend/src/notifications/notifications.module.ts
@@ -7,14 +7,26 @@ import { NotificationPreferencesService } from './notification-preferences.servi
 import { NotificationsController } from './notifications.controller';
 import { NotificationPreferencesController } from './notification-preferences.controller';
 import { ExternalDispatcherModule } from './external-dispatcher/external-dispatcher.module';
+import { ClosingSoonService } from './closing-soon.service';
+import { Call } from '../calls/entities/call.entity';
+import { Stake } from '../analytics/entities/stake.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([NotificationEntity, NotificationPreference]),
+    TypeOrmModule.forFeature([
+      NotificationEntity,
+      NotificationPreference,
+      Call,
+      Stake,
+    ]),
     ExternalDispatcherModule,
   ],
   controllers: [NotificationsController, NotificationPreferencesController],
-  providers: [NotificationsService, NotificationPreferencesService],
+  providers: [
+    NotificationsService,
+    NotificationPreferencesService,
+    ClosingSoonService,
+  ],
   exports: [NotificationsService, NotificationPreferencesService],
 })
 export class NotificationsModule {}


### PR DESCRIPTION
Adds a scheduled service that alerts stakers before a market they backed closes.

- closing-soon.service.ts: @Cron(EVERY_5_MINUTES) finds OPEN calls with endsAt within the next hour. For each, loads all stakes and notifies each staker: "Call '{title}' ends in X minutes — your stake is on {UP/DOWN}."
  * Two waves: a standard alert inside the 1-hour window and a second urgent alert at <=15 minutes (distinct dedupe keys).
  * Respects preferences — skips users who disabled CALL_CLOSING (IN_APP).
  * Emits `call.closing-soon` via EventEmitter2 for WebSocket broadcast, with the current odds ratio (YES:NO) and the user's position in the payload.
  * Deduplicates per user+call+wave so the same alert is never sent twice.
- notification-type.enum.ts: add CALL_CLOSING.
- call.entity.ts: add `endsAt` (the deadline the cron filters on; the entity previously had no scheduled-close field).
- Register ScheduleModule.forRoot() + EventEmitterModule.forRoot(); wire the service + Call/Stake repos into NotificationsModule.

Tests: closing-soon.service.spec.ts (7 cases) — standard & urgent waves, UP/DOWN mapping, odds in event payload, dedupe, preference skip, two-wave progression across time offsets, no-op when nothing is closing. All pass; production build + eslint clean on changed files.

closes #375 