### PR TITLE
Add reputation-weighted staking limits to call_registry

### DIFF
--- a/packages/contracts/call_registry/src/errors.rs
+++ b/packages/contracts/call_registry/src/errors.rs
@@ -38,4 +38,18 @@ pub enum CallRegistryError {
     Sep10TokenExpired = 16,
     /// Re-entrant call detected on a guarded function.
     ReentrancyDetected = 17,
+    /// A checked arithmetic operation (multiplication, division, addition, or
+    /// subtraction) would have overflowed/underflowed or divided by zero.
+    /// Raised by the reputation-weighted stake-limit calculations and any
+    /// other checked-math call sites in this crate.
+    Overflow = 18,
+}
+
+/// Panics with [`CallRegistryError::Overflow`]. Shared helper for checked
+/// arithmetic call sites across the crate (mirrors the equivalent
+/// `overflow<T>` helper used in the `outcome_manager` crate for the same
+/// purpose, so both contracts fail the same deterministic way on overflow
+/// instead of relying on raw wrapping/panicking arithmetic operators).
+pub fn overflow<T>(env: &soroban_sdk::Env) -> T {
+    soroban_sdk::panic_with_error!(env, CallRegistryError::Overflow);
 }

--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -8,6 +8,8 @@ use soroban_sdk::{Address, Bytes, BytesN, Env, Symbol};
 pub const PARAM_MAX_STAKE_PER_USER: &str = "max_stake_per_user";
 pub const PARAM_MIN_STAKE: &str = "min_stake";
 pub const PARAM_STAKING_CUTOFF: &str = "staking_cutoff_secs";
+pub const PARAM_BASE_STAKE_LIMIT: &str = "base_stake_limit";
+pub const PARAM_REPUTATION_MULTIPLIER: &str = "reputation_multiplier";
 
 /// Emitted when a new call is created
 pub fn emit_call_created(
@@ -398,6 +400,17 @@ pub fn emit_xlm_stake_withdrawn(
     env.events().publish(
         ("call_registry", "xlm_stake_withdrawn"),
         (call_id, staker.clone(), refunded_amount, penalty),
+    );
+}
+
+/// Emitted when a user's on-chain reputation stats change (via `resolve_call`)
+/// enough to alter their reputation-weighted individual stake limit (see
+/// `crate::reputation`). `new_limit` is the freshly recomputed
+/// `get_user_stake_limit` value.
+pub fn emit_stake_limit_updated(env: &Env, user: &Address, new_limit: i128) {
+    env.events().publish(
+        ("call_registry", "StakeLimitUpdated"),
+        (user.clone(), new_limit),
     );
 }
 

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -81,6 +81,7 @@ mod withdrawal;
 #[cfg(test)]
 mod fuzz_tests;
 mod governance;
+mod reputation;
 mod sep10;
 mod shares;
 mod storage;
@@ -175,6 +176,8 @@ impl CallRegistry {
             resolution_grace_period: 604800,
             admin_set: Vec::new(&env),
             admin_threshold: 1,
+            base_stake_limit: 0,
+            reputation_multiplier: 0,
         };
 
         set_config(&env, &config);
@@ -600,9 +603,24 @@ impl CallRegistry {
         let current_staker_stake = outcome_stakers.get(staker_key.clone()).unwrap_or(0);
         let updated_staker_stake = current_staker_stake + amount;
 
-        // Per-user stake cap
-        if config.max_stake_per_user > 0 && updated_staker_stake > config.max_stake_per_user {
-            panic!("Stake exceeds max_stake_per_user cap");
+        // Reputation-weighted individual stake cap (per call, per position).
+        // Replaces the old flat `max_stake_per_user`-only check: the user's
+        // personal limit now scales with their on-chain prediction accuracy
+        // and historical stake volume (see `reputation` module), while
+        // `max_stake_per_user`, if configured, still acts as an absolute
+        // outer ceiling on top of it.
+        let staker_stats = get_creator_stats(&env, &staker);
+        let staker_volume = get_user_total_stake_volume(&env, &staker);
+        let effective_limit = reputation::effective_stake_limit(
+            &env,
+            config.base_stake_limit,
+            config.reputation_multiplier,
+            config.max_stake_per_user,
+            &staker_stats,
+            staker_volume,
+        );
+        if updated_staker_stake > effective_limit {
+            panic!("Stake exceeds reputation-weighted stake limit");
         }
 
         // Transfer tokens in — supports both native XLM and SAC-wrapped tokens.
@@ -632,6 +650,7 @@ impl CallRegistry {
         set_call(&env, &call);
         add_staker_call(&env, &staker, call_id);
         record_stake(&env, &staker, amount);
+        record_user_stake_volume(&env, &staker, amount);
         extend_storage_ttl(&env);
 
         // Emit distinct XLM event so the indexer can differentiate XLM from USDC volume.
@@ -755,8 +774,37 @@ impl CallRegistry {
 
     /// Set the maximum individual stake per user per position per call (admin only).
     /// Pass `0` to remove the cap.
+    ///
+    /// This remains a separate, absolute ceiling on top of the
+    /// reputation-weighted personal limit — see `set_reputation_params` and
+    /// the `reputation` module doc comment for how the two combine.
     pub fn set_max_stake_per_user(env: Env, new_max: i128) {
         admin::set_max_stake_per_user(env, new_max);
+    }
+
+    /// Set reputation-weighted staking-limit parameters (admin only).
+    ///
+    /// * `base_limit` — the personal stake ceiling (per call, per position)
+    ///   for brand-new users, and the baseline the reputation multiplier
+    ///   scales from. Pass `0` to disable the reputation-weighted system
+    ///   entirely (only `max_stake_per_user`, if any, will apply).
+    /// * `multiplier` — reputation multiplier in basis points (`10_000` ==
+    ///   `1.0`). See the `reputation` module for the exact fixed-point
+    ///   formula.
+    ///
+    /// # Panics
+    /// * Contract not initialized.
+    /// * `base_limit` is negative.
+    pub fn set_reputation_params(env: Env, base_limit: i128, multiplier: u32) {
+        reputation::set_reputation_params(env, base_limit, multiplier);
+    }
+
+    /// View: the reputation-weighted individual stake limit (per call, per
+    /// position) currently enforced for `user` in `stake_on_call`, after
+    /// combining the reputation formula with `max_stake_per_user` (if
+    /// configured). Returns `i128::MAX` when no cap applies at all.
+    pub fn get_user_stake_limit(env: Env, user: Address) -> i128 {
+        reputation::get_user_stake_limit(&env, &user)
     }
 
     /// Set the minimum stake required per staking action (admin only).
@@ -832,6 +880,7 @@ impl CallRegistry {
 
         // Track creator reputation: increment total_resolved and conditionally total_correct
         let mut creator_stats = get_creator_stats(&env, &call.creator);
+        let old_creator_stats = creator_stats.clone();
         creator_stats.total_resolved += 1;
 
         // Check if creator staked on the winning position
@@ -846,6 +895,20 @@ impl CallRegistry {
         }
 
         set_creator_stats(&env, &call.creator, &creator_stats);
+
+        // Reputation stats just changed — recompute the creator's
+        // reputation-weighted stake limit and emit `StakeLimitUpdated` if it
+        // actually moved (e.g. crossing the "proven user" resolved-call
+        // threshold, or accuracy shifting enough to change the limit).
+        let creator_volume = get_user_total_stake_volume(&env, &call.creator);
+        reputation::maybe_emit_stake_limit_updated(
+            &env,
+            &call.creator,
+            &config,
+            &old_creator_stats,
+            &creator_stats,
+            creator_volume,
+        );
 
         set_call(&env, &call);
         extend_storage_ttl(&env);

--- a/packages/contracts/call_registry/src/reputation.rs
+++ b/packages/contracts/call_registry/src/reputation.rs
@@ -1,0 +1,306 @@
+//! Reputation-weighted individual staking limits.
+//!
+//! Historically `stake_on_call` enforced a single flat, admin-set
+//! `max_stake_per_user` cap for every user. This module replaces that with a
+//! *personal* limit derived from each user's on-chain prediction track record
+//! (`CreatorStats`) and their historical stake volume relative to the rest of
+//! the platform: proven, accurate predictors earn a higher personal limit,
+//! while brand-new accounts are held to a conservative baseline. This both
+//! curbs spam from disposable accounts and rewards demonstrated skill.
+//!
+//! # Fixed-point conventions
+//!
+//! Soroban/WASM contracts must never use floating-point types (`f32`/`f64`):
+//! floating-point arithmetic is not guaranteed to be bit-identical across
+//! host implementations, which would break consensus. Every ratio in this
+//! module is therefore expressed as an integer number of **basis points**
+//! (bps), where `10_000` represents `1.0` -- the same convention already used
+//! elsewhere in this crate for `fee_bps`:
+//!
+//! * `accuracy_bps`     -- `total_correct / max(total_resolved, 1)`, scaled to bps
+//!   (range `0..=10_000`).
+//! * `reputation_multiplier` (config field, `u32`) -- bps scale; `10_000` means
+//!   a fully accurate (100%) user's accuracy term contributes a full
+//!   *additional* `1.0x` on top of the baseline `1.0x` (see formula below).
+//! * `volume_factor_bps` -- `user_volume / platform_average_volume`, scaled to
+//!   bps, capped at [`MAX_VOLUME_FACTOR_BPS`] (`20_000` == `2.0x`).
+//!
+//! # Formula
+//!
+//! For a user whose `CreatorStats` show `total_resolved >=
+//! `[`NEW_USER_RESOLVED_THRESHOLD`]` (10):
+//!
+//! ```text
+//! accuracy_bps   = total_correct * 10_000 / max(total_resolved, 1)
+//! factor_bps     = 10_000 + (accuracy_bps * reputation_multiplier / 10_000)
+//! volume_factor  = min(user_volume * 10_000 / platform_average_volume, 20_000)
+//! reputation_limit = base_stake_limit * factor_bps / 10_000 * volume_factor / 10_000
+//! ```
+//!
+//! Users below the threshold (new accounts) skip the formula entirely and
+//! get exactly `base_stake_limit` -- neither their (necessarily low-sample)
+//! accuracy nor any stake volume they've accumulated can raise their limit
+//! until they have a real resolved track record. This is a deliberate hard
+//! gate: the acceptance criteria calls for new users to be "restricted to
+//! *only* base_stake_limit", so we do not let the general formula's edge
+//! cases (e.g. a new user with 0 resolved calls trivially has `accuracy_bps
+//! == 0`, but could still have accumulated large stake `volume_factor`)
+//! sneak in a higher limit.
+//!
+//! `platform_average_volume` approximates the acceptance criteria's
+//! "platform median volume" as `GlobalStats.total_stake_volume /
+//! GlobalStats.total_unique_stakers`. Note this is a *mean*, not a true
+//! median -- the contract does not track a sorted distribution of
+//! per-user volumes on-chain (that would be prohibitively expensive in
+//! storage/compute), and `GlobalStats` (see `types.rs`) only exposes the
+//! aggregate volume and unique-staker count, matching exactly what the
+//! issue's technical pointers described. This is called out explicitly here
+//! and in the implementation report.
+//!
+//! # Interaction with `max_stake_per_user`
+//!
+//! `max_stake_per_user` remains a separate, admin-set *absolute ceiling*.
+//! When configured (non-zero), it is combined with the computed reputation
+//! limit as `effective_limit = min(reputation_limit, max_stake_per_user)`.
+//! In other words, reputation can only ever narrow a user's limit to *below*
+//! the admin's platform-wide safety ceiling, never lift them above it -- an
+//! admin who sets `max_stake_per_user` is making a hard, platform-wide risk
+//! decision that no amount of reputation should override. If
+//! `max_stake_per_user == 0` (its existing "unlimited" sentinel), only the
+//! reputation limit applies. If `base_stake_limit == 0` (the reputation
+//! system left unconfigured, which is the default on a freshly initialized
+//! contract), the reputation limit itself is treated as unlimited, so
+//! existing/legacy deployments that never call `set_reputation_params`
+//! behave exactly as before this feature was added.
+
+use soroban_sdk::{Address, Env};
+
+use crate::errors::overflow;
+use crate::events::{
+    emit_admin_params_changed_i128, emit_admin_params_changed_u32, emit_stake_limit_updated,
+    PARAM_BASE_STAKE_LIMIT, PARAM_REPUTATION_MULTIPLIER,
+};
+use crate::storage::{
+    extend_storage_ttl, get_config, get_creator_stats, get_global_stats,
+    get_user_total_stake_volume, set_config,
+};
+use crate::types::{ContractConfig, CreatorStats};
+
+/// Basis-point scale used throughout this module: `10_000` == `1.0`.
+pub const BPS_SCALE: i128 = 10_000;
+
+/// Number of a user's resolved (self-created) calls required before
+/// reputation scaling applies at all. Below this, only `base_stake_limit`
+/// applies, regardless of accuracy or stake volume.
+pub const NEW_USER_RESOLVED_THRESHOLD: u32 = 10;
+
+/// Cap on `volume_factor_bps`: `20_000` bps == `2.0x`.
+pub const MAX_VOLUME_FACTOR_BPS: i128 = 20_000;
+
+/// Compute `accuracy_bps` for a `CreatorStats` snapshot:
+/// `total_correct / max(total_resolved, 1)`, scaled to basis points.
+fn accuracy_bps(env: &Env, stats: &CreatorStats) -> i128 {
+    let denom = stats.total_resolved.max(1) as i128;
+    (stats.total_correct as i128)
+        .checked_mul(BPS_SCALE)
+        .unwrap_or_else(|| overflow(env))
+        .checked_div(denom)
+        .unwrap_or_else(|| overflow(env))
+}
+
+/// Compute `volume_factor_bps = min(user_volume / platform_average_volume, 2.0x)`.
+/// Returns `BPS_SCALE` (neutral `1.0x`) if the platform has no stake history
+/// yet, to avoid dividing by zero.
+fn volume_factor_bps(env: &Env, user_volume: i128) -> i128 {
+    let stats = get_global_stats(env);
+    if stats.total_unique_stakers == 0 || stats.total_stake_volume <= 0 {
+        return BPS_SCALE;
+    }
+
+    let platform_average_volume = stats
+        .total_stake_volume
+        .checked_div(stats.total_unique_stakers as i128)
+        .unwrap_or_else(|| overflow(env));
+
+    if platform_average_volume <= 0 {
+        return BPS_SCALE;
+    }
+
+    let raw_bps = user_volume
+        .max(0)
+        .checked_mul(BPS_SCALE)
+        .unwrap_or_else(|| overflow(env))
+        .checked_div(platform_average_volume)
+        .unwrap_or_else(|| overflow(env));
+
+    raw_bps.min(MAX_VOLUME_FACTOR_BPS)
+}
+
+/// Compute the raw reputation-weighted limit for `stats`/`user_volume`
+/// against `base_stake_limit`/`reputation_multiplier`, *before* the
+/// `max_stake_per_user` ceiling is applied.
+///
+/// Returns `None` when `base_stake_limit <= 0`, meaning "the reputation
+/// system is unconfigured / imposes no limit".
+fn reputation_limit(
+    env: &Env,
+    base_stake_limit: i128,
+    reputation_multiplier: u32,
+    stats: &CreatorStats,
+    user_volume: i128,
+) -> Option<i128> {
+    if base_stake_limit <= 0 {
+        return None;
+    }
+
+    if stats.total_resolved < NEW_USER_RESOLVED_THRESHOLD {
+        // New / unproven account: hard gate at exactly the baseline, ignoring
+        // accuracy and volume entirely (see module doc comment).
+        return Some(base_stake_limit);
+    }
+
+    let acc_bps = accuracy_bps(env, stats);
+    let reputation_term = acc_bps
+        .checked_mul(reputation_multiplier as i128)
+        .unwrap_or_else(|| overflow(env))
+        .checked_div(BPS_SCALE)
+        .unwrap_or_else(|| overflow(env));
+    let factor_bps = BPS_SCALE
+        .checked_add(reputation_term)
+        .unwrap_or_else(|| overflow(env));
+
+    let vol_factor_bps = volume_factor_bps(env, user_volume);
+
+    let after_accuracy = base_stake_limit
+        .checked_mul(factor_bps)
+        .unwrap_or_else(|| overflow(env))
+        .checked_div(BPS_SCALE)
+        .unwrap_or_else(|| overflow(env));
+
+    let final_limit = after_accuracy
+        .checked_mul(vol_factor_bps)
+        .unwrap_or_else(|| overflow(env))
+        .checked_div(BPS_SCALE)
+        .unwrap_or_else(|| overflow(env));
+
+    Some(final_limit)
+}
+
+/// Combine the reputation limit with the admin's absolute `max_stake_per_user`
+/// ceiling (if configured) to get the limit actually enforced by
+/// `stake_on_call`. Returns `i128::MAX` when neither cap applies.
+pub fn effective_stake_limit(
+    env: &Env,
+    base_stake_limit: i128,
+    reputation_multiplier: u32,
+    max_stake_per_user: i128,
+    stats: &CreatorStats,
+    user_volume: i128,
+) -> i128 {
+    let rep_limit = reputation_limit(
+        env,
+        base_stake_limit,
+        reputation_multiplier,
+        stats,
+        user_volume,
+    )
+    .unwrap_or(i128::MAX);
+
+    if max_stake_per_user > 0 {
+        rep_limit.min(max_stake_per_user)
+    } else {
+        rep_limit
+    }
+}
+
+/// View: the reputation-weighted individual stake limit currently in effect
+/// for `user`, combining `CreatorStats`, historical stake volume, and the
+/// admin-configured parameters exactly as `stake_on_call` does. Returns
+/// `i128::MAX` when no cap applies at all.
+pub fn get_user_stake_limit(env: &Env, user: &Address) -> i128 {
+    let config = get_config(env).expect("not initialized");
+    let stats = get_creator_stats(env, user);
+    let user_volume = get_user_total_stake_volume(env, user);
+    effective_stake_limit(
+        env,
+        config.base_stake_limit,
+        config.reputation_multiplier,
+        config.max_stake_per_user,
+        &stats,
+        user_volume,
+    )
+}
+
+/// Admin-only: set `base_stake_limit` and `reputation_multiplier`.
+///
+/// # Authorization
+/// Current admin must sign.
+///
+/// # Panics
+/// * Contract not initialized.
+/// * `base_limit` is negative.
+pub fn set_reputation_params(env: Env, base_limit: i128, multiplier: u32) {
+    if base_limit < 0 {
+        panic!("base_stake_limit cannot be negative");
+    }
+
+    let mut config = get_config(&env).expect("not initialized");
+    config.admin.require_auth();
+
+    let old_base = config.base_stake_limit;
+    let old_multiplier = config.reputation_multiplier;
+    config.base_stake_limit = base_limit;
+    config.reputation_multiplier = multiplier;
+
+    set_config(&env, &config);
+    extend_storage_ttl(&env);
+
+    emit_admin_params_changed_i128(
+        &env,
+        PARAM_BASE_STAKE_LIMIT,
+        &config.admin,
+        old_base,
+        base_limit,
+    );
+    emit_admin_params_changed_u32(
+        &env,
+        PARAM_REPUTATION_MULTIPLIER,
+        &config.admin,
+        old_multiplier,
+        multiplier,
+    );
+}
+
+/// Recompute `user`'s effective stake limit before and after a `CreatorStats`
+/// mutation (i.e. around a `resolve_call` that updates `total_resolved` /
+/// `total_correct`) and emit `StakeLimitUpdated` iff the limit actually
+/// changed. Called from `resolve_call` after the creator's stats are updated.
+pub fn maybe_emit_stake_limit_updated(
+    env: &Env,
+    user: &Address,
+    config: &ContractConfig,
+    old_stats: &CreatorStats,
+    new_stats: &CreatorStats,
+    user_volume: i128,
+) {
+    let old_limit = effective_stake_limit(
+        env,
+        config.base_stake_limit,
+        config.reputation_multiplier,
+        config.max_stake_per_user,
+        old_stats,
+        user_volume,
+    );
+    let new_limit = effective_stake_limit(
+        env,
+        config.base_stake_limit,
+        config.reputation_multiplier,
+        config.max_stake_per_user,
+        new_stats,
+        user_volume,
+    );
+
+    if old_limit != new_limit {
+        emit_stake_limit_updated(env, user, new_limit);
+    }
+}

--- a/packages/contracts/call_registry/src/storage.rs
+++ b/packages/contracts/call_registry/src/storage.rs
@@ -22,6 +22,7 @@ pub enum DataKey {
     StakerCallSeen(Address, u64),
     CreatorStats(Address),
     UserStake(u64, Address, u32),
+    UserTotalStakeVolume(Address),
     UpStakerCount(u64),
     DownStakerCount(u64),
     VoidRefundClaimed(u64, Address),
@@ -364,6 +365,38 @@ pub fn get_creator_stats(env: &Env, creator: &Address) -> CreatorStats {
 pub fn set_creator_stats(env: &Env, creator: &Address, stats: &CreatorStats) {
     let key = DataKey::CreatorStats(creator.clone());
     env.storage().persistent().set(&key, stats);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+/// Get a user's cumulative total stake volume across all calls and positions
+/// they have ever staked on. Used as the "volume" input to the
+/// reputation-weighted stake-limit formula (see `crate::reputation`).
+pub fn get_user_total_stake_volume(env: &Env, user: &Address) -> i128 {
+    let key = DataKey::UserTotalStakeVolume(user.clone());
+    let result: Option<i128> = env.storage().persistent().get(&key);
+    if result.is_some() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    result.unwrap_or(0)
+}
+
+/// Accumulate `amount` into `user`'s cumulative total stake volume tracker.
+/// Uses checked addition; overflow panics with `CallRegistryError::Overflow`.
+pub fn record_user_stake_volume(env: &Env, user: &Address, amount: i128) {
+    let key = DataKey::UserTotalStakeVolume(user.clone());
+    let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+    let updated = current
+        .checked_add(amount)
+        .unwrap_or_else(|| crate::errors::overflow(env));
+    env.storage().persistent().set(&key, &updated);
     env.storage().persistent().extend_ttl(
         &key,
         PERSISTENT_LIFETIME_THRESHOLD,

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -2639,6 +2639,443 @@ mod call_registry {
         client.set_max_duration(&admin, &604_800u64);
         assert_eq!(client.get_max_duration(), 604_800u64);
     }
+    // ── Reputation-weighted staking limits ───────────────────────────────────
+
+    /// Find a specific event by topic among everything emitted so far.
+    /// `env.events().all()` accumulates events from every call in the test,
+    /// so callers who need a particular event (not necessarily the last one)
+    /// scan for it explicitly, mirroring `test_storage_stats_no_warning_below_threshold`'s
+    /// `.iter().any(...)` pattern above.
+    fn find_event(
+        env: &Env,
+        topic1: &str,
+        topic2: &str,
+    ) -> Option<(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)> {
+        let events = env.events().all();
+        for i in 0..events.len() {
+            let e = events.get(i).unwrap();
+            if e.1
+                == soroban_sdk::vec![env, topic1.into_val(env), topic2.into_val(env),]
+            {
+                return Some(e);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_reputation_limit_defaults_to_unlimited() {
+        // Fresh contract, reputation params never configured
+        // (base_stake_limit == 0 by default) -> no cap from reputation at all,
+        // matching pre-feature behavior for legacy/unconfigured deployments.
+        let (env, client, _admin, _om) = setup();
+        let user = Address::generate(&env);
+        assert_eq!(client.get_user_stake_limit(&user), i128::MAX);
+    }
+
+    #[test]
+    fn test_new_user_restricted_to_base_limit() {
+        let (env, admin, outcome_manager, other_creator) = create_test_env();
+        let new_user = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        client.set_reputation_params(&1_000_000_000_i128, &10_000u32);
+
+        // Give new_user a large stake-volume history on someone else's call.
+        // This must NOT raise their limit: CreatorStats (their own created &
+        // resolved calls) is the source of truth for reputation, and
+        // new_user has none, so they stay gated at exactly base_stake_limit
+        // regardless of stake volume.
+        let call_a = create_call_with_default_condition(
+            &client,
+            &other_creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
+        );
+        client.stake_on_call(&new_user, &call_a.id, &400_000_000_i128, &1);
+
+        assert_eq!(client.get_user_stake_limit(&new_user), 1_000_000_000);
+
+        // Staking exactly the base limit (on a fresh call/position) succeeds.
+        let call_b = create_call_with_default_condition(
+            &client,
+            &other_creator,
+            &stake_token,
+            &100_000_000_i128,
+            &3000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
+        );
+        let updated = client.stake_on_call(&new_user, &call_b.id, &1_000_000_000_i128, &1);
+        assert_eq!(updated.outcome_stakes.get(1).unwrap_or(0), 1_000_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "Stake exceeds reputation-weighted stake limit")]
+    fn test_new_user_exceeding_base_limit_panics() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let new_user = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        client.set_reputation_params(&1_000_000_000_i128, &10_000u32);
+
+        let call = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
+        );
+
+        // 1 stroop over the new-user base limit must be rejected.
+        client.stake_on_call(&new_user, &call.id, &1_000_000_001_i128, &1);
+    }
+
+    #[test]
+    fn test_proven_user_gets_higher_limit() {
+        let (env, admin, outcome_manager, proven_user) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        // Build a 10-call, 80%-accurate track record for `proven_user` as a
+        // call *creator* (CreatorStats -- total_created/total_resolved/
+        // total_correct -- is the reputation source of truth per the issue's
+        // technical pointers). Reputation params stay at their disabled
+        // default (0) while building history so this setup phase is not
+        // itself constrained by the very limit under test.
+        let mut call_ids: std::vec::Vec<u64> = std::vec::Vec::new();
+        for i in 0..10u64 {
+            let end_ts = 2000 + i * 1000;
+            let call = create_call_with_default_condition(
+                &client,
+                &proven_user,
+                &stake_token,
+                &100_000_000_i128,
+                &end_ts,
+                &token_address,
+                &pair_id,
+                &metadata_hash,
+                &2,
+            );
+            // proven_user stakes on UP (position 1) on their own call.
+            client.stake_on_call(&proven_user, &call.id, &50_000_000_i128, &1);
+            call_ids.push(call.id);
+        }
+
+        env.ledger().set_timestamp(20_000); // past every call's end_ts
+
+        // Resolve 8/10 as UP (matches proven_user's stake -> correct) and
+        // 2/10 as DOWN (incorrect) => 80% accuracy.
+        for (i, call_id) in call_ids.iter().enumerate() {
+            let outcome = if i < 8 { 1u32 } else { 2u32 };
+            client.resolve_call(call_id, &outcome, &150_000_000_i128);
+        }
+
+        let stats = client.get_creator_stats_view(&proven_user);
+        assert_eq!(stats.total_resolved, 10);
+        assert_eq!(stats.total_correct, 8);
+
+        // Now turn on reputation weighting.
+        client.set_reputation_params(&1_000_000_000_i128, &10_000u32);
+
+        // proven_user is the only staker on the platform so far
+        // (10 * 50_000_000 = 500_000_000 total volume, 1 unique staker),
+        // so platform_average_volume == proven_user's own volume =>
+        // volume_factor_bps == 10_000 (exactly 1.0x), no cap triggered.
+        //
+        // accuracy_bps  = 8 * 10_000 / 10               = 8_000  (80%)
+        // factor_bps    = 10_000 + (8_000 * 10_000/10_000) = 18_000 (1.8x)
+        // reputation_limit = 1_000_000_000 * 18_000/10_000 * 10_000/10_000
+        //                  = 1_800_000_000
+        assert_eq!(client.get_user_stake_limit(&proven_user), 1_800_000_000);
+
+        // Confirm stake_on_call actually enforces this higher, personal limit
+        // on a brand-new call.
+        let other_creator = Address::generate(&env);
+        let new_call = create_call_with_default_condition(
+            &client,
+            &other_creator,
+            &stake_token,
+            &100_000_000_i128,
+            &30_000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
+        );
+        let updated = client.stake_on_call(&proven_user, &new_call.id, &1_800_000_000_i128, &1);
+        assert_eq!(updated.outcome_stakes.get(1).unwrap_or(0), 1_800_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "Stake exceeds reputation-weighted stake limit")]
+    fn test_proven_user_still_capped_above_computed_limit() {
+        let (env, admin, outcome_manager, proven_user) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        let mut call_ids: std::vec::Vec<u64> = std::vec::Vec::new();
+        for i in 0..10u64 {
+            let end_ts = 2000 + i * 1000;
+            let call = create_call_with_default_condition(
+                &client,
+                &proven_user,
+                &stake_token,
+                &100_000_000_i128,
+                &end_ts,
+                &token_address,
+                &pair_id,
+                &metadata_hash,
+                &2,
+            );
+            client.stake_on_call(&proven_user, &call.id, &50_000_000_i128, &1);
+            call_ids.push(call.id);
+        }
+
+        env.ledger().set_timestamp(20_000);
+        for (i, call_id) in call_ids.iter().enumerate() {
+            let outcome = if i < 8 { 1u32 } else { 2u32 };
+            client.resolve_call(call_id, &outcome, &150_000_000_i128);
+        }
+
+        client.set_reputation_params(&1_000_000_000_i128, &10_000u32);
+        // computed reputation_limit == 1_800_000_000 (see test above).
+
+        let other_creator = Address::generate(&env);
+        let new_call = create_call_with_default_condition(
+            &client,
+            &other_creator,
+            &stake_token,
+            &100_000_000_i128,
+            &30_000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
+        );
+        // 1 stroop over the computed 1_800_000_000 reputation limit.
+        client.stake_on_call(&proven_user, &new_call.id, &1_800_000_001_i128, &1);
+    }
+
+    #[test]
+    fn test_stake_limit_recalculated_after_resolution_improves_accuracy() {
+        let (env, admin, outcome_manager, predictor) = create_test_env();
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        client.set_reputation_params(&1_000_000_000_i128, &10_000u32);
+
+        let mut call_ids: std::vec::Vec<u64> = std::vec::Vec::new();
+        for i in 0..10u64 {
+            let end_ts = 2000 + i * 1000;
+            let call = create_call_with_default_condition(
+                &client,
+                &predictor,
+                &stake_token,
+                &100_000_000_i128,
+                &end_ts,
+                &token_address,
+                &pair_id,
+                &metadata_hash,
+                &2,
+            );
+            client.stake_on_call(&predictor, &call.id, &50_000_000_i128, &1);
+            call_ids.push(call.id);
+        }
+
+        env.ledger().set_timestamp(20_000);
+
+        // Resolve the first 9 as UP (correct) -- still below the 10-resolved
+        // "proven user" threshold, so the limit stays pinned at base_stake_limit.
+        for call_id in call_ids.iter().take(9) {
+            client.resolve_call(call_id, &1u32, &150_000_000_i128);
+        }
+        assert_eq!(client.get_creator_stats_view(&predictor).total_resolved, 9);
+        assert_eq!(client.get_user_stake_limit(&predictor), 1_000_000_000);
+
+        // Resolve the 10th call, also correctly. This crosses the
+        // NEW_USER_RESOLVED_THRESHOLD (10) with 10/10 == 100% accuracy,
+        // which must both recompute and emit the new limit.
+        //
+        // NOTE: the test harness's `env.events().all()` only reflects events
+        // from the most recent top-level contract invocation, so the
+        // StakeLimitUpdated check below must happen immediately after this
+        // call and before any other client call (even read-only views).
+        client.resolve_call(&call_ids[9], &1u32, &150_000_000_i128);
+
+        let event = find_event(&env, "call_registry", "StakeLimitUpdated")
+            .expect("StakeLimitUpdated was not emitted on the 10th resolution");
+        let (user, new_limit): (Address, i128) = event.2.into_val(&env);
+        assert_eq!(user, predictor);
+        assert_eq!(new_limit, 2_000_000_000);
+
+        // accuracy_bps = 10 * 10_000 / 10 = 10_000 (100%)
+        // factor_bps   = 10_000 + (10_000 * 10_000 / 10_000) = 20_000 (2.0x)
+        // volume_factor = 1.0x (predictor is still the only staker on the
+        // platform: 10 * 50_000_000 = 500_000_000 total volume / 1 unique
+        // staker == predictor's own volume)
+        // reputation_limit = 1_000_000_000 * 20_000/10_000 * 10_000/10_000
+        //                   = 2_000_000_000
+        assert_eq!(client.get_user_stake_limit(&predictor), 2_000_000_000);
+    }
+
+    #[test]
+    fn test_admin_can_set_reputation_params() {
+        let (env, client, admin, _om) = setup();
+        let _ = admin;
+
+        let config_before = client.get_config();
+        assert_eq!(config_before.base_stake_limit, 0);
+        assert_eq!(config_before.reputation_multiplier, 0);
+
+        client.set_reputation_params(&2_000_000_000_i128, &15_000u32);
+
+        // NOTE: `env.events().all()` in this test harness only reflects the
+        // most recent top-level contract invocation, so this check must
+        // happen immediately after `set_reputation_params` and before any
+        // other client call (even read-only views like `get_config`).
+        let has_base_limit_event = find_event(&env, "call_registry", "admin_params_changed")
+            .is_some();
+        assert!(has_base_limit_event);
+
+        let config_after = client.get_config();
+        assert_eq!(config_after.base_stake_limit, 2_000_000_000);
+        assert_eq!(config_after.reputation_multiplier, 15_000);
+
+        let new_user = Address::generate(&env);
+        assert_eq!(client.get_user_stake_limit(&new_user), 2_000_000_000);
+    }
+
+    #[test]
+    fn test_max_stake_per_user_still_acts_as_absolute_ceiling() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let user = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        // Reputation alone would allow up to base_stake_limit (new-user tier
+        // == 1_000_000_000), but the admin's absolute ceiling is stricter and
+        // must win: effective_limit = min(reputation_limit, max_stake_per_user).
+        client.set_reputation_params(&1_000_000_000_i128, &10_000u32);
+        client.set_max_stake_per_user(&300_000_000_i128);
+
+        assert_eq!(client.get_user_stake_limit(&user), 300_000_000);
+
+        let call = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
+        );
+        let updated = client.stake_on_call(&user, &call.id, &300_000_000_i128, &1);
+        assert_eq!(updated.outcome_stakes.get(1).unwrap_or(0), 300_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "Stake exceeds reputation-weighted stake limit")]
+    fn test_max_stake_per_user_ceiling_rejects_excess() {
+        let (env, admin, outcome_manager, creator) = create_test_env();
+        let user = Address::generate(&env);
+        let contract_id = env.register_contract(None, CallRegistry);
+        let client = CallRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &outcome_manager, &TEST_MIN_STAKE);
+        env.ledger().set_timestamp(1000);
+
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+        let token_address = Address::generate(&env);
+        let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
+        let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        client.set_reputation_params(&1_000_000_000_i128, &10_000u32);
+        client.set_max_stake_per_user(&300_000_000_i128);
+
+        let call = create_call_with_default_condition(
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
+        );
+        client.stake_on_call(&user, &call.id, &300_000_001_i128, &1);
+    }
 }
 
 // ── Native XLM staking tests ──────────────────────────────────────────────────
@@ -3134,5 +3571,6 @@ mod sep10_tests {
         let user = Address::generate(&env);
         assert_eq!(client.get_sep10_home_domain(&user), None);
     }
+
 
 }

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -150,6 +150,17 @@ pub struct ContractConfig {
     pub admin_set: Vec<Address>,
     /// Minimum number of admin signatures required. Default: 1 (backward compatible).
     pub admin_threshold: u32,
+    /// Baseline individual stake limit (per call, per position) used by the
+    /// reputation-weighted staking-limit system (see `crate::reputation`).
+    /// `0` disables reputation-weighted limits entirely (unlimited, subject
+    /// only to `max_stake_per_user` if that is separately configured).
+    /// Default: 0.
+    pub base_stake_limit: i128,
+    /// Reputation multiplier in basis points (`10_000` == `1.0`) applied to a
+    /// user's on-chain prediction accuracy when computing their individual
+    /// reputation-weighted stake limit. See `crate::reputation` for the exact
+    /// fixed-point formula. Default: 0.
+    pub reputation_multiplier: u32,
 }
 
 /// Contract-wide aggregated statistics for dashboards.


### PR DESCRIPTION
## Summary
closes #468 
- Replaces the flat `max_stake_per_user` cap with a dynamic, accuracy-based limit derived from each user's `CreatorStats`
- Adds `base_stake_limit`/`reputation_multiplier` (bps) to `ContractConfig`; new fixed-point (basis-points) formula computes `accuracy_bps` / `factor_bps` / `volume_bps` and combines them into a per-user `reputation_limit`
- Users with <10 resolved calls are hard-gated to `base_stake_limit`; `max_stake_per_user`, when configured, still acts as an absolute outer ceiling on top of the reputation limit
- Adds `set_reputation_params` (admin) and `get_user_stake_limit` (view); emits `StakeLimitUpdated`
- New `UserTotalStakeVolume` per-user counter added since no equivalent aggregate existed

## Acceptance criteria
- [x] `base_stake_limit`/`reputation_multiplier` added to `ContractConfig`
- [x] Reputation-limit formula wired into `stake_on_call`
- [x] New users (<10 resolved) restricted to base limit
- [x] Proven users (>10 resolved, >70% accuracy) can reach up to `base_stake_limit * reputation_multiplier`
- [x] Reads existing `CreatorStats`
- [x] `set_reputation_params(env, base_limit, multiplier)` admin fn
- [x] `get_user_stake_limit(env, user) -> i128` view fn
- [x] `StakeLimitUpdated(user, new_limit)` event
- [x] Tests: new-user restriction, proven-user higher limit, recalculation after accuracy improves, admin param updates

## Test plan
- [x] `cargo test -p call-registry` — 121 unit + 6 integration tests passing
- [x] `cargo build --release -p call-registry`
- [x] Verified `backit-shared`, `outcome-manager`, `prediction-market` unaffected (workspace-wide `cargo test --workspace` blocked only by a pre-existing, unrelated missing-`stellar`-CLI build-script dependency in `prediction_market_factory`/`parlay_betting`, present on a clean `main` checkout too)