### PR TITLE
feat(outcome-manager): extend TWAP resolution for manipulation resist…

### DIFF
--- a/packages/contracts/outcome_manager/src/errors.rs
+++ b/packages/contracts/outcome_manager/src/errors.rs
@@ -60,4 +60,7 @@ pub enum OutcomeError {
     FactoryNotSet = 27,
     /// The market address does not match the factory's registry for this call_id.
     InvalidMarket = 28,
+    /// A price observation's timestamp falls outside `[call_end_ts -
+    /// twap_window_secs, call_end_ts]`.
+    ObservationOutsideWindow = 29,
 }

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -113,6 +113,14 @@ pub fn emit_price_observation_submitted(
     );
 }
 
+/// Emitted when a TWAP is successfully computed and used for resolution.
+pub fn emit_twap_computed(env: &Env, call_id: u64, twap_price: i128, observation_count: u32) {
+    env.events().publish(
+        (symbol_short!("twap"), symbol_short!("computed")),
+        (call_id, twap_price, observation_count),
+    );
+}
+
 /// Emitted when a claimable balance is created for a winning staker
 pub fn emit_claimable_balance_created(
     env: &Env,

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -25,10 +25,11 @@ use events::{
     emit_admin_params_changed, emit_batch_payout_started, emit_claimable_balance_created,
     emit_contract_upgraded, emit_fee_collected, emit_outcome_disputed, emit_outcome_finalized,
     emit_outcome_submitted, emit_payout_claimed, emit_price_observation_submitted,
+    emit_twap_computed,
 };
 use storage::{
-    set_dispute_window, set_max_submission_delay, InstanceKey, OracleVote, Outcome, PersistentKey,
-    PriceObservation, TempKey,
+    get_twap_config, set_dispute_window, set_max_submission_delay, set_twap_config, InstanceKey,
+    OracleVote, Outcome, PersistentKey, PriceObservation, TempKey,
 };
 use verification::{build_message, verify_signature};
 
@@ -221,6 +222,63 @@ fn compute_payout_parts(
         .unwrap_or_else(|| overflow(env));
 
     (staker_fee_share, payout)
+}
+
+/// Attempts to compute a valid TWAP from `observations`, extending the last
+/// observation's price forward to `end_ts`:
+///
+/// `TWAP = (p1*(t2-t1) + p2*(t3-t2) + ... + pN*(end_ts-tN)) / (end_ts-t1)`
+///
+/// Returns `None` — never panics — if there are fewer than
+/// `min_observations`, if the observations don't span at least half of
+/// `window_secs`, or on arithmetic overflow. Either signal means the TWAP
+/// isn't trustworthy and the caller should fall back to a single-point
+/// price instead.
+fn try_compute_twap(
+    observations: &Vec<PriceObservation>,
+    end_ts: u64,
+    window_secs: u64,
+    min_observations: u32,
+) -> Option<i128> {
+    let n = observations.len();
+    if n < min_observations {
+        return None;
+    }
+
+    let first = observations.get(0).unwrap();
+    let last = observations.get(n - 1).unwrap();
+    let span = last.timestamp.saturating_sub(first.timestamp);
+    if span < window_secs / 2 {
+        return None;
+    }
+
+    let mut weighted_sum: i128 = 0;
+    let mut total_time: i128 = 0;
+
+    for i in 0..n {
+        let obs = observations.get(i).unwrap();
+        let next_ts = if i + 1 < n {
+            observations.get(i + 1).unwrap().timestamp
+        } else {
+            end_ts
+        };
+        if next_ts < obs.timestamp {
+            // end_ts strictly before the last observation, or malformed
+            // order — genuinely invalid. `next_ts == obs.timestamp` is
+            // legitimate (a zero-length tail when end_ts lands exactly on
+            // the last observation) and contributes zero weight below.
+            return None;
+        }
+        let dt = (next_ts - obs.timestamp) as i128;
+        weighted_sum = obs.price.checked_mul(dt)?.checked_add(weighted_sum)?;
+        total_time = total_time.checked_add(dt)?;
+    }
+
+    if total_time == 0 {
+        return None;
+    }
+
+    weighted_sum.checked_div(total_time)
 }
 
 // ─── Contract ─────────────────────────────────────────────────────────────────
@@ -1007,6 +1065,7 @@ impl OutcomeManager {
     pub fn submit_price_observation(
         env: Env,
         call_id: u64,
+        call_end_ts: u64,
         observation: PriceObservation,
         oracle_pubkey: BytesN<32>,
         signature: BytesN<64>,
@@ -1024,6 +1083,12 @@ impl OutcomeManager {
             &observation.timestamp.to_be_bytes(),
         ));
         verify_signature(&env, &oracle_pubkey, &signature, &raw);
+
+        let (window_secs, _) = get_twap_config(&env);
+        let window_start = call_end_ts.saturating_sub(window_secs);
+        if observation.timestamp < window_start || observation.timestamp > call_end_ts {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::ObservationOutsideWindow);
+        }
 
         let key = TempKey::PriceObservations(call_id);
         let mut observations: Vec<PriceObservation> = env
@@ -1046,41 +1111,60 @@ impl OutcomeManager {
         emit_price_observation_submitted(&env, call_id, &oracle_pubkey, price, timestamp);
     }
 
-    pub fn compute_twap(env: Env, call_id: u64) -> i128 {
+    /// Computes the TWAP for `call_id` over its stored observations,
+    /// extended to `end_ts`. Panics (via typed `OutcomeError`) if there
+    /// aren't enough observations to trust the result — see
+    /// [`Self::resolve_price`] for a non-panicking fallback-aware variant.
+    pub fn compute_twap(env: Env, call_id: u64, end_ts: u64) -> i128 {
         let key = TempKey::PriceObservations(call_id);
         let observations: Vec<PriceObservation> = match env.storage().temporary().get(&key) {
             Some(observations) => observations,
             None => soroban_sdk::panic_with_error!(&env, OutcomeError::NoPriceObservations),
         };
 
-        let n = observations.len();
-        if n < 3 {
-            soroban_sdk::panic_with_error!(&env, OutcomeError::InsufficientPriceObservations);
+        let (window_secs, min_observations) = get_twap_config(&env);
+        match try_compute_twap(&observations, end_ts, window_secs, min_observations) {
+            Some(twap) => twap,
+            None => soroban_sdk::panic_with_error!(&env, OutcomeError::InsufficientPriceObservations),
         }
+    }
 
-        let mut weighted_sum: i128 = 0;
-        let mut total_time: i128 = 0;
+    /// Set the TWAP window length (seconds before a call's `end_ts`) and
+    /// the minimum observation count required for a TWAP to be trusted
+    /// (admin only).
+    pub fn set_twap_config(env: Env, window_secs: u64, min_observations: u32) {
+        require_admin(&env);
+        set_twap_config(&env, window_secs, min_observations);
+        emit_admin_params_changed(&env, window_secs);
+    }
 
-        for i in 0..(n - 1) {
-            let obs_i = observations.get(i).unwrap();
-            let obs_next = observations.get(i + 1).unwrap();
-            let dt = (obs_next.timestamp - obs_i.timestamp) as i128;
-            weighted_sum = obs_i
-                .price
-                .checked_mul(dt)
-                .unwrap_or_else(|| overflow(&env))
-                .checked_add(weighted_sum)
-                .unwrap_or_else(|| overflow(&env));
-            total_time = total_time.checked_add(dt).unwrap_or_else(|| overflow(&env));
+    /// Return the current `(window_secs, min_observations)` TWAP config.
+    pub fn get_twap_config(env: Env) -> (u64, u32) {
+        get_twap_config(&env)
+    }
+
+    /// Returns the resolution price for `call_id`: the TWAP over its final
+    /// observations if there are enough to trust, otherwise
+    /// `single_point_price` unchanged (e.g. an oracle's direct submission).
+    /// Never panics — a market with no or insufficient observations
+    /// (oracle downtime, a brand-new market) resolves exactly as it did
+    /// before TWAP existed.
+    pub fn resolve_price(env: Env, call_id: u64, end_ts: u64, single_point_price: i128) -> i128 {
+        let key = TempKey::PriceObservations(call_id);
+        let observations: Vec<PriceObservation> = env
+            .storage()
+            .temporary()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let (window_secs, min_observations) = get_twap_config(&env);
+        match try_compute_twap(&observations, end_ts, window_secs, min_observations) {
+            Some(twap_price) => {
+                emit_twap_computed(&env, call_id, twap_price, observations.len());
+                twap_price
+            }
+            None => single_point_price,
         }
-
-        if total_time == 0 {
-            soroban_sdk::panic_with_error!(&env, OutcomeError::ZeroTimeWindow);
-        }
-
-        weighted_sum
-            .checked_div(total_time)
-            .unwrap_or_else(|| overflow(&env))
     }
 
     pub fn schedule_oracle_removal(env: Env, oracle_pubkey: BytesN<32>, effective_ledger: u32) {

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -62,6 +62,12 @@ pub enum InstanceKey {
     ClaimableBalanceId(u64, Address),
     /// SDEX deviation threshold in basis points (default 500 = 5%)
     SdexThresholdBps,
+    /// TWAP window length in seconds, counting back from a call's `end_ts`.
+    /// Default 600 (10 minutes).
+    TwapWindowSecs,
+    /// Minimum price observations required for a TWAP to be considered
+    /// valid. Default 3.
+    TwapMinObservations,
 }
 
 #[contracttype]
@@ -144,4 +150,30 @@ pub fn get_max_submission_delay(env: &Env) -> u64 {
         .instance()
         .get(&InstanceKey::MaxSubmissionDelay)
         .unwrap_or(86400)
+}
+
+pub const DEFAULT_TWAP_WINDOW_SECS: u64 = 600;
+pub const DEFAULT_TWAP_MIN_OBSERVATIONS: u32 = 3;
+
+pub fn set_twap_config(env: &Env, window_secs: u64, min_observations: u32) {
+    env.storage()
+        .instance()
+        .set(&InstanceKey::TwapWindowSecs, &window_secs);
+    env.storage()
+        .instance()
+        .set(&InstanceKey::TwapMinObservations, &min_observations);
+}
+
+pub fn get_twap_config(env: &Env) -> (u64, u32) {
+    let window_secs = env
+        .storage()
+        .instance()
+        .get(&InstanceKey::TwapWindowSecs)
+        .unwrap_or(DEFAULT_TWAP_WINDOW_SECS);
+    let min_observations = env
+        .storage()
+        .instance()
+        .get(&InstanceKey::TwapMinObservations)
+        .unwrap_or(DEFAULT_TWAP_MIN_OBSERVATIONS);
+    (window_secs, min_observations)
 }

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -1043,10 +1043,16 @@ fn test_twap_three_equal_intervals() {
     let env = Env::default();
     let (_admin, _registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
     let call_id = 42u64;
+    let call_end_ts = 3000u64;
+    // Widen the window so observations from ts=1000 (2000s before end_ts)
+    // are accepted — this test is about the TWAP formula, not the window
+    // boundary (see test_submit_price_observation_rejects_outside_window).
+    client.set_twap_config(&2000u64, &3u32);
     for (price, ts) in [(100_i128, 1000u64), (200, 2000), (300, 3000)] {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
         client.submit_price_observation(
             &call_id,
+            &call_end_ts,
             &PriceObservation {
                 price,
                 timestamp: ts,
@@ -1055,7 +1061,61 @@ fn test_twap_three_equal_intervals() {
             &sig,
         );
     }
-    assert_eq!(client.compute_twap(&call_id), 150);
+    // end_ts == the last observation's own timestamp, so its tail segment
+    // contributes zero weight — same result as averaging only the gaps
+    // between consecutive observations: (100*1000 + 200*1000) / 2000 = 150.
+    assert_eq!(client.compute_twap(&call_id, &call_end_ts), 150);
+}
+
+#[test]
+fn test_twap_extends_last_price_to_end_ts() {
+    let env = Env::default();
+    let (_admin, _registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 43u64;
+    // Observations only span ts=1000..1400 within the 600s window
+    // [1000, 1600]; the last observation (300) never gets a "next"
+    // observation, so the TWAP must extend it forward to end_ts=1600 —
+    // without that extension this would (incorrectly) average to 150
+    // instead of 200.
+    for (price, ts) in [(100_i128, 1000u64), (200, 1200), (300, 1400)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &1600u64,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    // (100*200 + 200*200 + 300*200) / 600 = (20000+40000+60000)/600 = 200.
+    assert_eq!(client.compute_twap(&call_id, &1600u64), 200);
+}
+
+#[test]
+fn test_twap_irregular_spacing() {
+    let env = Env::default();
+    let (_admin, _registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 45u64;
+    let call_end_ts = 1000u64;
+    // Uneven gaps: 100s, then 300s, then a 100s tail to end_ts.
+    for (price, ts) in [(200_i128, 500u64), (400, 600), (100, 900)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &call_end_ts,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    // (200*100 + 400*300 + 100*100) / 500 = (20000+120000+10000)/500 = 300.
+    assert_eq!(client.compute_twap(&call_id, &call_end_ts), 300);
 }
 
 #[test]
@@ -1063,10 +1123,13 @@ fn test_twap_requires_minimum_3_observations() {
     let env = Env::default();
     let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
     let call_id = 44u64;
-    for (price, ts) in [(100_i128, 1000u64), (200, 2000)] {
+    // Within the default 600s window before end_ts=2000 (window starts at
+    // 1400) so submission itself succeeds — only the *count* is short.
+    for (price, ts) in [(100_i128, 1400u64), (200, 1500)] {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
         client.submit_price_observation(
             &call_id,
+            &2000u64,
             &PriceObservation {
                 price,
                 timestamp: ts,
@@ -1075,7 +1138,173 @@ fn test_twap_requires_minimum_3_observations() {
             &sig,
         );
     }
-    let result = client.try_compute_twap(&call_id);
+    let result = client.try_compute_twap(&call_id, &2000u64);
+    assert_contract_error(result, OutcomeError::InsufficientPriceObservations);
+}
+
+#[test]
+fn test_twap_requires_half_window_span() {
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 46u64;
+    let call_end_ts = 10_000u64;
+    // Default window is 600s (min span 300s), but these 3 observations are
+    // clustered within 20s — plenty of *count*, not enough *span*.
+    for (price, ts) in [(100_i128, 9980u64), (200, 9990), (300, 10_000)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &call_end_ts,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    let result = client.try_compute_twap(&call_id, &call_end_ts);
+    assert_contract_error(result, OutcomeError::InsufficientPriceObservations);
+}
+
+#[test]
+fn test_resolve_price_falls_back_to_single_point_when_insufficient() {
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 47u64;
+    let call_end_ts = 2000u64;
+    // Only 2 observations — not enough for a trusted TWAP. Within the
+    // default 600s window (starts at 1400) so submission itself succeeds.
+    for (price, ts) in [(100_i128, 1450u64), (200, 1500)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &call_end_ts,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    let single_point_price = 999_i128;
+    assert_eq!(
+        client.resolve_price(&call_id, &call_end_ts, &single_point_price),
+        single_point_price
+    );
+}
+
+#[test]
+fn test_resolve_price_uses_twap_when_available() {
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 48u64;
+    let call_end_ts = 3000u64;
+    client.set_twap_config(&2000u64, &3u32);
+    for (price, ts) in [(100_i128, 1000u64), (200, 2000), (300, 3000)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &call_end_ts,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    // Falls back price is never used here — the TWAP (150) wins.
+    assert_eq!(client.resolve_price(&call_id, &call_end_ts, &999), 150);
+}
+
+#[test]
+fn test_submit_price_observation_rejects_outside_window() {
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 49u64;
+    // Default window is 600s; an observation 1000s before end_ts is outside it.
+    let call_end_ts = 10_000u64;
+    let ts = 9_000u64;
+    let sig = sign_observation(&env, &oracle_secret, call_id, 100, ts);
+    let result = client.try_submit_price_observation(
+        &call_id,
+        &call_end_ts,
+        &PriceObservation {
+            price: 100,
+            timestamp: ts,
+        },
+        &oracle_pubkey,
+        &sig,
+    );
+    assert_contract_error(result, OutcomeError::ObservationOutsideWindow);
+}
+
+#[test]
+fn test_set_twap_config_changes_window_and_min_observations() {
+    let env = Env::default();
+    let (admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    client.set_twap_config(&200u64, &2u32);
+    assert_eq!(client.get_twap_config(), (200u64, 2u32));
+
+    // With min_observations lowered to 2, 2 well-spaced observations now
+    // produce a valid TWAP instead of falling back. Window is [1100, 1300];
+    // span (100) meets the new half-window requirement (100) exactly.
+    let call_id = 50u64;
+    let call_end_ts = 1300u64;
+    for (price, ts) in [(100_i128, 1100u64), (300, 1200)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &call_end_ts,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    // (100*100 + 300*100) / 200 = 200.
+    assert_eq!(client.compute_twap(&call_id, &call_end_ts), 200);
+    let _ = admin;
+}
+
+#[test]
+fn test_twap_overflow_prevention_large_window() {
+    let env = Env::default();
+    let (_admin, _reg, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 51u64;
+    // A large price and a very large time window shouldn't panic on
+    // overflow — try_compute_twap must reject gracefully via checked ops
+    // rather than trapping, and compute_twap surfaces that as a typed error
+    // rather than an unhandled overflow trap.
+    // i128::MAX/2 multiplied by even a ~1000-second gap vastly exceeds
+    // i128::MAX, so this overflows regardless of how wide the window is —
+    // widen it only enough that submission succeeds and the span check
+    // passes, so the overflow surfaces from compute_twap's own arithmetic
+    // (the actual thing under test), not from an unrelated rejection.
+    let huge_price = i128::MAX / 2;
+    let call_end_ts = 3000u64;
+    client.set_twap_config(&2000u64, &3u32);
+    for (price, ts) in [(huge_price, 1_000u64), (huge_price, 2_000), (huge_price, 3_000)] {
+        let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
+        client.submit_price_observation(
+            &call_id,
+            &call_end_ts,
+            &PriceObservation {
+                price,
+                timestamp: ts,
+            },
+            &oracle_pubkey,
+            &sig,
+        );
+    }
+    let result = client.try_compute_twap(&call_id, &call_end_ts);
+    // These inputs genuinely overflow i128 — `try_compute_twap`'s checked_*
+    // arithmetic must catch that and surface it as a graceful typed error
+    // (not an unhandled arithmetic panic/trap).
     assert_contract_error(result, OutcomeError::InsufficientPriceObservations);
 }
 


### PR DESCRIPTION
## Summary

Closes #473

TWAP already existed here as an **unintegrated stub** — `submit_price_observation` and `compute_twap` worked, but with no configuration, no time-window enforcement, no `TwapComputed` event, and — critically — a formula bug: it only averaged between the *first* and *last* submitted observation, silently dropping the tail segment from the last observation to the call's actual `end_ts`. This diverged from the issue's own stated formula. This PR extends the existing code to close those gaps rather than rebuilding it.

- **`TwapConfig`** (`window_secs`, `min_observations`; defaults 600s / 3) with a `set_twap_config` admin function and `get_twap_config` getter
- **`submit_price_observation`** now takes `call_end_ts` and rejects observations outside `[call_end_ts - window_secs, call_end_ts]` (`ObservationOutsideWindow`)
- **`compute_twap`**'s formula now extends the last observation's price forward to `end_ts` (previously silently dropped), and requires observations to span at least half the window in addition to the minimum count
- **`resolve_price(call_id, end_ts, single_point_price) -> i128`** — never panics; returns the TWAP when enough observations exist, falls back to the given single-point price otherwise. Deliberately does **not** touch the existing oracle-quorum/dispute-window pipeline (`submit_outcome`/`finalize_outcome`) — that flow is mature and already tested, and this issue only scopes the TWAP primitive + its fallback behavior, not a rewrite of resolution itself
- **`TwapComputed(call_id, twap_price, observation_count)`** event

## Acceptance criteria

- [x] `submit_price_observation(env, oracle, call_id, price, timestamp, pubkey, signature)` — extended existing function with window validation
- [x] Oracles submit observations during `twap_window_secs` before `end_ts` (default 600s), enforced on submission
- [x] `compute_twap(env, call_id) -> i128` — time-weighted average, now correctly extended to the window end
- [x] Minimum observation count *and* half-window span both required for a valid TWAP
- [x] Insufficient observations → graceful single-point fallback (`resolve_price`)
- [x] `set_twap_config(env, window_secs, min_observations)` admin function
- [x] `PriceObservationSubmitted` (already existed) and `TwapComputed` events
- [x] Tests: evenly-spaced accuracy, irregular spacing, insufficient-observations fallback, overflow prevention

## Test plan

- [x] `cargo test -p outcome-manager` — 59/59 passing, including 10 new/updated TWAP tests:
  - `test_twap_three_equal_intervals`, `test_twap_irregular_spacing`, `test_twap_extends_last_price_to_end_ts` (pins down the formula fix specifically — would fail against the old, buggy formula)
  - `test_twap_requires_minimum_3_observations`, `test_twap_requires_half_window_span`
  - `test_resolve_price_falls_back_to_single_point_when_insufficient`, `test_resolve_price_uses_twap_when_available`
  - `test_submit_price_observation_rejects_outside_window`
  - `test_set_twap_config_changes_window_and_min_observations`
  - `test_twap_overflow_prevention_large_window` — deliberately overflowing price × window combination, confirmed to surface as a graceful typed error rather than an arithmetic trap
- [x] `cargo test --workspace` — 118 tests passing across the whole workspace
- [x] `cargo build --release` — clean
