### PR TITLE
Add social recovery for unclaimed outcome_manager payouts (#470)

### DIFF
--- a/packages/contracts/outcome_manager/src/errors.rs
+++ b/packages/contracts/outcome_manager/src/errors.rs
@@ -63,4 +63,10 @@ pub enum OutcomeError {
     /// A price observation's timestamp falls outside `[call_end_ts -
     /// twap_window_secs, call_end_ts]`.
     ObservationOutsideWindow = 29,
+    /// `claim_on_behalf` was called by an address that is not the original
+    /// winner's designated recovery address (or none has been set).
+    NotRecoveryAgent = 30,
+    /// `claim_on_behalf` was called before `recovery_grace_period` has
+    /// elapsed since the call was settled.
+    RecoveryGracePeriodNotElapsed = 31,
 }

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -135,6 +135,41 @@ pub fn emit_claimable_balance_created(
     );
 }
 
+/// Emitted when a designated recovery address claims an unclaimed payout on
+/// the original winner's behalf, after the recovery grace period elapsed.
+pub fn emit_recovery_claimed(
+    env: &Env,
+    recovery_agent: &soroban_sdk::Address,
+    original_winner: &soroban_sdk::Address,
+    call_id: u64,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("recovery"), symbol_short!("claimed")),
+        (recovery_agent.clone(), original_winner.clone(), call_id, amount),
+    );
+}
+
+/// Emitted when a user sets (or replaces) their designated recovery address.
+pub fn emit_recovery_address_set(
+    env: &Env,
+    user: &soroban_sdk::Address,
+    recovery_address: &soroban_sdk::Address,
+) {
+    env.events().publish(
+        (symbol_short!("recovery"), symbol_short!("set")),
+        (user.clone(), recovery_address.clone()),
+    );
+}
+
+/// Emitted when a user removes their designated recovery address.
+pub fn emit_recovery_address_removed(env: &Env, user: &soroban_sdk::Address) {
+    env.events().publish(
+        (symbol_short!("recovery"), symbol_short!("removed")),
+        user.clone(),
+    );
+}
+
 use soroban_sdk::contracterror;
 
 #[contracterror]

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -25,6 +25,7 @@ use events::{
     emit_admin_params_changed, emit_batch_payout_started, emit_claimable_balance_created,
     emit_contract_upgraded, emit_fee_collected, emit_outcome_disputed, emit_outcome_finalized,
     emit_outcome_submitted, emit_payout_claimed, emit_price_observation_submitted,
+    emit_recovery_address_removed, emit_recovery_address_set, emit_recovery_claimed,
     emit_twap_computed,
 };
 use storage::{
@@ -178,6 +179,16 @@ fn require_call_settled(env: &Env, call_id: u64) {
     {
         soroban_sdk::panic_with_error!(env, OutcomeError::CallNotSettled);
     }
+}
+
+/// Read the settlement timestamp recorded for `call_id`. Both finalization
+/// paths (`Self::finalize` and `finalize_outcome`) write this at the same
+/// moment they write `FinalOutcome`, so by the time `require_call_settled`
+/// has passed this should always be present. Fall back to "now" (i.e. an
+/// elapsed time of zero) as a fail-safe if it's somehow missing, so a
+/// missing timestamp can never be mistaken for an *elapsed* grace period.
+fn get_settled_at(env: &Env, call_id: u64) -> u64 {
+    storage::get_settled_at_opt(env, call_id).unwrap_or_else(|| env.ledger().timestamp())
 }
 
 fn get_fee_config(env: &Env) -> (u32, Address) {
@@ -640,6 +651,7 @@ impl OutcomeManager {
         env.storage()
             .instance()
             .set(&InstanceKey::FinalOutcome(outcome.call_id), &outcome);
+        storage::set_settled_at(env, outcome.call_id, env.ledger().timestamp());
 
         registry_resolve_call(
             env,
@@ -724,6 +736,133 @@ impl OutcomeManager {
 
         emit_claimable_balance_created(&env, call_id, &staker, &balance_id, payout);
         emit_payout_claimed(&env, call_id, &staker, payout);
+    }
+
+    // ─── Social recovery ───────────────────────────────────────────────────
+
+    /// Designate a recovery address for `user`. If `user` doesn't claim a
+    /// payout within `recovery_grace_period` seconds of settlement, the
+    /// designated recovery address may claim it on `user`'s behalf via
+    /// `claim_on_behalf`. Must be signed by `user`. Setting a recovery
+    /// address does not remove `user`'s own right to claim at any time.
+    pub fn set_recovery_address(env: Env, user: Address, recovery_address: Address) {
+        user.require_auth();
+        storage::set_recovery_address(&env, user.clone(), recovery_address.clone());
+        emit_recovery_address_set(&env, &user, &recovery_address);
+    }
+
+    /// Remove `user`'s designated recovery address, if any. Must be signed
+    /// by `user`.
+    pub fn remove_recovery_address(env: Env, user: Address) {
+        user.require_auth();
+        storage::remove_recovery_address(&env, user.clone());
+        emit_recovery_address_removed(&env, &user);
+    }
+
+    /// Return `user`'s designated recovery address, if one has been set.
+    pub fn get_recovery_address(env: Env, user: Address) -> Option<Address> {
+        storage::get_recovery_address_opt(&env, user)
+    }
+
+    /// Set the grace period (seconds) that must elapse after a call is
+    /// settled before a designated recovery address may claim an unclaimed
+    /// payout on the original winner's behalf (admin only). Default 30 days.
+    pub fn set_recovery_grace_period(env: Env, new_period_secs: u64) {
+        require_admin(&env);
+        storage::set_recovery_grace_period(&env, new_period_secs);
+        emit_admin_params_changed(&env, new_period_secs);
+    }
+
+    /// Return the current recovery grace period, in seconds.
+    pub fn get_recovery_grace_period(env: Env) -> u64 {
+        storage::get_recovery_grace_period(&env)
+    }
+
+    /// Claim a winning staker's payout on their behalf, as their designated
+    /// recovery address, once `recovery_grace_period` has elapsed since the
+    /// call settled and the original winner hasn't claimed it themselves.
+    ///
+    /// Reuses the exact same payout computation as `claim_payout`
+    /// (`compute_payout_parts`) and the exact same `Claimed(call_id, ..)`
+    /// reentrancy-guard flag — marked against `original_winner` (not
+    /// `recovery_agent`) so the original winner can't *also* claim
+    /// afterward. The computed payout is transferred `to = recovery_agent`.
+    pub fn claim_on_behalf(
+        env: Env,
+        registry: Address,
+        call_id: u64,
+        recovery_agent: Address,
+        original_winner: Address,
+        staker_winning_stake: i128,
+        total_winning_stake: i128,
+        total_losing_stake: i128,
+    ) {
+        if is_paused(&env) {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
+        }
+
+        recovery_agent.require_auth();
+
+        let stored_recovery = storage::get_recovery_address_opt(&env, original_winner.clone());
+        if stored_recovery.as_ref() != Some(&recovery_agent) {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::NotRecoveryAgent);
+        }
+
+        require_call_settled(&env, call_id);
+
+        // Check the definitive "already claimed" state before the
+        // time-based grace-period gate, so a winner who already claimed
+        // always sees `AlreadyClaimed` rather than a confusing
+        // `RecoveryGracePeriodNotElapsed` if the grace period also hasn't
+        // elapsed yet.
+        let claimed_key = InstanceKey::Claimed(call_id, original_winner.clone());
+        if env.storage().instance().has(&claimed_key) {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadyClaimed);
+        }
+
+        let settled_at = get_settled_at(&env, call_id);
+        let grace_period = storage::get_recovery_grace_period(&env);
+        let elapsed = env.ledger().timestamp().saturating_sub(settled_at);
+        if elapsed < grace_period {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::RecoveryGracePeriodNotElapsed);
+        }
+
+        if staker_winning_stake <= 0 {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
+        }
+        if total_winning_stake <= 0 {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidWinningStake);
+        }
+
+        let (fee_bps, fee_collector) = get_fee_config(&env);
+        let total_fee = compute_total_fee(&env, total_losing_stake, fee_bps);
+        let net_losing = total_losing_stake
+            .checked_sub(total_fee)
+            .unwrap_or_else(|| overflow(&env));
+
+        let (staker_fee_share, payout) = compute_payout_parts(
+            &env,
+            staker_winning_stake,
+            total_winning_stake,
+            total_fee,
+            net_losing,
+        );
+
+        // Mark as claimed against the ORIGINAL WINNER before external calls
+        // (reentrancy guard) — this is the same flag `claim_payout` checks,
+        // so the original winner can no longer claim once the recovery
+        // agent has claimed on their behalf, and vice versa.
+        env.storage().instance().set(&claimed_key, &true);
+
+        if staker_fee_share > 0 {
+            registry_release_escrow(&env, &registry, call_id, &fee_collector, staker_fee_share);
+            emit_fee_collected(&env, call_id, staker_fee_share, &fee_collector);
+        }
+
+        // The actual tokens go to the recovery agent, not the original winner.
+        registry_release_escrow(&env, &registry, call_id, &recovery_agent, payout);
+
+        emit_recovery_claimed(&env, &recovery_agent, &original_winner, call_id, payout);
     }
 
     /// Batch-create claimable balances for multiple winning stakers (admin only).
@@ -930,6 +1069,7 @@ impl OutcomeManager {
         env.storage()
             .instance()
             .set(&InstanceKey::FinalOutcome(call_id), &pending);
+        storage::set_settled_at(&env, call_id, env.ledger().timestamp());
         let registry = get_registry(&env);
         registry_resolve_call(
             &env,

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -68,6 +68,15 @@ pub enum InstanceKey {
     /// Minimum price observations required for a TWAP to be considered
     /// valid. Default 3.
     TwapMinObservations,
+    /// Ledger timestamp (seconds) at which `call_id` was settled — i.e. the
+    /// moment `FinalOutcome(call_id)` was written, via either the immediate
+    /// quorum path (`Self::finalize`) or the dispute-window path
+    /// (`finalize_outcome`). Used to measure the social-recovery grace period.
+    SettledAt(u64),
+    /// Grace period (seconds) that must elapse after a call is settled
+    /// before a designated recovery address may claim an unclaimed payout
+    /// on the original winner's behalf. Default 30 days (2_592_000s).
+    RecoveryGracePeriodSecs,
 }
 
 #[contracttype]
@@ -78,6 +87,12 @@ pub enum PersistentKey {
     PendingOracleRemoval(BytesN<32>),
     /// Pending oracle addition: reserved for scheduled oracle onboarding.
     PendingOracleAdditions(BytesN<32>),
+    /// Social recovery: maps a user's address to the trusted recovery
+    /// address they've designated via `set_recovery_address`. Per-user, so
+    /// this lives in persistent (not instance) storage — see
+    /// `PersistentKey::Votes` for the established pattern of keying
+    /// per-entity persistent data off this enum.
+    RecoveryAddress(Address),
 }
 
 /// A single price data point submitted by an oracle for TWAP calculation
@@ -176,4 +191,59 @@ pub fn get_twap_config(env: &Env) -> (u64, u32) {
         .get(&InstanceKey::TwapMinObservations)
         .unwrap_or(DEFAULT_TWAP_MIN_OBSERVATIONS);
     (window_secs, min_observations)
+}
+
+// ─── Social recovery ────────────────────────────────────────────────────────
+
+/// 30 days, in seconds — the default grace period before a designated
+/// recovery address may claim an unclaimed payout on the original winner's
+/// behalf.
+pub const DEFAULT_RECOVERY_GRACE_PERIOD_SECS: u64 = 30 * 24 * 60 * 60;
+
+/// Record the ledger timestamp at which `call_id` was settled. Called at the
+/// exact moment `FinalOutcome(call_id)` is written (both the immediate-quorum
+/// path and the dispute-window path).
+pub fn set_settled_at(env: &Env, call_id: u64, ts: u64) {
+    env.storage()
+        .instance()
+        .set(&InstanceKey::SettledAt(call_id), &ts);
+}
+
+/// Read the settlement timestamp for `call_id`, if recorded.
+pub fn get_settled_at_opt(env: &Env, call_id: u64) -> Option<u64> {
+    env.storage().instance().get(&InstanceKey::SettledAt(call_id))
+}
+
+pub fn set_recovery_grace_period(env: &Env, secs: u64) {
+    env.storage()
+        .instance()
+        .set(&InstanceKey::RecoveryGracePeriodSecs, &secs);
+}
+
+pub fn get_recovery_grace_period(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&InstanceKey::RecoveryGracePeriodSecs)
+        .unwrap_or(DEFAULT_RECOVERY_GRACE_PERIOD_SECS)
+}
+
+/// Set (or overwrite) `user`'s designated recovery address.
+pub fn set_recovery_address(env: &Env, user: Address, recovery_address: Address) {
+    env.storage()
+        .persistent()
+        .set(&PersistentKey::RecoveryAddress(user), &recovery_address);
+}
+
+/// Read `user`'s designated recovery address, if any.
+pub fn get_recovery_address_opt(env: &Env, user: Address) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&PersistentKey::RecoveryAddress(user))
+}
+
+/// Remove `user`'s designated recovery address, if one is set.
+pub fn remove_recovery_address(env: &Env, user: Address) {
+    env.storage()
+        .persistent()
+        .remove(&PersistentKey::RecoveryAddress(user));
 }

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -1521,3 +1521,241 @@ fn test_rotation_keys_do_not_collide_with_admin_or_quorum() {
     assert!(client.is_oracle(&extra_pubkey), "admin key corrupted by rotation");
 }
 
+// ─── Social Recovery Tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_recovery_address() {
+    let env = Env::default();
+    let (_, _, client) = setup_with_fee(&env, 0);
+    let user = Address::generate(&env);
+    let recovery = Address::generate(&env);
+
+    assert!(client.get_recovery_address(&user).is_none());
+
+    client.set_recovery_address(&user, &recovery);
+    assert_eq!(client.get_recovery_address(&user), Some(recovery));
+}
+
+#[test]
+fn test_remove_recovery_address() {
+    let env = Env::default();
+    let (_, _, client) = setup_with_fee(&env, 0);
+    let user = Address::generate(&env);
+    let recovery = Address::generate(&env);
+
+    client.set_recovery_address(&user, &recovery);
+    assert!(client.get_recovery_address(&user).is_some());
+
+    client.remove_recovery_address(&user);
+    assert!(client.get_recovery_address(&user).is_none());
+}
+
+#[test]
+fn test_default_recovery_grace_period_is_30_days() {
+    let env = Env::default();
+    let (_, _, client) = setup_with_fee(&env, 0);
+    assert_eq!(client.get_recovery_grace_period(), 30 * 24 * 60 * 60);
+}
+
+/// The original winner is never blocked by a recovery address: they can
+/// claim at any time, including before the grace period would even allow
+/// the recovery agent to act. Once claimed, the recovery agent can no
+/// longer claim on their behalf (same `Claimed` flag).
+#[test]
+fn test_original_winner_claims_before_recovery_agent() {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let recovery_agent = Address::generate(&env);
+
+    client.set_recovery_address(&staker, &recovery_agent);
+
+    // Winner claims immediately -- no need to wait for the grace period.
+    client.claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+    assert!(client.has_claimed(&1u64, &staker));
+
+    // Recovery agent can no longer claim -- already claimed by the winner.
+    let result = client.try_claim_on_behalf(
+        &registry_id,
+        &1u64,
+        &recovery_agent,
+        &staker,
+        &100i128,
+        &100i128,
+        &100i128,
+    );
+    assert_contract_error(result, OutcomeError::AlreadyClaimed);
+}
+
+#[test]
+fn test_claim_on_behalf_fails_one_second_before_grace_period() {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let recovery_agent = Address::generate(&env);
+    let settled_at = env.ledger().timestamp();
+
+    client.set_recovery_address(&staker, &recovery_agent);
+
+    let grace_period = client.get_recovery_grace_period();
+    env.ledger().with_mut(|li| {
+        li.timestamp = settled_at + grace_period - 1;
+    });
+
+    let result = client.try_claim_on_behalf(
+        &registry_id,
+        &1u64,
+        &recovery_agent,
+        &staker,
+        &100i128,
+        &100i128,
+        &100i128,
+    );
+    assert_contract_error(result, OutcomeError::RecoveryGracePeriodNotElapsed);
+}
+
+#[test]
+fn test_claim_on_behalf_succeeds_exactly_at_grace_period() {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let recovery_agent = Address::generate(&env);
+    let settled_at = env.ledger().timestamp();
+
+    client.set_recovery_address(&staker, &recovery_agent);
+
+    let grace_period = client.get_recovery_grace_period();
+    env.ledger().with_mut(|li| {
+        li.timestamp = settled_at + grace_period;
+    });
+
+    client.claim_on_behalf(
+        &registry_id,
+        &1u64,
+        &recovery_agent,
+        &staker,
+        &100i128,
+        &100i128,
+        &100i128,
+    );
+
+    assert!(client.has_claimed(&1u64, &staker));
+
+    // Original winner can no longer claim afterward -- same `Claimed` flag.
+    let result =
+        client.try_claim_payout(&registry_id, &1u64, &staker, &100i128, &100i128, &100i128);
+    assert_contract_error(result, OutcomeError::AlreadyClaimed);
+}
+
+#[test]
+fn test_claim_on_behalf_fails_for_non_recovery_agent() {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let recovery_agent = Address::generate(&env);
+    let impostor = Address::generate(&env);
+    let settled_at = env.ledger().timestamp();
+
+    client.set_recovery_address(&staker, &recovery_agent);
+
+    let grace_period = client.get_recovery_grace_period();
+    env.ledger().with_mut(|li| {
+        li.timestamp = settled_at + grace_period;
+    });
+
+    let result = client.try_claim_on_behalf(
+        &registry_id,
+        &1u64,
+        &impostor,
+        &staker,
+        &100i128,
+        &100i128,
+        &100i128,
+    );
+    assert_contract_error(result, OutcomeError::NotRecoveryAgent);
+}
+
+#[test]
+fn test_claim_on_behalf_fails_when_no_recovery_address_set() {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let someone = Address::generate(&env);
+    let settled_at = env.ledger().timestamp();
+
+    let grace_period = client.get_recovery_grace_period();
+    env.ledger().with_mut(|li| {
+        li.timestamp = settled_at + grace_period;
+    });
+
+    let result = client.try_claim_on_behalf(
+        &registry_id,
+        &1u64,
+        &someone,
+        &staker,
+        &100i128,
+        &100i128,
+        &100i128,
+    );
+    assert_contract_error(result, OutcomeError::NotRecoveryAgent);
+}
+
+#[test]
+fn test_set_recovery_grace_period_changes_default() {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let recovery_agent = Address::generate(&env);
+    let settled_at = env.ledger().timestamp();
+
+    client.set_recovery_grace_period(&100u64);
+    assert_eq!(client.get_recovery_grace_period(), 100u64);
+
+    client.set_recovery_address(&staker, &recovery_agent);
+
+    // Would fail against the (unused) 30-day default, but the custom
+    // 100s period has elapsed.
+    env.ledger().with_mut(|li| {
+        li.timestamp = settled_at + 100;
+    });
+
+    client.claim_on_behalf(
+        &registry_id,
+        &1u64,
+        &recovery_agent,
+        &staker,
+        &100i128,
+        &100i128,
+        &100i128,
+    );
+    assert!(client.has_claimed(&1u64, &staker));
+}
+
+#[test]
+fn test_claim_on_behalf_fails_when_paused() {
+    let env = Env::default();
+    let (_, registry_id, client) = setup_with_fee(&env, 0);
+    let staker = Address::generate(&env);
+    let recovery_agent = Address::generate(&env);
+    let settled_at = env.ledger().timestamp();
+
+    client.set_recovery_address(&staker, &recovery_agent);
+    let grace_period = client.get_recovery_grace_period();
+    env.ledger().with_mut(|li| {
+        li.timestamp = settled_at + grace_period;
+    });
+
+    client.pause();
+
+    let result = client.try_claim_on_behalf(
+        &registry_id,
+        &1u64,
+        &recovery_agent,
+        &staker,
+        &100i128,
+        &100i128,
+        &100i128,
+    );
+    assert_contract_error(result, OutcomeError::ContractPaused);
+}
+


### PR DESCRIPTION
## Summary
closes #470 
- Users can designate a recovery address (`set_recovery_address`/`remove_recovery_address`, both user-signed) stored per-user in persistent storage
- `claim_on_behalf` lets the designated recovery address claim a payout once `recovery_grace_period` (default 30 days, admin-configurable via `set_recovery_grace_period`) has elapsed since settlement — reuses the same `compute_payout_parts`/`registry_release_escrow` path as `claim_payout`, marks the existing `Claimed(call_id, original_winner)` guard so the original winner can no longer double-claim afterward
- Original winner retains the ability to claim first at any time; doing so blocks the recovery agent via the same guard
- Added `InstanceKey::SettledAt(call_id)`, written at both places a call's outcome finalizes, since no existing timestamp actually represented "time of settlement"
- Emits `RecoveryClaimed(recovery_agent, original_winner, call_id, amount)` (plus `RecoveryAddressSet`/`RecoveryAddressRemoved`)

## Acceptance criteria
- [x] Recovery address stored via `DataKey::RecoveryAddress(user)` (persistent storage)
- [x] `set_recovery_address(env, user, recovery_address)` — user-signed
- [x] `remove_recovery_address(env, user)` — user-signed
- [x] `claim_on_behalf(env, recovery_agent, call_id, original_winner)` — recovery-address-only, only after grace period since settlement, transfers to recovery agent, emits `RecoveryClaimed`
- [x] Original winner can still claim first at any time
- [x] `get_recovery_address(env, user) -> Option<Address>` view fn
- [x] Tests: recovery claim after grace period, original winner claims first, non-recovery-agent fails, grace period not elapsed fails, set/remove recovery address

## Test plan
- [x] `cargo test -p outcome-manager` — 69 passing, 0 failed (10 new tests, boundary-tested at exactly `grace_period - 1` and `grace_period`)
- [x] `cargo build --release -p outcome-manager`
- [x] Verified all other workspace crates unaffected individually (`prediction_market_factory`/`parlay_betting` workspace-wide test blocked only by a pre-existing, unrelated missing `stellar`-CLI dependency)
