### PR TITLE
Add gas_station contract for cross-contract gas sponsorship (#469)

### DIFF
--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -658,6 +658,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gas-station"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "ed25519-dalek",
+ "outcome-manager",
+ "prediction-market",
+ "prediction-market-factory",
+ "rand",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/packages/contracts/Cargo.toml
+++ b/packages/contracts/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "prediction_market",
   "prediction_market_factory",
   "parlay_betting",
+  "gas_station",
   "contracts/hello-world",
 ]
 

--- a/packages/contracts/gas_station/Cargo.toml
+++ b/packages/contracts/gas_station/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "gas-station"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+outcome-manager = { path = "../outcome_manager" }
+prediction-market = { path = "../prediction_market" }
+prediction-market-factory = { path = "../prediction_market_factory" }
+backit-shared = { workspace = true }
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+rand = "0.8"

--- a/packages/contracts/gas_station/src/errors.rs
+++ b/packages/contracts/gas_station/src/errors.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum GasStationError {
+    /// A function requiring initialization was called before `initialize`.
+    NotInitialized = 1,
+    /// `initialize` was called on an already-initialized contract.
+    AlreadyInitialized = 2,
+    /// The caller-supplied admin address does not match the stored admin.
+    Unauthorized = 3,
+    /// `winning_cut_bps` exceeds 10 000 (100%).
+    InvalidWinningCutBps = 4,
+    /// `max_gas_xlm` (or an effective-stake gas estimate) is not positive,
+    /// or would make the effective stake negative.
+    InvalidGasAmount = 5,
+    /// `user` has no active sponsorship registered with this gas station.
+    UserNotSponsored = 6,
+    /// This `call_id` has already had its sponsored payout processed.
+    CallAlreadyProcessed = 7,
+    /// `staker_winning_stake` is 0 or negative; there is nothing to claim.
+    InvalidWinningStake = 8,
+    /// An arithmetic operation overflowed; the transaction is reverted.
+    Overflow = 9,
+    /// `refill_gas_pool` was called with a non-positive amount.
+    InvalidRefillAmount = 10,
+}

--- a/packages/contracts/gas_station/src/events.rs
+++ b/packages/contracts/gas_station/src/events.rs
@@ -1,0 +1,51 @@
+#![allow(deprecated)]
+
+use soroban_sdk::{Address, Env};
+
+pub fn emit_gas_station_initialized(env: &Env, admin: &Address, xlm_token: &Address) {
+    env.events().publish(
+        ("gas_station", "initialized"),
+        (admin.clone(), xlm_token.clone()),
+    );
+}
+
+pub fn emit_admin_changed(env: &Env, new_admin: &Address) {
+    env.events()
+        .publish(("gas_station", "admin_changed"), new_admin.clone());
+}
+
+pub fn emit_sponsorship_registered(
+    env: &Env,
+    user: &Address,
+    max_gas_xlm: i128,
+    winning_cut_bps: u32,
+) {
+    env.events().publish(
+        ("gas_station", "sponsorship_registered"),
+        (user.clone(), max_gas_xlm, winning_cut_bps),
+    );
+}
+
+pub fn emit_sponsorship_revoked(env: &Env, user: &Address) {
+    env.events()
+        .publish(("gas_station", "sponsorship_revoked"), user.clone());
+}
+
+pub fn emit_sponsored_payout_claimed(
+    env: &Env,
+    call_id: u64,
+    user: &Address,
+    gross_payout: i128,
+    cut: i128,
+    user_amount: i128,
+) {
+    env.events().publish(
+        ("gas_station", "sponsored_payout_claimed"),
+        (call_id, user.clone(), gross_payout, cut, user_amount),
+    );
+}
+
+pub fn emit_pool_refilled(env: &Env, amount: i128, new_balance: i128) {
+    env.events()
+        .publish(("gas_station", "pool_refilled"), (amount, new_balance));
+}

--- a/packages/contracts/gas_station/src/lib.rs
+++ b/packages/contracts/gas_station/src/lib.rs
@@ -1,0 +1,407 @@
+//! Cross-contract Gas Station for gasless UX.
+//!
+//! New Stellar users often don't hold any XLM, so they can't pay the network
+//! fee for their very first transaction — a classic chicken-and-egg problem.
+//! This contract lets the platform sponsor that fee on a user's behalf, in
+//! exchange for a small cut of the user's winnings if their sponsored call
+//! resolves in their favor. If it doesn't, the gas station simply absorbs
+//! the (small) cost.
+//!
+//! **What is, and isn't, on-chain here.** The actual fee payment happens
+//! off-chain: the backend relay submits the user's signed operation as the
+//! *inner* transaction of a Stellar fee-bump transaction, with the gas
+//! station's own account as the fee source (`POST /relay/tx` —
+//! `relay.service.ts`, explicitly out of scope for this contract). Soroban
+//! contracts have no way to observe or intercept that classic-layer fee
+//! payment, so this contract's role is: (1) record which users are
+//! sponsored and on what terms, (2) act as bookkeeping for how much gas the
+//! program has fronted and how much it has earned back, and (3) — the part
+//! that *does* need to be on-chain — actually enforce the winning cut at
+//! payout time, per [`GasStation::claim_sponsored_payout`].
+//!
+//! **Why the cut needs an on-chain intermediary.** `outcome_manager::claim_payout`
+//! (see `outcome_manager/src/lib.rs`) transfers a winner's payout directly to
+//! the winning `staker` address via the market's `release_escrow`. A third
+//! contract watching from the sidelines cannot "tax" a transfer it isn't
+//! part of. So, mirroring `parlay_betting`'s escrow model (see
+//! `parlay_betting/src/lib.rs`), this contract claims *as itself* — the
+//! payout lands in the gas station's own balance first — deducts its cut,
+//! and forwards the remainder to the user.
+//!
+//! **Auth chain — traced, not assumed.** Unlike `parlay_betting`, which
+//! needs `env.authorize_as_current_contract` to pre-authorize the token
+//! transfer *into* the market when it stakes as itself, this contract needs
+//! **no such pre-authorization** for the claim path. Tracing the call graph
+//! for `claim_sponsored_payout`:
+//!
+//! 1. `gas_station` calls `outcome_manager.claim_payout` directly, passing
+//!    `staker = gas_station`'s own address. Inside, `staker.require_auth()`
+//!    succeeds automatically: `gas_station` *is* the direct invoker of this
+//!    call, and Soroban auto-authorizes an address for a require_auth() check
+//!    when that address is the contract that directly invoked the current
+//!    call (the same rule `parlay_betting`'s doc comment relies on for its
+//!    own `staker.require_auth()` inside `stake_on_call`).
+//! 2. `outcome_manager` in turn calls `market.release_escrow(call_id, to,
+//!    amount)` directly. Inside, `config.outcome_manager.require_auth()`
+//!    succeeds automatically for the identical reason: `outcome_manager` is
+//!    the direct invoker of `release_escrow`.
+//! 3. `release_escrow` then calls `token.transfer(from = market's own
+//!    address, to, amount)` **directly** (the market's own code invokes the
+//!    token contract). The token's internal `from.require_auth()` succeeds
+//!    automatically because `from` (the market) is *itself* the direct
+//!    invoker of this specific call.
+//!
+//! At every hop, the address being authorized equals the direct caller of
+//! that exact invocation — no mismatch, so no explicit
+//! `authorize_as_current_contract` entry is ever needed. This is the
+//! opposite of `parlay_betting`'s staking path, where `stake_on_call`
+//! internally calls `token.transfer(from = parlay's address, ...)` **on the
+//! parlay's behalf but as the market's own invocation** — a genuine
+//! mismatch (from != direct invoker) that does require pre-authorization.
+//! The difference: `release_escrow`'s transfer always debits the *market's
+//! own* balance (it's paying out its own escrow), so `from` and the
+//! invoking contract are always the same contract at that hop.
+//!
+//! **Known limitation.** Because this contract always claims *as itself*
+//! (a single fixed address), `outcome_manager`'s `(call_id, staker)` claimed
+//! guard means only *one* sponsored claim can be settled per `call_id`
+//! through this gas station. If two different sponsored users both won on
+//! the very same `call_id`, only the first `claim_sponsored_payout` call for
+//! that `call_id` would succeed against `outcome_manager`; the second would
+//! fail with `AlreadyClaimed`. `parlay_betting` solves the analogous problem
+//! for its own use case with an aggregate-then-proportional-share scheme
+//! (see its `LegAggregate`); this contract does not replicate that, since
+//! the acceptance criteria for this feature describe a single-shot,
+//! single-user claim flow and multi-user-same-call collisions are not part
+//! of its test scope. A future enhancement could add the same aggregate
+//! pattern if this becomes a real-world concern.
+#![no_std]
+
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, token, Address, Env, IntoVal, Symbol};
+
+use errors::GasStationError;
+use events::{
+    emit_admin_changed, emit_gas_station_initialized, emit_pool_refilled,
+    emit_sponsored_payout_claimed, emit_sponsorship_registered, emit_sponsorship_revoked,
+};
+use types::{GasStationMetrics, SponsorshipInfo};
+
+/// 100% in basis points.
+const MAX_BPS: u32 = 10_000;
+
+// ─── Token transfer helper ─────────────────────────────────────────────────────
+//
+// Mirrors `prediction_market::transfer_token` exactly: dispatch between the
+// native-XLM `StellarAssetClient` and a generic SAC `token::Client`. The
+// gas station explicitly deals in XLM per the issue, but staying consistent
+// with the rest of the workspace costs nothing and keeps a single pattern
+// to reason about.
+
+#[cfg(not(test))]
+#[inline]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let sentinel = Address::from_string(&soroban_sdk::String::from_str(
+        env,
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    ));
+    *addr == sentinel
+}
+
+#[cfg(test)]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let key = soroban_sdk::Symbol::new(env, "xlm_sac_addr");
+    if let Some(sentinel) = env.storage().instance().get::<_, Address>(&key) {
+        return *addr == sentinel;
+    }
+    false
+}
+
+fn transfer_token(env: &Env, token_addr: &Address, from: &Address, to: &Address, amount: i128) {
+    if is_native_xlm(env, token_addr) {
+        token::StellarAssetClient::new(env, token_addr).transfer(from, to, &amount);
+    } else {
+        token::Client::new(env, token_addr).transfer(from, to, &amount);
+    }
+}
+
+// ─── Small helpers ──────────────────────────────────────────────────────────────
+
+fn overflow<T>(env: &Env) -> T {
+    soroban_sdk::panic_with_error!(env, GasStationError::Overflow);
+}
+
+fn require_initialized_admin(env: &Env) -> Address {
+    match storage::get_admin(env) {
+        Some(admin) => admin,
+        None => soroban_sdk::panic_with_error!(env, GasStationError::NotInitialized),
+    }
+}
+
+/// Looks up the stored admin and requires its authorization. Used by
+/// functions whose issue-specified signature has no explicit `admin`
+/// parameter (mirrors `outcome_manager::auth::require_admin`).
+fn require_admin(env: &Env) -> Address {
+    let admin = require_initialized_admin(env);
+    admin.require_auth();
+    admin
+}
+
+fn require_xlm_token(env: &Env) -> Address {
+    match storage::get_xlm_token(env) {
+        Some(token) => token,
+        None => soroban_sdk::panic_with_error!(env, GasStationError::NotInitialized),
+    }
+}
+
+// ─── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct GasStation;
+
+#[contractimpl]
+impl GasStation {
+    /// Initialize the gas station: sets the admin and the XLM (or SAC)
+    /// token this pool is denominated in.
+    pub fn initialize(env: Env, admin: Address, xlm_token: Address) {
+        if storage::get_admin(&env).is_some() {
+            soroban_sdk::panic_with_error!(&env, GasStationError::AlreadyInitialized);
+        }
+        admin.require_auth();
+
+        storage::set_admin(&env, &admin);
+        storage::set_xlm_token(&env, &xlm_token);
+        storage::set_metrics(&env, &GasStationMetrics::zero());
+
+        emit_gas_station_initialized(&env, &admin, &xlm_token);
+    }
+
+    pub fn set_admin(env: Env, new_admin: Address) {
+        require_admin(&env);
+        storage::set_admin(&env, &new_admin);
+        emit_admin_changed(&env, &new_admin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        require_initialized_admin(&env)
+    }
+
+    /// Register `user` for gas sponsorship (admin only). The gas station
+    /// commits to fronting up to `max_gas_xlm` of this user's transaction
+    /// fees (paid off-chain by the relay, see module docs) in exchange for
+    /// `winning_cut_bps` of their payout if their sponsored call wins.
+    ///
+    /// Immediately books `max_gas_xlm` against `total_xlm_spent` — the
+    /// conservative assumption that the full committed amount is "at risk"
+    /// the moment sponsorship starts, since a losing outcome recovers
+    /// nothing. A win later adds the collected cut back via
+    /// `total_winnings_collected`, which is netted against this in
+    /// `net_profit_loss`.
+    pub fn sponsor_transaction(env: Env, user: Address, max_gas_xlm: i128, winning_cut_bps: u32) {
+        require_admin(&env);
+
+        if max_gas_xlm <= 0 {
+            soroban_sdk::panic_with_error!(&env, GasStationError::InvalidGasAmount);
+        }
+        if winning_cut_bps > MAX_BPS {
+            soroban_sdk::panic_with_error!(&env, GasStationError::InvalidWinningCutBps);
+        }
+
+        let info = SponsorshipInfo {
+            max_gas_xlm,
+            winning_cut_bps,
+            sponsored_at: env.ledger().timestamp(),
+            active: true,
+        };
+        storage::set_sponsorship(&env, &user, &info);
+
+        let mut metrics = storage::get_metrics(&env);
+        metrics.total_transactions_sponsored = metrics
+            .total_transactions_sponsored
+            .checked_add(1)
+            .unwrap_or_else(|| overflow(&env));
+        metrics.total_xlm_spent = metrics
+            .total_xlm_spent
+            .checked_add(max_gas_xlm)
+            .unwrap_or_else(|| overflow(&env));
+        metrics.net_profit_loss = metrics
+            .total_winnings_collected
+            .checked_sub(metrics.total_xlm_spent)
+            .unwrap_or_else(|| overflow(&env));
+        storage::set_metrics(&env, &metrics);
+
+        emit_sponsorship_registered(&env, &user, max_gas_xlm, winning_cut_bps);
+    }
+
+    /// Deactivate a user's sponsorship (admin only). Past metrics are left
+    /// untouched; this only stops *future* claims from treating the user as
+    /// sponsored.
+    pub fn revoke_sponsorship(env: Env, user: Address) {
+        require_admin(&env);
+        if let Some(mut info) = storage::get_sponsorship(&env, &user) {
+            info.active = false;
+            storage::set_sponsorship(&env, &user, &info);
+        }
+        emit_sponsorship_revoked(&env, &user);
+    }
+
+    pub fn get_sponsorship(env: Env, user: Address) -> Option<SponsorshipInfo> {
+        storage::get_sponsorship(&env, &user)
+    }
+
+    pub fn is_sponsored(env: Env, user: Address) -> bool {
+        match storage::get_sponsorship(&env, &user) {
+            Some(info) => info.active,
+            None => false,
+        }
+    }
+
+    /// Pure arithmetic helper: `effective_stake = stake_amount -
+    /// estimated_gas_xlm`, per the acceptance criteria. The actual staking
+    /// call happens on `prediction_market` (untouched by this contract); the
+    /// (out-of-scope) relay flow calls this to compute the reduced stake
+    /// amount before constructing the user's sponsored stake transaction.
+    pub fn compute_effective_stake(env: Env, stake_amount: i128, estimated_gas_xlm: i128) -> i128 {
+        let effective = stake_amount
+            .checked_sub(estimated_gas_xlm)
+            .unwrap_or_else(|| overflow(&env));
+        if effective < 0 {
+            soroban_sdk::panic_with_error!(&env, GasStationError::InvalidGasAmount);
+        }
+        effective
+    }
+
+    /// Claim a sponsored user's payout, enforcing the winning cut.
+    ///
+    /// Calls `outcome_manager.claim_payout(registry, call_id, staker =
+    /// <this gas station's own address>, staker_winning_stake,
+    /// total_winning_stake, total_losing_stake)`, which lands the full
+    /// payout in this contract's own balance (measured via a balance
+    /// before/after diff, the same technique `parlay_betting` uses for its
+    /// own aggregate claims). Deducts `winning_cut_bps` (read from the
+    /// user's stored sponsorship) into the gas pool / metrics, and forwards
+    /// the remainder to `user`.
+    ///
+    /// Permissionless: no `require_auth` on `user` or the admin. Anyone —
+    /// the user, a keeper bot, the backend relay — can trigger settlement
+    /// once the call has resolved; the cut enforcement doesn't depend on
+    /// who calls this, only on `user` having an active sponsorship.
+    ///
+    /// See the module doc comment for the full auth-chain trace and the
+    /// known single-claim-per-`call_id` limitation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn claim_sponsored_payout(
+        env: Env,
+        registry: Address,
+        outcome_manager: Address,
+        call_id: u64,
+        user: Address,
+        staker_winning_stake: i128,
+        total_winning_stake: i128,
+        total_losing_stake: i128,
+    ) {
+        let info = match storage::get_sponsorship(&env, &user) {
+            Some(info) if info.active => info,
+            _ => soroban_sdk::panic_with_error!(&env, GasStationError::UserNotSponsored),
+        };
+
+        if storage::is_call_processed(&env, call_id) {
+            soroban_sdk::panic_with_error!(&env, GasStationError::CallAlreadyProcessed);
+        }
+
+        if staker_winning_stake <= 0 {
+            soroban_sdk::panic_with_error!(&env, GasStationError::InvalidWinningStake);
+        }
+
+        let xlm_token = require_xlm_token(&env);
+        let token_client = token::Client::new(&env, &xlm_token);
+        let contract_address = env.current_contract_address();
+        let balance_before = token_client.balance(&contract_address);
+
+        // Reentrancy guard, mirroring outcome_manager's "mark before
+        // external call" convention — set before the cross-contract call
+        // that could (in principle) re-enter this function.
+        storage::mark_call_processed(&env, call_id);
+
+        let args = (
+            registry,
+            call_id,
+            contract_address.clone(),
+            staker_winning_stake,
+            total_winning_stake,
+            total_losing_stake,
+        )
+            .into_val(&env);
+        let _: () = env.invoke_contract(&outcome_manager, &Symbol::new(&env, "claim_payout"), args);
+
+        let balance_after = token_client.balance(&contract_address);
+        let payout = balance_after
+            .checked_sub(balance_before)
+            .unwrap_or_else(|| overflow(&env));
+
+        let cut = payout
+            .checked_mul(info.winning_cut_bps as i128)
+            .unwrap_or_else(|| overflow(&env))
+            .checked_div(MAX_BPS as i128)
+            .unwrap_or_else(|| overflow(&env));
+
+        let user_amount = payout
+            .checked_sub(cut)
+            .unwrap_or_else(|| overflow(&env));
+
+        if user_amount > 0 {
+            transfer_token(&env, &xlm_token, &contract_address, &user, user_amount);
+        }
+
+        let mut metrics = storage::get_metrics(&env);
+        metrics.total_winnings_collected = metrics
+            .total_winnings_collected
+            .checked_add(cut)
+            .unwrap_or_else(|| overflow(&env));
+        metrics.net_profit_loss = metrics
+            .total_winnings_collected
+            .checked_sub(metrics.total_xlm_spent)
+            .unwrap_or_else(|| overflow(&env));
+        storage::set_metrics(&env, &metrics);
+
+        emit_sponsored_payout_claimed(&env, call_id, &user, payout, cut, user_amount);
+    }
+
+    /// Current XLM (or configured SAC) balance held by the gas station pool.
+    pub fn get_gas_station_balance(env: Env) -> i128 {
+        let xlm_token = require_xlm_token(&env);
+        token::Client::new(&env, &xlm_token).balance(&env.current_contract_address())
+    }
+
+    /// Refill the gas pool from the treasury/admin (admin only). Used both
+    /// for the initial funding and for periodic top-ups from protocol fees.
+    pub fn refill_gas_pool(env: Env, admin: Address, amount: i128) {
+        let stored_admin = require_initialized_admin(&env);
+        if admin != stored_admin {
+            soroban_sdk::panic_with_error!(&env, GasStationError::Unauthorized);
+        }
+        admin.require_auth();
+
+        if amount <= 0 {
+            soroban_sdk::panic_with_error!(&env, GasStationError::InvalidRefillAmount);
+        }
+
+        let xlm_token = require_xlm_token(&env);
+        let contract_address = env.current_contract_address();
+        transfer_token(&env, &xlm_token, &admin, &contract_address, amount);
+
+        let new_balance = token::Client::new(&env, &xlm_token).balance(&contract_address);
+        emit_pool_refilled(&env, amount, new_balance);
+    }
+
+    pub fn get_metrics(env: Env) -> GasStationMetrics {
+        storage::get_metrics(&env)
+    }
+}

--- a/packages/contracts/gas_station/src/storage.rs
+++ b/packages/contracts/gas_station/src/storage.rs
@@ -1,0 +1,62 @@
+use crate::types::{GasStationMetrics, SponsorshipInfo};
+use soroban_sdk::{contracttype, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    XlmToken,
+    Sponsorship(Address),
+    /// Marks that the aggregate `outcome_manager` claim for this `call_id`
+    /// has already been performed by this gas station (see the module doc
+    /// comment on `claim_sponsored_payout` for the single-claim-per-call
+    /// limitation this guards).
+    CallProcessed(u64),
+    Metrics,
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::Admin)
+}
+
+pub fn set_xlm_token(env: &Env, token: &Address) {
+    env.storage().instance().set(&DataKey::XlmToken, token);
+}
+
+pub fn get_xlm_token(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::XlmToken)
+}
+
+pub fn set_sponsorship(env: &Env, user: &Address, info: &SponsorshipInfo) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Sponsorship(user.clone()), info);
+}
+
+pub fn get_sponsorship(env: &Env, user: &Address) -> Option<SponsorshipInfo> {
+    env.storage().instance().get(&DataKey::Sponsorship(user.clone()))
+}
+
+pub fn get_metrics(env: &Env) -> GasStationMetrics {
+    env.storage()
+        .instance()
+        .get(&DataKey::Metrics)
+        .unwrap_or_else(GasStationMetrics::zero)
+}
+
+pub fn set_metrics(env: &Env, metrics: &GasStationMetrics) {
+    env.storage().instance().set(&DataKey::Metrics, metrics);
+}
+
+pub fn is_call_processed(env: &Env, call_id: u64) -> bool {
+    env.storage().instance().has(&DataKey::CallProcessed(call_id))
+}
+
+pub fn mark_call_processed(env: &Env, call_id: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::CallProcessed(call_id), &true);
+}

--- a/packages/contracts/gas_station/src/test.rs
+++ b/packages/contracts/gas_station/src/test.rs
@@ -1,0 +1,561 @@
+#![cfg(test)]
+
+extern crate std;
+
+use crate::errors::GasStationError;
+use crate::{GasStation, GasStationClient};
+use backit_shared::{build_message, OUTCOME_DOWN, OUTCOME_UP};
+use outcome_manager::{OutcomeManager, OutcomeManagerClient, SignedOutcome};
+use prediction_market::{ConditionType, MarketInitArgs, PredictionMarketClient};
+use prediction_market_factory::{PredictionMarketFactory, PredictionMarketFactoryClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Bytes, BytesN, Env, Vec,
+};
+
+fn install_market_wasm(env: &Env) -> BytesN<32> {
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let release_v1 = workspace_root.join("target/wasm32v1-none/release");
+    let release_unknown = workspace_root.join("target/wasm32-unknown-unknown/release");
+    let candidates = [
+        release_v1.join("prediction_market.optimized.wasm"),
+        release_v1.join("prediction_market.wasm"),
+        release_unknown.join("prediction_market.optimized.wasm"),
+    ];
+
+    let wasm_path = candidates
+        .iter()
+        .find(|path| path.exists())
+        .unwrap_or_else(|| {
+            panic!(
+                "missing Soroban-compatible prediction_market WASM — run:\n  \
+                 cd packages/contracts/prediction_market && cargo build --release --target wasm32v1-none"
+            )
+        });
+
+    let wasm_bytes = std::fs::read(wasm_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", wasm_path.display()));
+    env.deployer().upload_contract_wasm(wasm_bytes.as_slice())
+}
+
+fn default_market_args(env: &Env, stake_token: &Address, end_ts: u64) -> MarketInitArgs {
+    MarketInitArgs {
+        stake_token: stake_token.clone(),
+        stake_amount: 100,
+        start_price: 100_000_000,
+        end_ts,
+        token_address: stake_token.clone(),
+        pair_id: Bytes::from_slice(env, b"XLM-USDC"),
+        metadata_hash: BytesN::from_array(env, &[9u8; 32]),
+        condition: ConditionType::PercentUp(5),
+        outcome_count: 2,
+    }
+}
+
+fn setup_token(env: &Env, admin: &Address) -> Address {
+    let token = env.register_stellar_asset_contract_v2(admin.clone());
+    let sac = token.address();
+    StellarAssetClient::new(env, &sac).mint(admin, &100_000_000_000);
+    sac
+}
+
+fn gen_keypair(env: &Env) -> (BytesN<32>, BytesN<32>) {
+    use ed25519_dalek::SigningKey;
+    use rand::RngCore;
+
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    let signing_key = SigningKey::from_bytes(&seed);
+    let public_key = signing_key.verifying_key();
+    (
+        BytesN::from_array(env, &seed),
+        BytesN::from_array(env, &public_key.to_bytes()),
+    )
+}
+
+fn sign_outcome(
+    env: &Env,
+    secret: &BytesN<32>,
+    call_id: u64,
+    outcome: u32,
+    price: i128,
+    timestamp: u64,
+) -> BytesN<64> {
+    use ed25519_dalek::{Signer, SigningKey};
+
+    let msg = build_message(env, call_id, outcome, price, timestamp);
+    let mut msg_bytes = [0u8; 128];
+    let msg_len = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_bytes[..msg_len]);
+    let signing_key = SigningKey::from_bytes(&secret.to_array());
+    let signature = signing_key.sign(&msg_bytes[..msg_len]);
+    BytesN::from_array(env, &signature.to_bytes())
+}
+
+struct TestSetup<'a> {
+    env: Env,
+    admin: Address,
+    creator: Address,
+    token: Address,
+    factory: PredictionMarketFactoryClient<'a>,
+    outcome_mgr: OutcomeManagerClient<'a>,
+    outcome_mgr_id: Address,
+    gas_station: GasStationClient<'a>,
+    oracle_secret: BytesN<32>,
+    oracle_pubkey: BytesN<32>,
+}
+
+/// Full real-contract stack: `prediction_market_factory` + `outcome_manager`
+/// + `gas_station`, wired together exactly like production. `fee_bps = 0` on
+/// the outcome manager so the protocol fee doesn't complicate the payout
+/// arithmetic this test suite is actually about (the gas station's cut).
+fn setup_full_stack<'a>() -> TestSetup<'a> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let token = setup_token(&env, &admin);
+
+    let market_wasm = install_market_wasm(&env);
+    let factory_id = env.register(PredictionMarketFactory, ());
+    let factory = PredictionMarketFactoryClient::new(&env, &factory_id);
+
+    let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
+    let outcome_mgr_id = env.register(OutcomeManager, ());
+    let outcome_mgr = OutcomeManagerClient::new(&env, &outcome_mgr_id);
+    let fee_collector = Address::generate(&env);
+
+    let mut oracles = Vec::new(&env);
+    oracles.push_back(oracle_pubkey.clone());
+
+    // quorum=1, dispute_window_secs=0, fee_bps=0: a single oracle submission
+    // finalizes immediately with no protocol fee skimmed off.
+    outcome_mgr.initialize(&admin, &oracles, &1u32, &fee_collector, &0u32, &0u64);
+    factory.initialize(&admin, &outcome_mgr_id, &market_wasm, &100i128);
+    factory.whitelist_token(&token);
+    outcome_mgr.set_factory(&factory_id);
+
+    let gas_station_id = env.register(GasStation, ());
+    let gas_station = GasStationClient::new(&env, &gas_station_id);
+    gas_station.initialize(&admin, &token);
+
+    TestSetup {
+        env,
+        admin,
+        creator,
+        token,
+        factory,
+        outcome_mgr,
+        outcome_mgr_id,
+        gas_station,
+        oracle_secret,
+        oracle_pubkey,
+    }
+}
+
+/// Deploy a fresh market and fund `stakers` with plenty of the stake token.
+fn deploy_market(setup: &TestSetup, end_ts: u64) -> (Address, u64) {
+    let env = &setup.env;
+    let args = default_market_args(env, &setup.token, end_ts);
+    let market_addr = setup.factory.deploy_market(&setup.creator, &args);
+    let market = PredictionMarketClient::new(env, &market_addr);
+    let call_id = market.get_call_id();
+    (market_addr, call_id)
+}
+
+fn fund(setup: &TestSetup, who: &Address, amount: i128) {
+    TokenClient::new(&setup.env, &setup.token).transfer(&setup.admin, who, &amount);
+}
+
+fn resolve_market(setup: &TestSetup, call_id: u64, outcome: u32, end_ts: u64) {
+    let env = &setup.env;
+    env.ledger().set_timestamp(end_ts + 1);
+    let signed = SignedOutcome {
+        call_id,
+        outcome,
+        price: 110_000_000,
+        timestamp: end_ts + 1,
+        oracle_pubkey: setup.oracle_pubkey.clone(),
+        signature: sign_outcome(
+            env,
+            &setup.oracle_secret,
+            call_id,
+            outcome,
+            110_000_000,
+            end_ts + 1,
+        ),
+    };
+    setup.outcome_mgr.submit_outcome_for_market(&signed, &end_ts);
+}
+
+fn assert_contract_error<T, E>(
+    result: Result<Result<T, E>, Result<soroban_sdk::Error, soroban_sdk::InvokeError>>,
+    expected: GasStationError,
+) {
+    assert!(matches!(
+        result,
+        Err(Ok(err)) if err == soroban_sdk::Error::from_contract_error(expected as u32)
+    ));
+}
+
+// ─── sponsor_transaction / registration ────────────────────────────────────────
+
+#[test]
+fn sponsor_transaction_registers_user_and_updates_metrics() {
+    let setup = setup_full_stack();
+    let user = Address::generate(&setup.env);
+
+    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+
+    let info = setup.gas_station.get_sponsorship(&user).unwrap();
+    assert_eq!(info.max_gas_xlm, 50);
+    assert_eq!(info.winning_cut_bps, 300);
+    assert!(info.active);
+    assert!(setup.gas_station.is_sponsored(&user));
+
+    let metrics = setup.gas_station.get_metrics();
+    assert_eq!(metrics.total_transactions_sponsored, 1);
+    assert_eq!(metrics.total_xlm_spent, 50);
+    assert_eq!(metrics.total_winnings_collected, 0);
+    assert_eq!(metrics.net_profit_loss, -50);
+}
+
+#[test]
+fn sponsor_transaction_rejects_invalid_cut_bps() {
+    let setup = setup_full_stack();
+    let user = Address::generate(&setup.env);
+
+    let result = setup
+        .gas_station
+        .try_sponsor_transaction(&user, &50i128, &10_001u32);
+    assert_contract_error(result, GasStationError::InvalidWinningCutBps);
+}
+
+#[test]
+fn sponsor_transaction_rejects_non_positive_gas() {
+    let setup = setup_full_stack();
+    let user = Address::generate(&setup.env);
+
+    let result = setup
+        .gas_station
+        .try_sponsor_transaction(&user, &0i128, &300u32);
+    assert_contract_error(result, GasStationError::InvalidGasAmount);
+}
+
+#[test]
+fn revoke_sponsorship_deactivates_without_erasing_history() {
+    let setup = setup_full_stack();
+    let user = Address::generate(&setup.env);
+    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+
+    setup.gas_station.revoke_sponsorship(&user);
+
+    assert!(!setup.gas_station.is_sponsored(&user));
+    let info = setup.gas_station.get_sponsorship(&user).unwrap();
+    assert_eq!(info.max_gas_xlm, 50); // history preserved, just inactive
+}
+
+#[test]
+fn compute_effective_stake_matches_formula() {
+    let setup = setup_full_stack();
+    assert_eq!(setup.gas_station.compute_effective_stake(&1_000i128, &50i128), 950);
+}
+
+#[test]
+fn compute_effective_stake_rejects_gas_exceeding_stake() {
+    let setup = setup_full_stack();
+    let result = setup
+        .gas_station
+        .try_compute_effective_stake(&50i128, &1_000i128);
+    assert_contract_error(result, GasStationError::InvalidGasAmount);
+}
+
+// ─── claim_sponsored_payout: win path ──────────────────────────────────────────
+
+#[test]
+fn sponsored_stake_win_gas_station_earns_cut_and_user_gets_remainder() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    let token = TokenClient::new(env, &setup.token);
+
+    let user = Address::generate(env);
+    let counterparty = Address::generate(env);
+    fund(&setup, &user, 10_000);
+    fund(&setup, &counterparty, 10_000);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (market_addr, call_id) = deploy_market(&setup, end_ts);
+    let market = PredictionMarketClient::new(env, &market_addr);
+
+    // Sponsor the user for up to 50 stroops of gas at a 3% winning cut.
+    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+
+    // The user stakes directly, as themselves (the gas station only ever
+    // relays the fee off-chain — see module docs — it never becomes an
+    // intermediary staker).
+    market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_UP);
+    market.stake_on_call(&counterparty, &call_id, &3_000i128, &OUTCOME_DOWN);
+
+    resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
+
+    let user_balance_before_claim = token.balance(&user);
+    let gas_station_balance_before = setup.gas_station.get_gas_station_balance();
+    assert_eq!(gas_station_balance_before, 0);
+
+    // winning_stake = 1,000 (sole winner), losing_stake = 3,000, fee_bps=0.
+    // payout = 1,000 + 3,000 = 4,000. cut = 4,000 * 300 / 10,000 = 120.
+    // user receives 4,000 - 120 = 3,880.
+    setup.gas_station.claim_sponsored_payout(
+        &market_addr,
+        &setup.outcome_mgr_id,
+        &call_id,
+        &user,
+        &1_000i128,
+        &1_000i128,
+        &3_000i128,
+    );
+
+    assert_eq!(token.balance(&user), user_balance_before_claim + 3_880);
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 120);
+
+    let metrics = setup.gas_station.get_metrics();
+    assert_eq!(metrics.total_winnings_collected, 120);
+    // total_xlm_spent was booked at sponsor time (50); net = 120 - 50 = 70.
+    assert_eq!(metrics.net_profit_loss, 70);
+}
+
+#[test]
+fn claim_sponsored_payout_cannot_be_processed_twice_for_same_call() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+
+    let user = Address::generate(env);
+    let counterparty = Address::generate(env);
+    fund(&setup, &user, 10_000);
+    fund(&setup, &counterparty, 10_000);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (market_addr, call_id) = deploy_market(&setup, end_ts);
+    let market = PredictionMarketClient::new(env, &market_addr);
+
+    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+    market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_UP);
+    market.stake_on_call(&counterparty, &call_id, &3_000i128, &OUTCOME_DOWN);
+    resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
+
+    setup.gas_station.claim_sponsored_payout(
+        &market_addr,
+        &setup.outcome_mgr_id,
+        &call_id,
+        &user,
+        &1_000i128,
+        &1_000i128,
+        &3_000i128,
+    );
+
+    let result = setup.gas_station.try_claim_sponsored_payout(
+        &market_addr,
+        &setup.outcome_mgr_id,
+        &call_id,
+        &user,
+        &1_000i128,
+        &1_000i128,
+        &3_000i128,
+    );
+    assert_contract_error(result, GasStationError::CallAlreadyProcessed);
+}
+
+#[test]
+fn claim_sponsored_payout_rejects_unsponsored_user() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+
+    let user = Address::generate(env);
+    let counterparty = Address::generate(env);
+    fund(&setup, &user, 10_000);
+    fund(&setup, &counterparty, 10_000);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (market_addr, call_id) = deploy_market(&setup, end_ts);
+    let market = PredictionMarketClient::new(env, &market_addr);
+
+    // Note: no sponsor_transaction call for `user`.
+    market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_UP);
+    market.stake_on_call(&counterparty, &call_id, &3_000i128, &OUTCOME_DOWN);
+    resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
+
+    let result = setup.gas_station.try_claim_sponsored_payout(
+        &market_addr,
+        &setup.outcome_mgr_id,
+        &call_id,
+        &user,
+        &1_000i128,
+        &1_000i128,
+        &3_000i128,
+    );
+    assert_contract_error(result, GasStationError::UserNotSponsored);
+}
+
+// ─── claim_sponsored_payout: loss path ─────────────────────────────────────────
+
+#[test]
+fn sponsored_stake_loss_gas_station_absorbs_cost_no_deduction() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    let token = TokenClient::new(env, &setup.token);
+
+    let user = Address::generate(env);
+    let counterparty = Address::generate(env);
+    fund(&setup, &user, 10_000);
+    fund(&setup, &counterparty, 10_000);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (market_addr, call_id) = deploy_market(&setup, end_ts);
+    let market = PredictionMarketClient::new(env, &market_addr);
+
+    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+
+    let user_balance_after_stake_before_resolve;
+    market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_DOWN);
+    market.stake_on_call(&counterparty, &call_id, &3_000i128, &OUTCOME_UP);
+    user_balance_after_stake_before_resolve = token.balance(&user);
+
+    // The market resolves UP — the sponsored user picked DOWN and lost.
+    resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
+
+    // Nothing to claim: the user has zero winning stake. Attempting a claim
+    // is rejected before any funds move.
+    let result = setup.gas_station.try_claim_sponsored_payout(
+        &market_addr,
+        &setup.outcome_mgr_id,
+        &call_id,
+        &user,
+        &0i128,
+        &3_000i128,
+        &1_000i128,
+    );
+    assert_contract_error(result, GasStationError::InvalidWinningStake);
+
+    // The user's balance is unchanged since the (failed) claim attempt —
+    // they simply don't get their stake back (as normal for prediction
+    // markets), and no gas station cut is deducted from a non-existent
+    // payout.
+    assert_eq!(token.balance(&user), user_balance_after_stake_before_resolve);
+
+    // The pool's on-chain balance is untouched by the loss — the estimated
+    // gas cost was fronted off-chain (see module docs); what the gas
+    // station "absorbs" is the accounting write-off, visible here as a
+    // negative net_profit_loss with total_xlm_spent already booked at
+    // sponsor time and never recovered.
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 0);
+
+    let metrics = setup.gas_station.get_metrics();
+    assert_eq!(metrics.total_transactions_sponsored, 1);
+    assert_eq!(metrics.total_xlm_spent, 50);
+    assert_eq!(metrics.total_winnings_collected, 0);
+    assert_eq!(metrics.net_profit_loss, -50);
+}
+
+// ─── pool refilling ─────────────────────────────────────────────────────────────
+
+#[test]
+fn refill_gas_pool_increases_balance() {
+    let setup = setup_full_stack();
+
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 0);
+    setup.gas_station.refill_gas_pool(&setup.admin, &10_000i128);
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 10_000);
+
+    setup.gas_station.refill_gas_pool(&setup.admin, &5_000i128);
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 15_000);
+}
+
+#[test]
+fn refill_gas_pool_rejects_non_positive_amount() {
+    let setup = setup_full_stack();
+    let result = setup.gas_station.try_refill_gas_pool(&setup.admin, &0i128);
+    assert_contract_error(result, GasStationError::InvalidRefillAmount);
+}
+
+#[test]
+fn winning_cuts_flow_back_into_the_same_pool_refill_grows() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+
+    let user = Address::generate(env);
+    let counterparty = Address::generate(env);
+    fund(&setup, &user, 10_000);
+    fund(&setup, &counterparty, 10_000);
+
+    setup.gas_station.refill_gas_pool(&setup.admin, &1_000i128);
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 1_000);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (market_addr, call_id) = deploy_market(&setup, end_ts);
+    let market = PredictionMarketClient::new(env, &market_addr);
+
+    setup.gas_station.sponsor_transaction(&user, &50i128, &1_000u32); // 10%
+    market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_UP);
+    market.stake_on_call(&counterparty, &call_id, &1_000i128, &OUTCOME_DOWN);
+    resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
+
+    // payout = 1,000 + 1,000 = 2,000; cut = 200 (10%).
+    setup.gas_station.claim_sponsored_payout(
+        &market_addr,
+        &setup.outcome_mgr_id,
+        &call_id,
+        &user,
+        &1_000i128,
+        &1_000i128,
+        &1_000i128,
+    );
+
+    // Pool started at 1,000 (refill) and grew by the 200 cut.
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 1_200);
+}
+
+// ─── admin controls ─────────────────────────────────────────────────────────────
+
+#[test]
+fn refill_gas_pool_rejects_mismatched_admin() {
+    let setup = setup_full_stack();
+    let not_admin = Address::generate(&setup.env);
+    fund(&setup, &not_admin, 10_000);
+
+    let result = setup
+        .gas_station
+        .try_refill_gas_pool(&not_admin, &1_000i128);
+    assert_contract_error(result, GasStationError::Unauthorized);
+}
+
+#[test]
+fn set_admin_transfers_admin_rights() {
+    let setup = setup_full_stack();
+    let new_admin = Address::generate(&setup.env);
+    fund(&setup, &new_admin, 10_000);
+
+    setup.gas_station.set_admin(&new_admin);
+    assert_eq!(setup.gas_station.get_admin(), new_admin);
+
+    // The old admin address is no longer accepted by refill_gas_pool's
+    // explicit address check.
+    let result = setup
+        .gas_station
+        .try_refill_gas_pool(&setup.admin, &1_000i128);
+    assert_contract_error(result, GasStationError::Unauthorized);
+
+    // The new admin works.
+    setup.gas_station.refill_gas_pool(&new_admin, &1_000i128);
+    assert_eq!(setup.gas_station.get_gas_station_balance(), 1_000);
+}
+
+#[test]
+fn initialize_cannot_be_called_twice() {
+    let setup = setup_full_stack();
+    let result = setup
+        .gas_station
+        .try_initialize(&setup.admin, &setup.token);
+    assert_contract_error(result, GasStationError::AlreadyInitialized);
+}

--- a/packages/contracts/gas_station/src/types.rs
+++ b/packages/contracts/gas_station/src/types.rs
@@ -1,0 +1,48 @@
+use soroban_sdk::contracttype;
+
+/// A user's active gas-sponsorship agreement with the gas station.
+///
+/// Registered via [`crate::GasStation::sponsor_transaction`]. `winning_cut_bps`
+/// is read back at payout time by [`crate::GasStation::claim_sponsored_payout`]
+/// to compute the gas station's cut.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SponsorshipInfo {
+    /// Upper bound on the gas cost (in stroops of the configured XLM token)
+    /// the gas station has committed to cover for this user.
+    pub max_gas_xlm: i128,
+    /// Basis points of the sponsored payout the gas station keeps if the
+    /// user wins (e.g. `300` = 3%).
+    pub winning_cut_bps: u32,
+    /// Ledger timestamp at which this sponsorship was registered.
+    pub sponsored_at: u64,
+    /// Whether this sponsorship is currently active (admin-revocable).
+    pub active: bool,
+}
+
+/// Running totals for the gas station's sponsorship program.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GasStationMetrics {
+    /// Count of `sponsor_transaction` registrations.
+    pub total_transactions_sponsored: u64,
+    /// Cumulative estimated gas (in stroops) committed across all
+    /// sponsorships, whether or not the sponsored user ultimately won.
+    pub total_xlm_spent: i128,
+    /// Cumulative winning cuts collected via `claim_sponsored_payout`.
+    pub total_winnings_collected: i128,
+    /// `total_winnings_collected - total_xlm_spent`. Can be negative when
+    /// losses (gas fronted for users who didn't win) outweigh cuts earned.
+    pub net_profit_loss: i128,
+}
+
+impl GasStationMetrics {
+    pub fn zero() -> Self {
+        GasStationMetrics {
+            total_transactions_sponsored: 0,
+            total_xlm_spent: 0,
+            total_winnings_collected: 0,
+            net_profit_loss: 0,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
closes #469 
- New standalone `gas_station` crate that sponsors gas for users in exchange for a cut of winnings
- `sponsor_transaction`/`revoke_sponsorship` manage per-user sponsorship state; `compute_effective_stake` implements the `stake_amount - estimated_gas_xlm` formula
- `claim_sponsored_payout` acts as an intermediary claimer: it claims a sponsored user's payout from `outcome_manager` as itself, deducts `winning_cut_bps`, and forwards the remainder — traced the full auth call graph and confirmed no `authorize_as_current_contract` step is required for this call chain (documented in the module doc comment)
- Pool refilled via `refill_gas_pool` (admin) and via collected winning cuts; `get_gas_station_balance`/`get_metrics` expose `total_transactions_sponsored`, `total_xlm_spent`, `total_winnings_collected`, `net_profit_loss`
- Contract-only change — no backend/relay files touched, per the issue's own scope note

## Acceptance criteria
- [x] `sponsor_transaction(env, user, max_gas_xlm, winning_cut_bps)`
- [x] `effective_stake = stake_amount - estimated_gas_xlm`
- [x] On win: `winning_cut_bps` deducted from payout before forwarding to user
- [x] On loss: no deduction, pool absorbs cost (via `net_profit_loss` bookkeeping)
- [x] Pool refilled from protocol fees + winning cuts
- [x] `get_gas_station_balance(env) -> i128`
- [x] `refill_gas_pool(env, admin, amount)` admin fn
- [x] Metrics: total_transactions_sponsored, total_xlm_spent, total_winnings_collected, net_profit_loss
- [x] Tests: sponsored win → cut earned, sponsored loss → pool absorbs, pool refilling, admin controls, accurate deduction

## Known limitation
Since the gas station claims payouts as a single fixed address, two different sponsored winners on the *same* `call_id` would collide on `outcome_manager`'s per-`(call_id, staker)` claimed-guard (the second claim fails with `AlreadyClaimed`). Not in this issue's test scope; flagged as a follow-up (an aggregate/proportional-share scheme similar to `parlay_betting`'s would resolve it).

## Test plan
- [x] `cargo test -p gas-station` — 16/16 passing, against real `outcome_manager`/`prediction_market`/`prediction_market_factory` contracts (no mocks)
- [x] `cargo build --release -p gas-station`
- [x] `cargo test --workspace` — 206 passing, 0 failed