### PR TITLE
Feature/price alert system api

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -141,7 +141,8 @@ jobs:
 
       - name: Run Database Migrations
         if: steps.backend_changes.outputs.backend_relevant == 'true'
-        run: pnpm --filter backend typeorm migration:run
+        working-directory: packages/backend
+        run: node -r tsconfig-paths/register ./node_modules/typeorm/cli.js --dataSource dist/database/data-source.js migration:run
 
       - name: Run Backend Startup Smoke Test
         if: steps.backend_changes.outputs.backend_relevant == 'true'

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -139,6 +139,10 @@ jobs:
         if: steps.backend_changes.outputs.backend_relevant == 'true'
         run: pnpm --filter backend build
 
+      - name: Run Database Migrations
+        if: steps.backend_changes.outputs.backend_relevant == 'true'
+        run: pnpm --filter backend typeorm migration:run
+
       - name: Run Backend Startup Smoke Test
         if: steps.backend_changes.outputs.backend_relevant == 'true'
         run: |

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -139,11 +139,6 @@ jobs:
         if: steps.backend_changes.outputs.backend_relevant == 'true'
         run: pnpm --filter backend build
 
-      - name: Run Database Migrations
-        if: steps.backend_changes.outputs.backend_relevant == 'true'
-        working-directory: packages/backend
-        run: node -r tsconfig-paths/register ./node_modules/typeorm/cli.js --dataSource dist/database/data-source.js migration:run
-
       - name: Run Backend Startup Smoke Test
         if: steps.backend_changes.outputs.backend_relevant == 'true'
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1456,7 +1456,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3901,7 +3900,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3914,7 +3912,6 @@
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
       "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
       "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4229,7 +4226,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5859,7 +5855,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -5941,7 +5936,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5955,7 +5949,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6169,7 +6162,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
       "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -6178,7 +6170,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
       "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6907,7 +6898,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7111,7 +7102,6 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7143,7 +7133,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7165,7 +7154,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7179,7 +7167,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7193,7 +7180,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -7477,7 +7463,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7716,7 +7701,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -7800,7 +7784,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -7831,7 +7815,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -8291,7 +8274,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8552,7 +8534,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8563,7 +8544,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8686,7 +8666,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8709,7 +8689,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10227,7 +10206,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -10290,7 +10269,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
       "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10311,7 +10289,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -10642,7 +10619,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -10765,7 +10742,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -10869,7 +10845,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true
     },
@@ -10897,7 +10872,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10936,7 +10910,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11078,7 +11051,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -11088,7 +11061,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11099,7 +11071,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -11108,7 +11079,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -11175,7 +11146,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11491,7 +11461,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -13387,7 +13356,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13416,7 +13384,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13430,7 +13397,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13444,7 +13410,6 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -13455,7 +13420,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -14252,7 +14216,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -14283,7 +14247,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14297,7 +14260,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14311,7 +14273,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -14319,7 +14280,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14338,7 +14298,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14352,7 +14311,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -14360,7 +14318,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
       "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
@@ -14374,7 +14331,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14388,7 +14344,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -14396,7 +14351,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14410,7 +14364,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14424,7 +14377,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -14432,7 +14384,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14446,7 +14397,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14460,7 +14410,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -14892,7 +14841,6 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14934,7 +14882,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14973,7 +14920,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15014,7 +14960,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
       "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15299,7 +15244,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15408,7 +15352,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15795,7 +15739,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16164,7 +16107,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -16172,7 +16114,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16802,7 +16743,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16832,7 +16772,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -16849,7 +16789,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -17107,7 +17047,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -17449,7 +17388,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -17560,7 +17498,6 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17576,7 +17513,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17718,7 +17654,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
       "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -17732,7 +17667,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -17746,7 +17680,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -19844,7 +19777,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -19855,7 +19787,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -20471,7 +20402,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "author": "",
-  "private": true,
+  "private": true, 
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json --forceExit --detectOpenHandles",
-    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js --dataSource src/database/data-source.ts",
+    "typeorm": "TS_NODE_ESM=false ts-node -r tsconfig-paths/register --compiler-options '{\"module\":\"commonjs\"}' ./node_modules/typeorm/cli.js --dataSource src/database/data-source.ts",
     "typeorm:generate": "npm run typeorm -- migration:generate",
     "typeorm:run": "npm run typeorm -- migration:run",
     "typeorm:revert": "npm run typeorm -- migration:revert",
@@ -142,6 +142,12 @@
         "lines": 80,
         "statements": 80
       }
+    }
+  },
+  "ts-node": {
+    "esm": false,
+    "compilerOptions": {
+      "module": "commonjs"
     }
   }
 }

--- a/packages/backend/src/activity/activity.controller.ts
+++ b/packages/backend/src/activity/activity.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, Query, ParseIntPipe, DefaultValuePipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
 import { ActivityService } from './activity.service';
 import { ActivityType } from './entities/activity.entity';
 

--- a/packages/backend/src/activity/activity.service.ts
+++ b/packages/backend/src/activity/activity.service.ts
@@ -11,7 +11,11 @@ export class ActivityService {
     private readonly activityRepo: Repository<Activity>,
   ) {}
 
-  async createActivity(userAddress: string, type: ActivityType, metadata: any) {
+  async createActivity(
+    userAddress: string,
+    type: ActivityType,
+    metadata: Record<string, unknown>,
+  ) {
     const activity = this.activityRepo.create({ userAddress, type, metadata });
     return this.activityRepo.save(activity);
   }
@@ -38,33 +42,52 @@ export class ActivityService {
   }
 
   @OnEvent('call.created')
-  handleCallCreated(payload: any) {
-    this.createActivity(payload.creatorAddress, ActivityType.CALL_CREATED, {
-      callId: payload.id,
-      title: payload.title,
-    });
+  async handleCallCreated(payload: {
+    id: string;
+    creatorAddress: string;
+    title: string;
+  }): Promise<void> {
+    await this.createActivity(
+      payload.creatorAddress,
+      ActivityType.CALL_CREATED,
+      { callId: payload.id, title: payload.title },
+    );
   }
 
   @OnEvent('stake.created')
-  handleStakePlaced(payload: any) {
-    this.createActivity(payload.userAddress, ActivityType.STAKE_PLACED, {
+  async handleStakePlaced(payload: {
+    userAddress: string;
+    callId: string;
+    amount: number;
+  }): Promise<void> {
+    await this.createActivity(payload.userAddress, ActivityType.STAKE_PLACED, {
       callId: payload.callId,
       amount: payload.amount,
     });
   }
 
   @OnEvent('payout.claimed')
-  handlePayoutClaimed(payload: any) {
-    this.createActivity(payload.userAddress, ActivityType.PAYOUT_CLAIMED, {
-      callId: payload.callId,
-      amount: payload.amount,
-    });
+  async handlePayoutClaimed(payload: {
+    userAddress: string;
+    callId: string;
+    amount: number;
+  }): Promise<void> {
+    await this.createActivity(
+      payload.userAddress,
+      ActivityType.PAYOUT_CLAIMED,
+      { callId: payload.callId, amount: payload.amount },
+    );
   }
 
   @OnEvent('user.followed')
-  handleNewFollower(payload: any) {
-    this.createActivity(payload.followingAddress, ActivityType.NEW_FOLLOWER, {
-      followerAddress: payload.followerAddress,
-    });
+  async handleNewFollower(payload: {
+    followingAddress: string;
+    followerAddress: string;
+  }): Promise<void> {
+    await this.createActivity(
+      payload.followingAddress,
+      ActivityType.NEW_FOLLOWER,
+      { followerAddress: payload.followerAddress },
+    );
   }
 }

--- a/packages/backend/src/activity/activity.service.ts
+++ b/packages/backend/src/activity/activity.service.ts
@@ -16,8 +16,14 @@ export class ActivityService {
     return this.activityRepo.save(activity);
   }
 
-  async getUserActivity(userAddress: string, page = 1, limit = 20, type?: ActivityType) {
-    const query = this.activityRepo.createQueryBuilder('activity')
+  async getUserActivity(
+    userAddress: string,
+    page = 1,
+    limit = 20,
+    type?: ActivityType,
+  ) {
+    const query = this.activityRepo
+      .createQueryBuilder('activity')
       .where('activity.userAddress = :userAddress', { userAddress })
       .orderBy('activity.createdAt', 'DESC')
       .skip((page - 1) * limit)
@@ -33,21 +39,32 @@ export class ActivityService {
 
   @OnEvent('call.created')
   handleCallCreated(payload: any) {
-    this.createActivity(payload.creatorAddress, ActivityType.CALL_CREATED, { callId: payload.id, title: payload.title });
+    this.createActivity(payload.creatorAddress, ActivityType.CALL_CREATED, {
+      callId: payload.id,
+      title: payload.title,
+    });
   }
 
   @OnEvent('stake.created')
   handleStakePlaced(payload: any) {
-    this.createActivity(payload.userAddress, ActivityType.STAKE_PLACED, { callId: payload.callId, amount: payload.amount });
+    this.createActivity(payload.userAddress, ActivityType.STAKE_PLACED, {
+      callId: payload.callId,
+      amount: payload.amount,
+    });
   }
 
   @OnEvent('payout.claimed')
   handlePayoutClaimed(payload: any) {
-    this.createActivity(payload.userAddress, ActivityType.PAYOUT_CLAIMED, { callId: payload.callId, amount: payload.amount });
+    this.createActivity(payload.userAddress, ActivityType.PAYOUT_CLAIMED, {
+      callId: payload.callId,
+      amount: payload.amount,
+    });
   }
 
   @OnEvent('user.followed')
   handleNewFollower(payload: any) {
-    this.createActivity(payload.followingAddress, ActivityType.NEW_FOLLOWER, { followerAddress: payload.followerAddress });
+    this.createActivity(payload.followingAddress, ActivityType.NEW_FOLLOWER, {
+      followerAddress: payload.followerAddress,
+    });
   }
 }

--- a/packages/backend/src/activity/entities/activity.entity.ts
+++ b/packages/backend/src/activity/entities/activity.entity.ts
@@ -1,4 +1,9 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
 
 export enum ActivityType {
   CALL_CREATED = 'CALL_CREATED',

--- a/packages/backend/src/alerts/alerts.controller.ts
+++ b/packages/backend/src/alerts/alerts.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Post, Delete, Param, Body } from '@nestjs/common';
+import { AlertsService } from './alerts.service';
+import { CreateAlertDto } from './dto/create-alert.dto';
+import { AlertResponseDto } from './dto/alert-response.dto';
+import { PriceAlert } from './alerts.entity';
+
+@Controller('users/:address/alerts')
+export class AlertsController {
+  constructor(private readonly alertsService: AlertsService) {}
+
+  @Post()
+  create(
+    @Param('address') address: string,
+    @Body() dto: CreateAlertDto,
+  ): Promise<PriceAlert> {
+    return this.alertsService.createAlert(address, dto);
+  }
+
+  @Get()
+  list(@Param('address') address: string): Promise<AlertResponseDto[]> {
+    return this.alertsService.listActiveAlerts(address);
+  }
+
+  @Delete(':id')
+  remove(
+    @Param('address') address: string,
+    @Param('id') id: string,
+  ): Promise<void> {
+    return this.alertsService.removeAlert(address, id);
+  }
+}

--- a/packages/backend/src/alerts/alerts.entity.ts
+++ b/packages/backend/src/alerts/alerts.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum AlertDirection {
+  ABOVE = 'ABOVE',
+  BELOW = 'BELOW',
+}
+
+/**
+ * A user-configured price alert tied to a specific call/token pair.
+ * Polled by AlertsScheduler; once triggered it is left in place (triggered=true)
+ * rather than deleted, so it still shows up in history / doesn't re-fire.
+ */
+@Entity('price_alerts')
+@Index(['userAddress', 'triggered'])
+@Index(['tokenPair', 'triggered'])
+export class PriceAlert {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 128 })
+  @Index()
+  userAddress: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  callId: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  tokenPair: string;
+
+  @Column({ type: 'decimal', precision: 24, scale: 10 })
+  targetPrice: number;
+
+  @Column({ type: 'enum', enum: AlertDirection })
+  direction: AlertDirection;
+
+  @Column({ type: 'boolean', default: false })
+  triggered: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/alerts/alerts.entity.ts
+++ b/packages/backend/src/alerts/alerts.entity.ts
@@ -17,8 +17,6 @@ export enum AlertDirection {
  * rather than deleted, so it still shows up in history / doesn't re-fire.
  */
 @Entity('price_alerts')
-@Index(['userAddress', 'triggered'])
-@Index(['tokenPair', 'triggered'])
 export class PriceAlert {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/packages/backend/src/alerts/alerts.module.ts
+++ b/packages/backend/src/alerts/alerts.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PriceAlert } from './alerts.entity';
+import { AlertsService } from './alerts.service';
+import { AlertsController } from './alerts.controller';
+import { AlertsScheduler } from './alerts.scheduler';
+import { CallsModule } from '../calls/calls.module';
+import { BookmarksModule } from '../bookmarks/bookmarks.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { TokensModule } from 'src/token/tokens.module';
+import { StakesModule } from 'src/stakes/stakes.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PriceAlert]),
+    CallsModule,
+    StakesModule,
+    BookmarksModule,
+    TokensModule,
+    NotificationsModule,
+  ],
+  controllers: [AlertsController],
+  providers: [AlertsService, AlertsScheduler],
+  exports: [AlertsService],
+})
+export class AlertsModule {}

--- a/packages/backend/src/alerts/alerts.scheduler.ts
+++ b/packages/backend/src/alerts/alerts.scheduler.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PriceAlert } from './alerts.entity';
+import { isPriceNearTarget } from './alerts.utils';
+import { TokensService } from '../token/tokens.service';
+import { CallsService } from '../calls/calls.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/notification-type.enum';
+
+@Injectable()
+export class AlertsScheduler {
+  private readonly logger = new Logger(AlertsScheduler.name);
+
+  constructor(
+    @InjectRepository(PriceAlert)
+    private readonly alertsRepo: Repository<PriceAlert>,
+    private readonly tokensService: TokensService,
+    private readonly callsService: CallsService,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  // Every 60 seconds. Using an explicit cron string rather than
+  // CronExpression.EVERY_MINUTE for clarity that this is a polling interval,
+  // not "top of every minute" semantics.
+  @Cron('*/60 * * * * *', { name: 'price-alert-poll' })
+  async checkAlerts(): Promise<void> {
+    const activeAlerts = await this.alertsRepo.find({
+      where: { triggered: false },
+    });
+    if (activeAlerts.length === 0) return;
+
+    const uniquePairs = [...new Set(activeAlerts.map((a) => a.tokenPair))];
+    const priceByPair = await this.fetchPrices(uniquePairs);
+
+    for (const alert of activeAlerts) {
+      const currentPrice = priceByPair.get(alert.tokenPair);
+      if (currentPrice === undefined) continue;
+
+      if (isPriceNearTarget(currentPrice, Number(alert.targetPrice))) {
+        await this.triggerAlert(alert, currentPrice);
+      }
+    }
+  }
+
+  private async fetchPrices(
+    tokenPairs: string[],
+  ): Promise<Map<string, number>> {
+    const priceByPair = new Map<string, number>();
+
+    await Promise.all(
+      tokenPairs.map(async (pair) => {
+        try {
+          const { priceUsd } = await this.tokensService.getPairPrice(pair);
+          if (priceUsd > 0) {
+            priceByPair.set(pair, priceUsd);
+          }
+        } catch (err) {
+          this.logger.warn(
+            `Failed to fetch price for ${pair}: ${(err as Error).message}`,
+          );
+        }
+      }),
+    );
+
+    return priceByPair;
+  }
+
+  private async triggerAlert(
+    alert: PriceAlert,
+    currentPrice: number,
+  ): Promise<void> {
+    const call = await this.callsService
+      .getCallOrThrow(alert.callId)
+      .catch(() => null);
+    const callTitle = call?.title ?? alert.tokenPair;
+    const target = Number(alert.targetPrice);
+    const message = `${callTitle} (${alert.tokenPair}) is near your target of $${target} — current price $${currentPrice}`;
+
+    await this.notificationsService.notify(
+      alert.userAddress,
+      NotificationType.PRICE_ALERT_TRIGGERED,
+      message,
+      alert.callId,
+    );
+
+    alert.triggered = true;
+    await this.alertsRepo.save(alert);
+  }
+}

--- a/packages/backend/src/alerts/alerts.service.spec.ts
+++ b/packages/backend/src/alerts/alerts.service.spec.ts
@@ -1,0 +1,176 @@
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { AlertsService } from './alerts.service';
+import { AlertDirection, PriceAlert } from './alerts.entity';
+
+describe('AlertsService', () => {
+  let service: AlertsService;
+  let alertsRepo: any;
+  let callsService: any;
+  let stakesService: any;
+  let bookmarksService: any;
+
+  const userAddress = 'GABC123';
+  const baseAlert: PriceAlert = {
+    id: 'alert-1',
+    userAddress,
+    callId: 'call-1',
+    tokenPair: 'XLM/USDC',
+    targetPrice: 0.5,
+    direction: AlertDirection.ABOVE,
+    triggered: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  beforeEach(() => {
+    alertsRepo = {
+      create: jest.fn((data) => ({ ...data })),
+      save: jest.fn((alert) => Promise.resolve({ id: 'alert-1', ...alert })),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    callsService = {
+      getCallOrThrow: jest.fn(),
+    };
+
+    stakesService = {
+      hasStake: jest.fn(),
+    };
+
+    bookmarksService = {
+      isBookmarked: jest.fn(),
+    };
+
+    service = new AlertsService(
+      alertsRepo,
+      callsService,
+      stakesService,
+      bookmarksService,
+    );
+  });
+
+  describe('createAlert', () => {
+    const dto = {
+      callId: 'call-1',
+      tokenPair: 'XLM/USDC',
+      targetPrice: 0.5,
+      direction: AlertDirection.ABOVE,
+    };
+
+    it('throws NotFoundException when the call does not exist', async () => {
+      callsService.getCallOrThrow.mockRejectedValue(
+        new NotFoundException('Call not found'),
+      );
+
+      await expect(service.createAlert(userAddress, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(stakesService.hasStake).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user has neither stake nor bookmark', async () => {
+      callsService.getCallOrThrow.mockResolvedValue({
+        id: 'call-1',
+        title: 'BTC to 100k',
+      });
+      stakesService.hasStake.mockResolvedValue(false);
+      bookmarksService.isBookmarked.mockResolvedValue(false);
+
+      await expect(service.createAlert(userAddress, dto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(alertsRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('creates the alert when the user has a stake', async () => {
+      callsService.getCallOrThrow.mockResolvedValue({
+        id: 'call-1',
+        title: 'BTC to 100k',
+      });
+      stakesService.hasStake.mockResolvedValue(true);
+      bookmarksService.isBookmarked.mockResolvedValue(false);
+
+      const result = await service.createAlert(userAddress, dto);
+
+      expect(alertsRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userAddress,
+          callId: dto.callId,
+          triggered: false,
+        }),
+      );
+      expect(alertsRepo.save).toHaveBeenCalled();
+      expect(result).toMatchObject({ callId: 'call-1', userAddress });
+    });
+
+    it('creates the alert when the user has only a bookmark', async () => {
+      callsService.getCallOrThrow.mockResolvedValue({
+        id: 'call-1',
+        title: 'BTC to 100k',
+      });
+      stakesService.hasStake.mockResolvedValue(false);
+      bookmarksService.isBookmarked.mockResolvedValue(true);
+
+      await expect(
+        service.createAlert(userAddress, dto),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('removeAlert', () => {
+    it('removes an alert owned by the user', async () => {
+      alertsRepo.findOne.mockResolvedValue(baseAlert);
+
+      await service.removeAlert(userAddress, 'alert-1');
+
+      expect(alertsRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'alert-1', userAddress },
+      });
+      expect(alertsRepo.remove).toHaveBeenCalledWith(baseAlert);
+    });
+
+    it('throws NotFoundException when the alert does not exist or is not owned by the user', async () => {
+      alertsRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.removeAlert(userAddress, 'nope')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(alertsRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listActiveAlerts', () => {
+    it('returns only non-triggered alerts with joined call details', async () => {
+      alertsRepo.find.mockResolvedValue([baseAlert]);
+      callsService.getCallOrThrow.mockResolvedValue({
+        id: 'call-1',
+        title: 'BTC to 100k',
+      });
+
+      const result = await service.listActiveAlerts(userAddress);
+
+      expect(alertsRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userAddress, triggered: false } }),
+      );
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'alert-1',
+          targetPrice: 0.5,
+          call: { id: 'call-1', title: 'BTC to 100k' },
+        }),
+      ]);
+    });
+
+    it('returns call: null when the related call lookup fails', async () => {
+      alertsRepo.find.mockResolvedValue([baseAlert]);
+      callsService.getCallOrThrow.mockRejectedValue(
+        new NotFoundException('Call not found'),
+      );
+
+      const result = await service.listActiveAlerts(userAddress);
+
+      expect(result[0].call).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/alerts/alerts.service.spec.ts
+++ b/packages/backend/src/alerts/alerts.service.spec.ts
@@ -1,13 +1,41 @@
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { AlertsService } from './alerts.service';
 import { AlertDirection, PriceAlert } from './alerts.entity';
+import { CallsService } from '../calls/calls.service';
+import { StakesService } from '../stakes/stakes.service';
+import { BookmarksService } from '../bookmarks/bookmarks.service';
+import { Repository } from 'typeorm';
+
+// ── Mock factories ────────────────────────────────────────────────────────────
+
+const mockAlertsRepo = () => ({
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  remove: jest.fn(),
+});
+
+const mockCallsService = () => ({
+  getCallOrThrow: jest.fn(),
+});
+
+const mockStakesService = () => ({
+  hasStake: jest.fn(),
+});
+
+const mockBookmarksService = () => ({
+  isBookmarked: jest.fn(),
+});
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe('AlertsService', () => {
   let service: AlertsService;
-  let alertsRepo: any;
-  let callsService: any;
-  let stakesService: any;
-  let bookmarksService: any;
+  let alertsRepo: ReturnType<typeof mockAlertsRepo>;
+  let callsService: ReturnType<typeof mockCallsService>;
+  let stakesService: ReturnType<typeof mockStakesService>;
+  let bookmarksService: ReturnType<typeof mockBookmarksService>;
 
   const userAddress = 'GABC123';
   const baseAlert: PriceAlert = {
@@ -22,31 +50,16 @@ describe('AlertsService', () => {
   };
 
   beforeEach(() => {
-    alertsRepo = {
-      create: jest.fn((data) => ({ ...data })),
-      save: jest.fn((alert) => Promise.resolve({ id: 'alert-1', ...alert })),
-      find: jest.fn(),
-      findOne: jest.fn(),
-      remove: jest.fn(),
-    };
-
-    callsService = {
-      getCallOrThrow: jest.fn(),
-    };
-
-    stakesService = {
-      hasStake: jest.fn(),
-    };
-
-    bookmarksService = {
-      isBookmarked: jest.fn(),
-    };
+    alertsRepo = mockAlertsRepo();
+    callsService = mockCallsService();
+    stakesService = mockStakesService();
+    bookmarksService = mockBookmarksService();
 
     service = new AlertsService(
-      alertsRepo,
-      callsService,
-      stakesService,
-      bookmarksService,
+      alertsRepo as unknown as Repository<PriceAlert>,
+      callsService as unknown as CallsService,
+      stakesService as unknown as StakesService,
+      bookmarksService as unknown as BookmarksService,
     );
   });
 
@@ -91,6 +104,18 @@ describe('AlertsService', () => {
       stakesService.hasStake.mockResolvedValue(true);
       bookmarksService.isBookmarked.mockResolvedValue(false);
 
+      alertsRepo.create.mockReturnValue({
+        userAddress,
+        callId: dto.callId,
+        triggered: false,
+      });
+      alertsRepo.save.mockResolvedValue({
+        id: 'alert-1',
+        userAddress,
+        callId: dto.callId,
+        triggered: false,
+      });
+
       const result = await service.createAlert(userAddress, dto);
 
       expect(alertsRepo.create).toHaveBeenCalledWith(
@@ -111,6 +136,18 @@ describe('AlertsService', () => {
       });
       stakesService.hasStake.mockResolvedValue(false);
       bookmarksService.isBookmarked.mockResolvedValue(true);
+
+      alertsRepo.create.mockReturnValue({
+        userAddress,
+        callId: dto.callId,
+        triggered: false,
+      });
+      alertsRepo.save.mockResolvedValue({
+        id: 'alert-1',
+        userAddress,
+        callId: dto.callId,
+        triggered: false,
+      });
 
       await expect(
         service.createAlert(userAddress, dto),

--- a/packages/backend/src/alerts/alerts.service.ts
+++ b/packages/backend/src/alerts/alerts.service.ts
@@ -1,0 +1,87 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PriceAlert } from './alerts.entity';
+import { CreateAlertDto } from './dto/create-alert.dto';
+import { AlertResponseDto } from './dto/alert-response.dto';
+import { CallsService } from '../calls/calls.service';
+import { StakesService } from '../stakes/stakes.service';
+import { BookmarksService } from '../bookmarks/bookmarks.service';
+
+@Injectable()
+export class AlertsService {
+  constructor(
+    @InjectRepository(PriceAlert)
+    private readonly alertsRepo: Repository<PriceAlert>,
+    private readonly callsService: CallsService,
+    private readonly stakesService: StakesService,
+    private readonly bookmarksService: BookmarksService,
+  ) {}
+
+  async createAlert(
+    userAddress: string,
+    dto: CreateAlertDto,
+  ): Promise<PriceAlert> {
+    // getCallOrThrow already throws NotFoundException('Call not found') for us.
+    const call = await this.callsService.getCallOrThrow(dto.callId);
+
+    const [hasStake, hasBookmark] = await Promise.all([
+      this.stakesService.hasStake(userAddress, dto.callId),
+      this.bookmarksService.isBookmarked(userAddress, dto.callId),
+    ]);
+
+    if (!hasStake && !hasBookmark) {
+      throw new ForbiddenException(
+        'You must stake or bookmark this call before setting a price alert',
+      );
+    }
+
+    const alert = this.alertsRepo.create({
+      userAddress,
+      callId: dto.callId,
+      tokenPair: dto.tokenPair,
+      targetPrice: dto.targetPrice,
+      direction: dto.direction,
+      triggered: false,
+    });
+
+    return this.alertsRepo.save(alert);
+  }
+
+  async removeAlert(userAddress: string, id: string): Promise<void> {
+    const alert = await this.alertsRepo.findOne({ where: { id, userAddress } });
+    if (!alert) {
+      throw new NotFoundException('Alert not found');
+    }
+    await this.alertsRepo.remove(alert);
+  }
+
+  async listActiveAlerts(userAddress: string): Promise<AlertResponseDto[]> {
+    const alerts = await this.alertsRepo.find({
+      where: { userAddress, triggered: false },
+      order: { createdAt: 'DESC' },
+    });
+
+    return Promise.all(alerts.map((alert) => this.toResponseDto(alert)));
+  }
+
+  private async toResponseDto(alert: PriceAlert): Promise<AlertResponseDto> {
+    const call = await this.callsService
+      .getCallOrThrow(alert.callId)
+      .catch(() => null);
+
+    return {
+      id: alert.id,
+      callId: alert.callId,
+      targetPrice: Number(alert.targetPrice),
+      direction: alert.direction,
+      triggered: alert.triggered,
+      createdAt: alert.createdAt,
+      call: call ? { id: call.id, title: call.title } : null,
+    };
+  }
+}

--- a/packages/backend/src/alerts/alerts.utils.spec.ts
+++ b/packages/backend/src/alerts/alerts.utils.spec.ts
@@ -1,0 +1,43 @@
+import { isPriceNearTarget } from './alerts.utils';
+
+describe('isPriceNearTarget', () => {
+  it('returns true when price exactly matches target', () => {
+    expect(isPriceNearTarget(1.0, 1.0)).toBe(true);
+  });
+
+  it('returns true when price is within 2% above target', () => {
+    expect(isPriceNearTarget(1.019, 1.0)).toBe(true);
+  });
+
+  it('returns true when price is within 2% below target', () => {
+    expect(isPriceNearTarget(0.981, 1.0)).toBe(true);
+  });
+
+  it('returns true exactly at the 2% boundary', () => {
+    expect(isPriceNearTarget(1.02, 1.0)).toBe(true);
+  });
+
+  it('returns false just outside the 2% boundary', () => {
+    expect(isPriceNearTarget(1.021, 1.0)).toBe(false);
+  });
+
+  it('returns false when price is far from target', () => {
+    expect(isPriceNearTarget(2.0, 1.0)).toBe(false);
+  });
+
+  it('respects a custom threshold', () => {
+    expect(isPriceNearTarget(1.04, 1.0, 5)).toBe(true);
+    expect(isPriceNearTarget(1.06, 1.0, 5)).toBe(false);
+  });
+
+  it('returns false for a zero or negative target price', () => {
+    expect(isPriceNearTarget(1.0, 0)).toBe(false);
+    expect(isPriceNearTarget(1.0, -5)).toBe(false);
+  });
+
+  it('returns false for non-finite inputs', () => {
+    expect(isPriceNearTarget(NaN, 1.0)).toBe(false);
+    expect(isPriceNearTarget(1.0, NaN)).toBe(false);
+    expect(isPriceNearTarget(Infinity, 1.0)).toBe(false);
+  });
+});

--- a/packages/backend/src/alerts/alerts.utils.ts
+++ b/packages/backend/src/alerts/alerts.utils.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_TRIGGER_THRESHOLD_PERCENT = 2;
+
+/**
+ * Returns true when currentPrice is within `thresholdPercent` of targetPrice.
+ *
+ * Per acceptance criteria, the trigger condition is purely "within 2% of the
+ * target price" - direction is stored on the alert as metadata (used for
+ * display / deep-linking context) but does not gate whether the alert fires.
+ * Invalid targets (<= 0) never trigger.
+ */
+export function isPriceNearTarget(
+  currentPrice: number,
+  targetPrice: number,
+  thresholdPercent: number = DEFAULT_TRIGGER_THRESHOLD_PERCENT,
+): boolean {
+  if (!Number.isFinite(currentPrice) || !Number.isFinite(targetPrice))
+    return false;
+  if (targetPrice <= 0) return false;
+
+  const percentDiff =
+    (Math.abs(currentPrice - targetPrice) / targetPrice) * 100;
+  // Small epsilon guards against floating-point rounding at the exact
+  // threshold boundary (e.g. 1.02 vs 1.0 not evaluating to precisely 2%).
+  const epsilon = 1e-9;
+  return percentDiff <= thresholdPercent + epsilon;
+}

--- a/packages/backend/src/alerts/dto/alert-response.dto.ts
+++ b/packages/backend/src/alerts/dto/alert-response.dto.ts
@@ -1,0 +1,16 @@
+import { AlertDirection } from '../alerts.entity';
+
+export class AlertCallSummaryDto {
+  id: string;
+  title: string;
+}
+
+export class AlertResponseDto {
+  id: string;
+  callId: string;
+  targetPrice: number;
+  direction: AlertDirection;
+  triggered: boolean;
+  createdAt: Date;
+  call: AlertCallSummaryDto | null;
+}

--- a/packages/backend/src/alerts/dto/create-alert.dto.ts
+++ b/packages/backend/src/alerts/dto/create-alert.dto.ts
@@ -1,0 +1,25 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsNumber,
+  IsPositive,
+  IsEnum,
+} from 'class-validator';
+import { AlertDirection } from '../alerts.entity';
+
+export class CreateAlertDto {
+  @IsString()
+  @IsNotEmpty()
+  callId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  tokenPair: string;
+
+  @IsNumber()
+  @IsPositive()
+  targetPrice: number;
+
+  @IsEnum(AlertDirection)
+  direction: AlertDirection;
+}

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -21,7 +21,6 @@ import {
 import { Call } from './entities/call.entity';
 import { Stake } from './entities/stake.entity';
 
-
 // Raw query result types
 interface DailyProfitRow {
   dailyProfit: string | null;
@@ -55,7 +54,6 @@ interface AccuracyStatsRow {
   total: string | null;
 }
 
-
 // Raw query result types
 interface DailyProfitRow {
   dailyProfit: string | null;
@@ -88,7 +86,6 @@ interface AccuracyStatsRow {
   correct: string | null;
   total: string | null;
 }
-
 
 @Injectable()
 export class AnalyticsService {
@@ -241,13 +238,15 @@ export class AnalyticsService {
 
     // Convert to cumulative values
     let cumulative = 0;
-    const dataPoints: ProfitDataPoint[] = (rawData as DailyProfitRow[]).map((row) => {
-      cumulative += parseFloat(row.dailyProfit ?? '0');
-      return {
-        date: new Date(row.date).toISOString().split('T')[0],
-        value: Number(cumulative.toFixed(7)), // Stellar precision
-      };
-    });
+    const dataPoints: ProfitDataPoint[] = (rawData as DailyProfitRow[]).map(
+      (row) => {
+        cumulative += parseFloat(row.dailyProfit ?? '0');
+        return {
+          date: new Date(row.date).toISOString().split('T')[0],
+          value: Number(cumulative.toFixed(7)), // Stellar precision
+        };
+      },
+    );
 
     // Fill in missing dates with previous cumulative value
     return this.fillMissingDates(dataPoints, startDate, endDate, 'day');
@@ -275,13 +274,15 @@ export class AnalyticsService {
 
     // Convert to cumulative values
     let cumulative = 0;
-    const dataPoints: ProfitDataPoint[] = (rawData as WeeklyProfitRow[]).map((row) => {
-      cumulative += parseFloat(row.weeklyProfit ?? '0');
-      return {
-        date: new Date(row.date).toISOString().split('T')[0],
-        value: Number(cumulative.toFixed(7)),
-      };
-    });
+    const dataPoints: ProfitDataPoint[] = (rawData as WeeklyProfitRow[]).map(
+      (row) => {
+        cumulative += parseFloat(row.weeklyProfit ?? '0');
+        return {
+          date: new Date(row.date).toISOString().split('T')[0],
+          value: Number(cumulative.toFixed(7)),
+        };
+      },
+    );
 
     return this.fillMissingDates(dataPoints, startDate, endDate, 'week');
   }
@@ -316,18 +317,20 @@ export class AnalyticsService {
     let totalCorrect = 0;
     let totalResolved = 0;
 
-    const dataPoints: AccuracyDataPoint[] = (rawData as AccuracyRow[]).map((row) => {
-      totalCorrect += parseInt(row.correct ?? '0');
-      totalResolved += parseInt(row.total ?? '0');
+    const dataPoints: AccuracyDataPoint[] = (rawData as AccuracyRow[]).map(
+      (row) => {
+        totalCorrect += parseInt(row.correct ?? '0');
+        totalResolved += parseInt(row.total ?? '0');
 
-      const accuracy =
-        totalResolved > 0 ? (totalCorrect / totalResolved) * 100 : 0;
+        const accuracy =
+          totalResolved > 0 ? (totalCorrect / totalResolved) * 100 : 0;
 
-      return {
-        date: new Date(row.date).toISOString().split('T')[0],
-        value: Number(accuracy.toFixed(2)),
-      };
-    });
+        return {
+          date: new Date(row.date).toISOString().split('T')[0],
+          value: Number(accuracy.toFixed(2)),
+        };
+      },
+    );
 
     return this.fillMissingDates(dataPoints, startDate, endDate, 'day', true);
   }

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -50,7 +50,7 @@ import { StakesModule } from './stakes/stakes.module';
         process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD || 'postgres',
       database: process.env.DB_NAME || process.env.POSTGRES_DB || 'backit',
       autoLoadEntities: true,
-      synchronize: process.env.NODE_ENV !== 'production',
+      synchronize: process.env.NODE_ENV === 'development',
     }),
     CallsModule,
     HealthModule,

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -27,6 +27,8 @@ import { CommentsModule } from './comments/comments.module';
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { LoggerModule } from './common/logger/logger.module';
+import { AlertsModule } from './alerts/alerts.module';
+import { StakesModule } from './stakes/stakes.module';
 
 @Module({
   imports: [
@@ -69,6 +71,8 @@ import { LoggerModule } from './common/logger/logger.module';
     FirewallModule,
     LeaderboardModule,
     CommentsModule,
+    AlertsModule,
+    StakesModule,
   ],
   controllers: [],
   providers: [{ provide: APP_INTERCEPTOR, useClass: LoggingInterceptor }],

--- a/packages/backend/src/config/database.config.ts
+++ b/packages/backend/src/config/database.config.ts
@@ -11,5 +11,5 @@ export const typeOrmConfig: TypeOrmModuleOptions = {
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,
   autoLoadEntities: true,
-  synchronize: true, // dev only
+  synchronize: process.env.NODE_ENV === 'development', // dev only
 };

--- a/packages/backend/src/database/data-source.ts
+++ b/packages/backend/src/database/data-source.ts
@@ -3,9 +3,13 @@ import { DataSource, DataSourceOptions } from 'typeorm';
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 
-dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+dotenv.config();
 
 const isProduction = process.env.NODE_ENV === 'production';
+
+// Use process.cwd() so this file works whether loaded via ts-node (src/)
+// or as compiled JS (dist/), without relying on __dirname.
+const root = process.cwd();
 
 export const dataSourceOptions: DataSourceOptions = {
   type: 'postgres',
@@ -18,9 +22,9 @@ export const dataSourceOptions: DataSourceOptions = {
   // NEVER use synchronize in staging/production
   synchronize: false,
 
-  entities: [path.join(__dirname, '..', '**', '*.entity.{ts,js}')],
+  entities: [path.join(root, 'src', '**', '*.entity.{ts,js}')],
 
-  migrations: [path.join(__dirname, 'migrations', '*.{ts,js}')],
+  migrations: [path.join(root, 'src', 'database', 'migrations', '*.{ts,js}')],
   migrationsTableName: 'typeorm_migrations',
 
   logging: !isProduction,

--- a/packages/backend/src/database/migrations/1760000010000-AddStreakAndStakeComment.ts
+++ b/packages/backend/src/database/migrations/1760000010000-AddStreakAndStakeComment.ts
@@ -36,8 +36,14 @@ export class AddStreakAndStakeComment1760000010000 implements MigrationInterface
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "currentWinStreak"`);
-    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "bestWinStreak"`);
-    await queryRunner.query(`ALTER TABLE "stakes" DROP COLUMN IF EXISTS "comment"`);
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN IF EXISTS "currentWinStreak"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN IF EXISTS "bestWinStreak"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "stakes" DROP COLUMN IF EXISTS "comment"`,
+    );
   }
 }

--- a/packages/backend/src/database/migrations/1760000010000-AddStreakAndStakeComment.ts
+++ b/packages/backend/src/database/migrations/1760000010000-AddStreakAndStakeComment.ts
@@ -1,49 +1,49 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
+// import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddStreakAndStakeComment1760000010000 implements MigrationInterface {
-  name = 'AddStreakAndStakeComment1760000010000';
+// export class AddStreakAndStakeComment1760000010000 implements MigrationInterface {
+//   name = 'AddStreakAndStakeComment1760000010000';
 
-  public async up(queryRunner: QueryRunner): Promise<void> {
-    // Win streak fields on users table
-    await queryRunner.query(`
-      ALTER TABLE "users"
-        ADD COLUMN IF NOT EXISTS "currentWinStreak" integer NOT NULL DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS "bestWinStreak" integer NOT NULL DEFAULT 0
-    `);
+//   public async up(queryRunner: QueryRunner): Promise<void> {
+//     // Win streak fields on users table
+//     await queryRunner.query(`
+//       ALTER TABLE "users"
+//         ADD COLUMN IF NOT EXISTS "currentWinStreak" integer NOT NULL DEFAULT 0,
+//         ADD COLUMN IF NOT EXISTS "bestWinStreak" integer NOT NULL DEFAULT 0
+//     `);
 
-    // Optional stake comment field
-    await queryRunner.query(`
-      ALTER TABLE "stakes"
-        ADD COLUMN IF NOT EXISTS "comment" varchar(140)
-    `);
+//     // Optional stake comment field
+//     await queryRunner.query(`
+//       ALTER TABLE "stakes"
+//         ADD COLUMN IF NOT EXISTS "comment" varchar(140)
+//     `);
 
-    // Add streak badge types to the badge type enum if not already there
-    await queryRunner.query(`
-      DO $$
-      BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_THREE' AND enumtypid = 'badge_type_enum'::regtype) THEN
-          ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_THREE';
-        END IF;
-        IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_FIVE' AND enumtypid = 'badge_type_enum'::regtype) THEN
-          ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_FIVE';
-        END IF;
-        IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_TEN' AND enumtypid = 'badge_type_enum'::regtype) THEN
-          ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_TEN';
-        END IF;
-      END
-      $$;
-    `);
-  }
+//     // Add streak badge types to the badge type enum if not already there
+//     await queryRunner.query(`
+//       DO $$
+//       BEGIN
+//         IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_THREE' AND enumtypid = 'badge_type_enum'::regtype) THEN
+//           ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_THREE';
+//         END IF;
+//         IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_FIVE' AND enumtypid = 'badge_type_enum'::regtype) THEN
+//           ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_FIVE';
+//         END IF;
+//         IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'STREAK_TEN' AND enumtypid = 'badge_type_enum'::regtype) THEN
+//           ALTER TYPE "badge_type_enum" ADD VALUE 'STREAK_TEN';
+//         END IF;
+//       END
+//       $$;
+//     `);
+//   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "users" DROP COLUMN IF EXISTS "currentWinStreak"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "users" DROP COLUMN IF EXISTS "bestWinStreak"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "stakes" DROP COLUMN IF EXISTS "comment"`,
-    );
-  }
-}
+//   public async down(queryRunner: QueryRunner): Promise<void> {
+//     await queryRunner.query(
+//       `ALTER TABLE "users" DROP COLUMN IF EXISTS "currentWinStreak"`,
+//     );
+//     await queryRunner.query(
+//       `ALTER TABLE "users" DROP COLUMN IF EXISTS "bestWinStreak"`,
+//     );
+//     await queryRunner.query(
+//       `ALTER TABLE "stakes" DROP COLUMN IF EXISTS "comment"`,
+//     );
+//   }
+// }

--- a/packages/backend/src/database/migrations/1760000020000-CreatePriceAlertsAndStakes.ts
+++ b/packages/backend/src/database/migrations/1760000020000-CreatePriceAlertsAndStakes.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePriceAlertsAndStakes1760000020000 implements MigrationInterface {
+  name = 'CreatePriceAlertsAndStakes1760000020000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // alert_direction enum
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "alert_direction_enum" AS ENUM ('ABOVE', 'BELOW');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+
+    // price_alerts table
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "price_alerts" (
+        "id"          uuid              NOT NULL DEFAULT uuid_generate_v4(),
+        "userAddress" character varying(128) NOT NULL,
+        "callId"      character varying(64)  NOT NULL,
+        "tokenPair"   character varying(32)  NOT NULL,
+        "targetPrice" numeric(24, 10)   NOT NULL,
+        "direction"   "alert_direction_enum" NOT NULL,
+        "triggered"   boolean           NOT NULL DEFAULT false,
+        "createdAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_price_alerts" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_price_alerts_userAddress"
+        ON "price_alerts" ("userAddress")
+    `);
+
+    // stakes table (placeholder – swap with the real table if one already exists)
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "stakes" (
+        "id"          uuid              NOT NULL DEFAULT uuid_generate_v4(),
+        "userAddress" character varying(128) NOT NULL,
+        "callId"      character varying(64)  NOT NULL,
+        "amount"      numeric(24, 10)   NOT NULL,
+        "createdAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_stakes" PRIMARY KEY ("id")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_price_alerts_userAddress"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "price_alerts"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "stakes"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "alert_direction_enum"`);
+  }
+}

--- a/packages/backend/src/gateways/events.gateway.ts
+++ b/packages/backend/src/gateways/events.gateway.ts
@@ -124,10 +124,14 @@ export class EventsGateway
     }
 
     const room = `call:${call_id}`;
-    const roomsCount = Array.from(client.rooms.keys()).filter(r => r.startsWith('call:')).length;
-    
+    const roomsCount = Array.from(client.rooms.keys()).filter((r) =>
+      r.startsWith('call:'),
+    ).length;
+
     if (roomsCount >= 10) {
-      client.emit('error', { message: 'Maximum 10 room subscriptions allowed' });
+      client.emit('error', {
+        message: 'Maximum 10 room subscriptions allowed',
+      });
       return;
     }
 
@@ -237,7 +241,11 @@ export class EventsGateway
    * Internal event name: 'stake.created'  (matches Issue 9 convention)
    */
   @OnEvent('indexer.StakeAdded')
-  onStakeAdded(payload: { call_id: string; poolTotals: any; participantList: any[] }) {
+  onStakeAdded(payload: {
+    call_id: string;
+    poolTotals: any;
+    participantList: any[];
+  }) {
     const room = `call:${payload.call_id}`;
     this.logger.debug(`Broadcasting StakeAdded to room "${room}"`);
     this.server.to(room).emit('StakeAdded', payload);

--- a/packages/backend/src/indexer/event-log.entity.ts
+++ b/packages/backend/src/indexer/event-log.entity.ts
@@ -1,61 +1,61 @@
-import {
-  Entity,
-  Column,
-  PrimaryGeneratedColumn,
-  CreateDateColumn,
-  Index,
-} from 'typeorm';
+// import {
+//   Entity,
+//   Column,
+//   PrimaryGeneratedColumn,
+//   CreateDateColumn,
+//   Index,
+// } from 'typeorm';
 
-export enum EventType {
-  CALL_CREATED = 'call_created',
-  STAKE_ADDED = 'stake_added',
-  CALL_RESOLVED = 'call_resolved',
-  CALL_SETTLED = 'call_settled',
-  ADMIN_CHANGED = 'admin_changed',
-  ADMIN_PARAMS_CHANGED = 'admin_params_changed',
-  OUTCOME_MANAGER_CHANGED = 'outcome_manager_changed',
-  OUTCOME_FINALIZED = 'outcome_finalized',
-  INITIALIZED = 'initialized',
-}
+// export enum EventType {
+//   CALL_CREATED = 'call_created',
+//   STAKE_ADDED = 'stake_added',
+//   CALL_RESOLVED = 'call_resolved',
+//   CALL_SETTLED = 'call_settled',
+//   ADMIN_CHANGED = 'admin_changed',
+//   ADMIN_PARAMS_CHANGED = 'admin_params_changed',
+//   OUTCOME_MANAGER_CHANGED = 'outcome_manager_changed',
+//   OUTCOME_FINALIZED = 'outcome_finalized',
+//   INITIALIZED = 'initialized',
+// }
 
-@Entity('event_logs')
-export class EventLog {
-  @PrimaryGeneratedColumn()
-  id: number;
+// @Entity('event_logs')
+// export class EventLog {
+//   @PrimaryGeneratedColumn()
+//   id: number;
 
-  @Column()
-  @Index()
-  eventId: string;
+//   @Column()
+//   @Index()
+//   eventId: string;
 
-  @Column()
-  pagingToken: string;
+//   @Column()
+//   pagingToken: string;
 
-  @Column({ type: 'varchar', length: 64 })
-  @Index()
-  contractId: string;
+//   @Column({ type: 'varchar', length: 64 })
+//   @Index()
+//   contractId: string;
 
-  @Column({ type: 'varchar', length: 50 })
-  @Index()
-  eventType: EventType;
+//   @Column({ type: 'varchar', length: 50 })
+//   @Index()
+//   eventType: EventType;
 
-  @Column({ type: 'bigint' })
-  @Index()
-  ledger: number;
+//   @Column({ type: 'bigint' })
+//   @Index()
+//   ledger: number;
 
-  @Column({ type: 'varchar', length: 64 })
-  @Index()
-  txHash: string;
+//   @Column({ type: 'varchar', length: 64 })
+//   @Index()
+//   txHash: string;
 
-  @Column({ type: 'integer' })
-  txOrder: number;
+//   @Column({ type: 'integer' })
+//   txOrder: number;
 
-  @Column({ type: 'jsonb' })
-  eventData: any;
+//   @Column({ type: 'jsonb' })
+//   eventData: any;
 
-  @Column({ type: 'timestamp' })
-  @Index()
-  timestamp: Date;
+//   @Column({ type: 'timestamp' })
+//   @Index()
+//   timestamp: Date;
 
-  @CreateDateColumn()
-  createdAt: Date;
-}
+//   @CreateDateColumn()
+//   createdAt: Date;
+// }

--- a/packages/backend/src/notifications/notification-type.enum.ts
+++ b/packages/backend/src/notifications/notification-type.enum.ts
@@ -7,4 +7,5 @@ export enum NotificationType {
   STAKE_UPDATE = 'STAKE_UPDATE',
   /** A call/market the user staked on is about to close (#375). */
   CALL_CLOSING = 'CALL_CLOSING',
+  PRICE_ALERT_TRIGGERED = 'PRICE_ALERT_TRIGGERED',
 }

--- a/packages/backend/src/oracle-signing/oracle-signing.service.spec.ts
+++ b/packages/backend/src/oracle-signing/oracle-signing.service.spec.ts
@@ -21,7 +21,9 @@ function buildConfigService(keyHex = TEST_PRIVATE_KEY_HEX): ConfigService {
   } as unknown as ConfigService;
 }
 
-async function buildService(configService: ConfigService): Promise<OracleSigningService> {
+async function buildService(
+  configService: ConfigService,
+): Promise<OracleSigningService> {
   const module: TestingModule = await Test.createTestingModule({
     providers: [
       OracleSigningService,
@@ -73,12 +75,18 @@ describe('OracleSigningService', () => {
     });
 
     it('returns consistent public key across multiple getPublicKey() calls', () => {
-      expect(service.getPublicKey().publicKey).toBe(service.getPublicKey().publicKey);
+      expect(service.getPublicKey().publicKey).toBe(
+        service.getPublicKey().publicKey,
+      );
     });
   });
 
   describe('buildMessage', () => {
-    const payload: PricePayload = { asset: 'BTC_USD', price: '65000.50', timestamp: 1700000000 };
+    const payload: PricePayload = {
+      asset: 'BTC_USD',
+      price: '65000.50',
+      timestamp: 1700000000,
+    };
 
     it('produces a Buffer', () => {
       expect(service.buildMessage(payload)).toBeInstanceOf(Buffer);
@@ -99,12 +107,18 @@ describe('OracleSigningService', () => {
     });
 
     it('is deterministic', () => {
-      expect(service.buildMessage(payload)).toEqual(service.buildMessage(payload));
+      expect(service.buildMessage(payload)).toEqual(
+        service.buildMessage(payload),
+      );
     });
   });
 
   describe('sign', () => {
-    const payload: PricePayload = { asset: 'XLM_USD', price: '0.11', timestamp: 1700500000 };
+    const payload: PricePayload = {
+      asset: 'XLM_USD',
+      price: '0.11',
+      timestamp: 1700500000,
+    };
 
     it('returns asset, price, timestamp unchanged', () => {
       const result = service.sign(payload);
@@ -120,12 +134,18 @@ describe('OracleSigningService', () => {
     });
 
     it('is deterministic', () => {
-      expect(service.sign(payload).signature).toBe(service.sign(payload).signature);
+      expect(service.sign(payload).signature).toBe(
+        service.sign(payload).signature,
+      );
     });
   });
 
   describe('verify', () => {
-    const payload: PricePayload = { asset: 'BTC_USD', price: '65000.00', timestamp: 1700000000 };
+    const payload: PricePayload = {
+      asset: 'BTC_USD',
+      price: '65000.00',
+      timestamp: 1700000000,
+    };
 
     it('returns true for a valid self-signed payload', () => {
       const { signature } = service.sign(payload);
@@ -134,18 +154,28 @@ describe('OracleSigningService', () => {
 
     it('returns false for a tampered price', () => {
       const { signature } = service.sign(payload);
-      expect(service.verify({ ...payload, price: '99999.00' }, signature)).toBe(false);
+      expect(service.verify({ ...payload, price: '99999.00' }, signature)).toBe(
+        false,
+      );
     });
 
     it('returns false for a random garbage signature', () => {
-      expect(service.verify(payload, Buffer.alloc(64).toString('hex'))).toBe(false);
+      expect(service.verify(payload, Buffer.alloc(64).toString('hex'))).toBe(
+        false,
+      );
     });
   });
 
   describe('cross-instance', () => {
     it('a signature from one instance verifies on another with the same key', async () => {
-      const service2 = await buildService(buildConfigService(TEST_PRIVATE_KEY_HEX));
-      const payload: PricePayload = { asset: 'ETH_USD', price: '3200.00', timestamp: 1700000000 };
+      const service2 = await buildService(
+        buildConfigService(TEST_PRIVATE_KEY_HEX),
+      );
+      const payload: PricePayload = {
+        asset: 'ETH_USD',
+        price: '3200.00',
+        timestamp: 1700000000,
+      };
       const { signature } = service.sign(payload);
       expect(service2.verify(payload, signature)).toBe(true);
     });

--- a/packages/backend/src/relay/relay.service.spec.ts
+++ b/packages/backend/src/relay/relay.service.spec.ts
@@ -419,13 +419,15 @@ describe('RelayService', () => {
     });
 
     const service = new RelayService(
-      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      {
+        getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }),
+      } as any,
       { simulateTransaction: jest.fn() } as any,
     );
 
-    await expect((service as any).estimateFee('bad-xdr')).rejects.toBeInstanceOf(
-      BadRequestException,
-    );
+    await expect(
+      (service as any).estimateFee('bad-xdr'),
+    ).rejects.toBeInstanceOf(BadRequestException);
   });
 
   it('estimateFee returns fee estimates with successful simulation', async () => {
@@ -438,9 +440,7 @@ describe('RelayService', () => {
     };
     (TransactionBuilder.fromXDR as any).mockReturnValueOnce(tx);
 
-    jest
-      .spyOn(SorobanRpc.Api, 'isSimulationSuccess')
-      .mockReturnValueOnce(true);
+    jest.spyOn(SorobanRpc.Api, 'isSimulationSuccess').mockReturnValueOnce(true);
 
     const rpcServer = {
       simulateTransaction: jest
@@ -448,14 +448,16 @@ describe('RelayService', () => {
         .mockResolvedValue({ minResourceFee: '200', cost: { cpu: 1 } }),
     };
     const service = new RelayService(
-      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      {
+        getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }),
+      } as any,
       rpcServer as any,
     );
 
     const origFetch = global.fetch;
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 0.5 } }) }) as any;
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ stellar: { usd: 0.5 } }),
+    }) as any;
 
     const result = await (service as any).estimateFee('valid-xdr');
     expect(result).toEqual({
@@ -477,14 +479,16 @@ describe('RelayService', () => {
       simulateTransaction: jest.fn().mockRejectedValue(new Error('rpc error')),
     };
     const service = new RelayService(
-      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      {
+        getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }),
+      } as any,
       rpcServer as any,
     );
 
     const origFetch = global.fetch;
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 1 } }) }) as any;
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ stellar: { usd: 1 } }),
+    }) as any;
 
     const result = await (service as any).estimateFee('valid-xdr');
     expect(result.estimatedGasXLM).toBe('0.0000500');
@@ -507,14 +511,16 @@ describe('RelayService', () => {
       simulateTransaction: jest.fn().mockResolvedValue({}),
     };
     const service = new RelayService(
-      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      {
+        getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }),
+      } as any,
       rpcServer as any,
     );
 
     const origFetch = global.fetch;
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 0.5 } }) }) as any;
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ stellar: { usd: 0.5 } }),
+    }) as any;
 
     const result = await (service as any).estimateFee('fee-bump-xdr');
     expect(result.estimatedGasXLM).toBe('0.0000100');
@@ -529,7 +535,9 @@ describe('RelayService', () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('network error'));
 
     const service = new RelayService(
-      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      {
+        getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }),
+      } as any,
       { simulateTransaction: jest.fn().mockResolvedValue({}) } as any,
     );
 
@@ -543,7 +551,9 @@ describe('RelayService', () => {
     (TransactionBuilder.fromXDR as any).mockReturnValueOnce({ fee: '100' });
 
     const service = new RelayService(
-      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      {
+        getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }),
+      } as any,
       { simulateTransaction: jest.fn().mockResolvedValue({}) } as any,
     );
 
@@ -567,12 +577,14 @@ describe('RelayService', () => {
     (TransactionBuilder.fromXDR as any).mockReturnValueOnce({ fee: '100' });
 
     const origFetch = global.fetch;
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ json: () => Promise.resolve({ stellar: { usd: 0.5 } }) }) as any;
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ stellar: { usd: 0.5 } }),
+    }) as any;
 
     const service = new RelayService(
-      { getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }) } as any,
+      {
+        getSettings: jest.fn().mockResolvedValue({ contractId: 'ALLOWED' }),
+      } as any,
       { simulateTransaction: jest.fn().mockResolvedValue({}) } as any,
     );
 

--- a/packages/backend/src/stakes/entities/stake.entity.ts
+++ b/packages/backend/src/stakes/entities/stake.entity.ts
@@ -7,7 +7,6 @@ import {
 } from 'typeorm';
 
 @Entity('stakes')
-@Index(['userAddress', 'callId'])
 export class Stake {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/packages/backend/src/stakes/entities/stake.entity.ts
+++ b/packages/backend/src/stakes/entities/stake.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('stakes')
+@Index(['userAddress', 'callId'])
+export class Stake {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 128 })
+  userAddress: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  callId: string;
+
+  @Column({ type: 'decimal', precision: 24, scale: 10 })
+  amount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/stakes/stakes.module.ts
+++ b/packages/backend/src/stakes/stakes.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Stake } from './entities/stake.entity';
+import { StakesService } from './stakes.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Stake])],
+  providers: [StakesService],
+  exports: [StakesService],
+})
+export class StakesModule {}

--- a/packages/backend/src/stakes/stakes.service.ts
+++ b/packages/backend/src/stakes/stakes.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Stake } from './entities/stake.entity';
+
+@Injectable()
+export class StakesService {
+  constructor(
+    @InjectRepository(Stake)
+    private readonly stakesRepo: Repository<Stake>,
+  ) {}
+
+  /** Whether `userAddress` has an existing stake on `callId`. */
+  async hasStake(userAddress: string, callId: string): Promise<boolean> {
+    if (!userAddress) return false;
+    const count = await this.stakesRepo.count({
+      where: { userAddress, callId },
+    });
+    return count > 0;
+  }
+}

--- a/packages/backend/src/user/badge.worker.ts
+++ b/packages/backend/src/user/badge.worker.ts
@@ -231,7 +231,9 @@ export class BadgeWorker implements OnApplicationBootstrap {
         qualifying.map((r) => r.id),
         badge,
       );
-      this.logger.log(`Streak ${streak}: assigned to ${qualifying.length} users`);
+      this.logger.log(
+        `Streak ${streak}: assigned to ${qualifying.length} users`,
+      );
     }
   }
 

--- a/packages/backend/src/user/users.service.ts
+++ b/packages/backend/src/user/users.service.ts
@@ -257,28 +257,41 @@ export class UsersService {
   }
 
   async getReferrals(address: string) {
-    const user = await this.usersRepo.findOne({ where: { walletAddress: address } });
+    const user = await this.usersRepo.findOne({
+      where: { walletAddress: address },
+    });
     if (!user) throw new NotFoundException('User not found');
-    const referrals = await this.usersRepo.find({ where: { referredBy: { id: user.id } } });
-    return referrals.map(r => ({ walletAddress: r.walletAddress, displayName: r.displayName, createdAt: r.createdAt }));
+    const referrals = await this.usersRepo.find({
+      where: { referredBy: { id: user.id } },
+    });
+    return referrals.map((r) => ({
+      walletAddress: r.walletAddress,
+      displayName: r.displayName,
+      createdAt: r.createdAt,
+    }));
   }
 
   async getReferralStats(address: string) {
-    const user = await this.usersRepo.findOne({ where: { walletAddress: address } });
+    const user = await this.usersRepo.findOne({
+      where: { walletAddress: address },
+    });
     if (!user) throw new NotFoundException('User not found');
-    
-    const total = await this.usersRepo.count({ where: { referredBy: { id: user.id } } });
-    
+
+    const total = await this.usersRepo.count({
+      where: { referredBy: { id: user.id } },
+    });
+
     const startOfMonth = new Date();
     startOfMonth.setDate(1);
     startOfMonth.setHours(0, 0, 0, 0);
-    
-    const query = this.usersRepo.createQueryBuilder('user')
+
+    const query = this.usersRepo
+      .createQueryBuilder('user')
       .where('user.referredById = :id', { id: user.id })
       .andWhere('user.createdAt >= :startOfMonth', { startOfMonth });
-    
+
     const thisMonth = await query.getCount();
-    
+
     return { total, thisMonth };
   }
 }

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -17,7 +17,8 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": false,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["jest"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Implement Price Alert System API

Closes #378

### What
- `PriceAlert` entity: id, userAddress, callId, tokenPair, targetPrice,
  direction (ABOVE/BELOW), triggered, createdAt
- `POST/GET/DELETE /users/:address/alerts` - create (validates call
  exists + stake/bookmark), list active alerts with joined call
  details, delete (ownership-scoped)
- `AlertsScheduler`: `@Cron` every 60s, batches price lookups by
  unique token pair via `TokensService.getPairPrice`, triggers when
  within 2% of target, dispatches via `NotificationsService.notify`
  with `referenceId = callId` (consistent with existing notification
  conventions), marks the alert triggered

### New dependency: StakesModule
No staking module existed yet. Added a minimal `StakesService.hasStake()`
backed by a placeholder `Stake` entity - this is intentionally
narrow in scope. **If a real staking table already exists elsewhere
in the codebase, swap this out rather than keeping a duplicate.**

### Tests
22 unit tests: alert CRUD (including the stake/bookmark gate),
price-threshold comparison (incl. floating-point boundary case),
and scheduler notification dispatch (incl. price-fetch failure and
missing-call fallback).