### PR TITLE
Add lending_pool contract: passive-yield Kelly-edge prediction market pool

### DIFF
--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -889,6 +889,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lending-pool"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "ed25519-dalek",
+ "outcome-manager",
+ "prediction-market",
+ "prediction-market-factory",
+ "rand",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/packages/contracts/Cargo.toml
+++ b/packages/contracts/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "parlay_betting",
   "gas_station",
   "oracle_marketplace",
+  "lending_pool",
   "contracts/hello-world",
 ]
 

--- a/packages/contracts/lending_pool/Cargo.toml
+++ b/packages/contracts/lending_pool/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "lending-pool"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+backit-shared = { workspace = true }
+prediction-market = { path = "../prediction_market" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+prediction-market-factory = { path = "../prediction_market_factory" }
+outcome-manager = { path = "../outcome_manager" }
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+rand = "0.8"

--- a/packages/contracts/lending_pool/src/errors.rs
+++ b/packages/contracts/lending_pool/src/errors.rs
@@ -1,0 +1,25 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum LendingPoolError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    InvalidAmount = 3,
+    BelowMinDeposit = 4,
+    PoolFull = 5,
+    InsufficientShares = 6,
+    ZeroSupply = 7,
+    InsufficientLiquidity = 8,
+    Overflow = 9,
+    PoolTooSmall = 10,
+    EmptyInput = 11,
+    AllocationNotFound = 12,
+    AlreadyHarvested = 13,
+    MarketNotResolved = 14,
+    MarketCallFailed = 15,
+    Unauthorized = 16,
+    InvalidBps = 17,
+    InvalidConfig = 18,
+}

--- a/packages/contracts/lending_pool/src/events.rs
+++ b/packages/contracts/lending_pool/src/events.rs
@@ -1,0 +1,44 @@
+#![allow(deprecated)]
+
+use soroban_sdk::{Address, Env};
+
+pub fn emit_deposited(env: &Env, user: &Address, amount: i128, lp_shares_minted: i128) {
+    env.events().publish(
+        ("lending_pool", "Deposited"),
+        (user.clone(), amount, lp_shares_minted),
+    );
+}
+
+pub fn emit_withdrawn(env: &Env, user: &Address, lp_shares_burned: i128, amount_out: i128) {
+    env.events().publish(
+        ("lending_pool", "Withdrawn"),
+        (user.clone(), lp_shares_burned, amount_out),
+    );
+}
+
+pub fn emit_capital_allocated(
+    env: &Env,
+    call_id: u64,
+    market_address: &Address,
+    position: u32,
+    amount: i128,
+) {
+    env.events().publish(
+        ("lending_pool", "CapitalAllocated"),
+        (call_id, market_address.clone(), position, amount),
+    );
+}
+
+pub fn emit_yield_harvested(
+    env: &Env,
+    call_id: u64,
+    won: bool,
+    gross_change: i128,
+    protocol_fee: i128,
+    net_yield: i128,
+) {
+    env.events().publish(
+        ("lending_pool", "YieldHarvested"),
+        (call_id, won, gross_change, protocol_fee, net_yield),
+    );
+}

--- a/packages/contracts/lending_pool/src/lib.rs
+++ b/packages/contracts/lending_pool/src/lib.rs
@@ -1,0 +1,758 @@
+//! Passive-yield lending pool for BACKit prediction markets.
+//!
+//! Depositors pool USDC (or any configured SAC / native XLM) and receive LP
+//! shares tracking their proportional claim on the pool. Anyone may then call
+//! [`LendingPool::allocate_capital`] to have the pool stake a slice of its
+//! capital on the statistically favored side of open markets (a simplified
+//! Kelly-Criterion edge strategy), and anyone may call
+//! [`LendingPool::harvest_yield`] once a staked market resolves to realize
+//! the pool's winnings (or losses) and update the LP share price.
+//!
+//! **Scope decisions** (see `lending_pool` design notes / issue #466):
+//!
+//! - **LP shares are a plain internal ledger**, not a deployed SAC token.
+//!   `prediction_market::Call::share_tokens` is a `Map<u32, Address>` of
+//!   *per-outcome-position* addresses that field is populated by nothing in
+//!   this codebase today (no constructor arg sets it, no code writes to it)
+//!   — it is not an established, reusable "mint a real SAC for pool shares"
+//!   pattern to mirror. Deploying and administering a full second SAC per
+//!   pool instance is a large amount of additional surface (asset issuer
+//!   setup, trustlines, a second contract deployment) for what the
+//!   acceptance criteria actually needs: a proportional, transfer-free
+//!   accounting unit. A `Map<Address, i128>` + `total_lp_shares` counter
+//!   (mirroring `index_fund`'s `UserIndexBalance` ledger) captures the same
+//!   economics — deposit mints shares at the current NAV, withdraw burns
+//!   them — without the extra deployment/administration surface.
+//! - **No "true" oracle-probability feed exists pre-existing in this
+//!   codebase** for *open* (unresolved) markets — see doc comment on
+//!   [`LendingPool::allocate_capital`].
+//! - **Harvesting**: this pool is the staker of record on every allocation
+//!   (it stakes *as itself*, mirroring `parlay_betting`'s escrow model), so
+//!   after a market resolves it must claim its own payout. `prediction_market`
+//!   has no standalone "claim" entrypoint of its own — claims are brokered by
+//!   `outcome_manager::claim_payout_for_market`, which computes the pro-rata
+//!   payout from caller-supplied stake totals and calls back into
+//!   `prediction_market::release_escrow` to move the tokens. `harvest_yield`
+//!   wraps that call, deducts the protocol fee on any realized profit, and
+//!   updates `total_yield_earned` / the LP share price.
+#![no_std]
+#![allow(clippy::too_many_arguments)]
+
+mod errors;
+mod events;
+mod storage;
+mod types;
+mod xcontract;
+
+pub use types::{Allocation, AllocationOutcome, MarketAllocationInput, PoolConfig, PoolStats};
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation};
+use soroban_sdk::{contract, contractimpl, token, Address, Env, IntoVal, Symbol, Vec};
+
+use errors::LendingPoolError;
+use events::{emit_capital_allocated, emit_deposited, emit_withdrawn, emit_yield_harvested};
+use prediction_market::PredictionMarketClient;
+use storage::*;
+use types::YieldEvent;
+
+/// Basis-point scale: 10_000 == 100%. All probability / edge / fee / APY
+/// math in this contract is fixed-point integer arithmetic in this unit —
+/// Soroban/WASM contracts must not use floats.
+const BPS_SCALE: i128 = 10_000;
+/// Rolling window, in seconds, used to annualize realized yield into an APY.
+const APY_WINDOW_SECS: u64 = 7 * 86_400;
+/// Days-per-year used to annualize the rolling-window yield sum.
+const DAYS_PER_YEAR: i128 = 365;
+const WINDOW_DAYS: i128 = 7;
+
+const DEFAULT_MAX_ALLOCATION_BPS: u32 = 500; // 5%
+const DEFAULT_PROTOCOL_FEE_BPS: u32 = 1_000; // 10%
+const DEFAULT_EDGE_THRESHOLD_BPS: u32 = 100; // 1%
+const MAX_BPS: u32 = 10_000;
+
+// ─── Native-XLM / SAC token dispatch (mirrors prediction_market::transfer_token) ──
+
+#[cfg(not(test))]
+#[inline]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let sentinel = Address::from_string(&soroban_sdk::String::from_str(
+        env,
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    ));
+    *addr == sentinel
+}
+
+#[cfg(test)]
+fn is_native_xlm(env: &Env, addr: &Address) -> bool {
+    let key = soroban_sdk::Symbol::new(env, "xlm_sac_addr");
+    if let Some(sentinel) = env.storage().instance().get::<_, Address>(&key) {
+        return *addr == sentinel;
+    }
+    false
+}
+
+fn transfer_token(env: &Env, token_addr: &Address, from: &Address, to: &Address, amount: i128) {
+    if is_native_xlm(env, token_addr) {
+        token::StellarAssetClient::new(env, token_addr).transfer(from, to, &amount);
+    } else {
+        token::Client::new(env, token_addr).transfer(from, to, &amount);
+    }
+}
+
+fn token_balance(env: &Env, token_addr: &Address) -> i128 {
+    token::Client::new(env, token_addr).balance(&env.current_contract_address())
+}
+
+/// Pre-authorizes the nested `transfer` that `prediction_market::stake_on_call`
+/// performs on this contract's behalf, exactly mirroring
+/// `parlay_betting::authorize_stake_transfer` (see that function's doc
+/// comment for the full explanation of why this is required).
+fn authorize_stake_transfer(
+    env: &Env,
+    stake_token: &Address,
+    from: &Address,
+    market_address: &Address,
+    amount: i128,
+) {
+    let args: Vec<soroban_sdk::Val> = (from.clone(), market_address.clone(), amount).into_val(env);
+    let entry = InvokerContractAuthEntry::Contract(SubContractInvocation {
+        context: ContractContext {
+            contract: stake_token.clone(),
+            fn_name: Symbol::new(env, "transfer"),
+            args,
+        },
+        sub_invocations: Vec::new(env),
+    });
+    env.authorize_as_current_contract(Vec::from_array(env, [entry]));
+}
+
+fn other_position(position: u32) -> u32 {
+    if position == 1 {
+        2
+    } else {
+        1
+    }
+}
+
+fn compute_tvl(env: &Env, config: &PoolConfig) -> Result<i128, LendingPoolError> {
+    let liquid = token_balance(env, &config.stake_token);
+    let locked = get_total_allocated_locked(env);
+    liquid
+        .checked_add(locked)
+        .ok_or(LendingPoolError::Overflow)
+}
+
+/// Appends a yield event and prunes entries older than [`APY_WINDOW_SECS`],
+/// bounding the list's storage footprint over the pool's lifetime.
+fn record_yield_event(env: &Env, net_yield: i128) {
+    let now = env.ledger().timestamp();
+    let existing = get_yield_events(env);
+    let mut kept = Vec::new(env);
+    for ev in existing.iter() {
+        if now.saturating_sub(ev.timestamp) <= APY_WINDOW_SECS {
+            kept.push_back(ev);
+        }
+    }
+    kept.push_back(YieldEvent {
+        timestamp: now,
+        net_yield,
+    });
+    set_yield_events(env, &kept);
+}
+
+/// Rolling 7-day annualized yield, in basis points (can be negative).
+/// `apy_bps = sum(net_yield over last 7 days) * 10_000 * 365 / (7 * tvl)`.
+/// This treats the trailing window's yield as representative of a full
+/// 7-day period even early in the pool's life (fewer than 7 days of
+/// history) — a documented simplification, not a true annualization of a
+/// partial sample.
+fn compute_apy_bps(env: &Env, tvl: i128) -> i128 {
+    if tvl <= 0 {
+        return 0;
+    }
+    let now = env.ledger().timestamp();
+    let events = get_yield_events(env);
+    let mut sum: i128 = 0;
+    for ev in events.iter() {
+        if now.saturating_sub(ev.timestamp) <= APY_WINDOW_SECS {
+            sum = sum.saturating_add(ev.net_yield);
+        }
+    }
+    sum.saturating_mul(BPS_SCALE)
+        .saturating_mul(DAYS_PER_YEAR)
+        .checked_div(WINDOW_DAYS)
+        .and_then(|v| v.checked_div(tvl))
+        .unwrap_or(0)
+}
+
+/// Resolve `call_id`'s deployed market address via the configured factory.
+fn resolve_market_address(
+    env: &Env,
+    config: &PoolConfig,
+    call_id: u64,
+) -> Result<Address, LendingPoolError> {
+    xcontract::resolve_market_address(env, config, call_id)
+}
+
+#[contract]
+pub struct LendingPool;
+
+#[contractimpl]
+impl LendingPool {
+    /// Initialize the pool (callable once). `min_allocation_pool_size` is
+    /// the minimum TVL `allocate_capital` requires before it will stake
+    /// anything. `max_allocation_bps_per_market`, `protocol_fee_bps` and
+    /// `edge_threshold_bps` are seeded with sane defaults (5%, 10%, 1%) and
+    /// can be tuned afterwards by `admin` via the `set_*` functions below.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        treasury: Address,
+        stake_token: Address,
+        prediction_market_factory: Address,
+        outcome_manager: Address,
+        min_deposit: i128,
+        max_pool_size: i128,
+        min_allocation_pool_size: i128,
+    ) -> Result<(), LendingPoolError> {
+        if get_config(&env).is_some() {
+            return Err(LendingPoolError::AlreadyInitialized);
+        }
+        admin.require_auth();
+
+        if min_deposit <= 0 || max_pool_size <= 0 || min_allocation_pool_size <= 0 {
+            return Err(LendingPoolError::InvalidConfig);
+        }
+        if min_allocation_pool_size > max_pool_size {
+            return Err(LendingPoolError::InvalidConfig);
+        }
+
+        set_config(
+            &env,
+            &PoolConfig {
+                admin,
+                treasury,
+                stake_token,
+                prediction_market_factory,
+                outcome_manager,
+                min_deposit,
+                max_pool_size,
+                min_allocation_pool_size,
+                max_allocation_bps_per_market: DEFAULT_MAX_ALLOCATION_BPS,
+                protocol_fee_bps: DEFAULT_PROTOCOL_FEE_BPS,
+                edge_threshold_bps: DEFAULT_EDGE_THRESHOLD_BPS,
+            },
+        );
+        Ok(())
+    }
+
+    // ─── Depositor-facing ────────────────────────────────────────────────
+
+    /// Deposit `amount` of the pool's stake token and mint LP shares at the
+    /// current share price (`total_value_locked / total_lp_shares`, 1:1 on
+    /// the very first deposit). Returns the number of LP shares minted.
+    pub fn deposit(env: Env, user: Address, amount: i128) -> Result<i128, LendingPoolError> {
+        user.require_auth();
+
+        let config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        if amount <= 0 {
+            return Err(LendingPoolError::InvalidAmount);
+        }
+        if amount < config.min_deposit {
+            return Err(LendingPoolError::BelowMinDeposit);
+        }
+
+        let tvl_before = compute_tvl(&env, &config)?;
+        let new_tvl = tvl_before
+            .checked_add(amount)
+            .ok_or(LendingPoolError::Overflow)?;
+        if new_tvl > config.max_pool_size {
+            return Err(LendingPoolError::PoolFull);
+        }
+
+        let total_supply = get_total_lp_shares(&env);
+        let lp_shares = if total_supply <= 0 || tvl_before <= 0 {
+            amount
+        } else {
+            amount
+                .checked_mul(total_supply)
+                .ok_or(LendingPoolError::Overflow)?
+                .checked_div(tvl_before)
+                .ok_or(LendingPoolError::Overflow)?
+        };
+        if lp_shares <= 0 {
+            return Err(LendingPoolError::InvalidAmount);
+        }
+
+        transfer_token(&env, &config.stake_token, &user, &env.current_contract_address(), amount);
+
+        set_total_lp_shares(
+            &env,
+            total_supply
+                .checked_add(lp_shares)
+                .ok_or(LendingPoolError::Overflow)?,
+        );
+        let total_deposited = get_total_deposited(&env);
+        set_total_deposited(
+            &env,
+            total_deposited
+                .checked_add(amount)
+                .ok_or(LendingPoolError::Overflow)?,
+        );
+        let user_shares = get_lp_shares(&env, &user);
+        set_lp_shares(
+            &env,
+            &user,
+            user_shares
+                .checked_add(lp_shares)
+                .ok_or(LendingPoolError::Overflow)?,
+        );
+
+        emit_deposited(&env, &user, amount, lp_shares);
+        Ok(lp_shares)
+    }
+
+    /// Burn `lp_amount` LP shares and return the proportional share of the
+    /// pool's current total value locked. Fails with
+    /// `InsufficientLiquidity` if the pool's *unallocated* balance can't
+    /// cover it (capital currently staked in open markets isn't
+    /// withdrawable until `harvest_yield` frees it).
+    pub fn withdraw(env: Env, user: Address, lp_amount: i128) -> Result<i128, LendingPoolError> {
+        user.require_auth();
+
+        let config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        if lp_amount <= 0 {
+            return Err(LendingPoolError::InvalidAmount);
+        }
+
+        let user_shares = get_lp_shares(&env, &user);
+        if user_shares < lp_amount {
+            return Err(LendingPoolError::InsufficientShares);
+        }
+
+        let total_supply = get_total_lp_shares(&env);
+        if total_supply <= 0 {
+            return Err(LendingPoolError::ZeroSupply);
+        }
+
+        let tvl = compute_tvl(&env, &config)?;
+        let amount_out = lp_amount
+            .checked_mul(tvl)
+            .ok_or(LendingPoolError::Overflow)?
+            .checked_div(total_supply)
+            .ok_or(LendingPoolError::Overflow)?;
+
+        let liquid = token_balance(&env, &config.stake_token);
+        if amount_out > liquid {
+            return Err(LendingPoolError::InsufficientLiquidity);
+        }
+
+        set_total_lp_shares(
+            &env,
+            total_supply
+                .checked_sub(lp_amount)
+                .ok_or(LendingPoolError::Overflow)?,
+        );
+        set_lp_shares(
+            &env,
+            &user,
+            user_shares
+                .checked_sub(lp_amount)
+                .ok_or(LendingPoolError::Overflow)?,
+        );
+
+        transfer_token(&env, &config.stake_token, &env.current_contract_address(), &user, amount_out);
+
+        emit_withdrawn(&env, &user, lp_amount, amount_out);
+        Ok(amount_out)
+    }
+
+    // ─── Capital allocation (Kelly-edge strategy) ───────────────────────
+
+    /// Permissionless: stake a slice of the pool's liquid capital on each
+    /// open market in `markets`, once the pool's total value locked is at
+    /// least `min_allocation_pool_size`.
+    ///
+    /// **Scope decision on `oracle_probability_bps`:** there is no
+    /// pre-existing canonical "true probability" feed for *open* markets
+    /// anywhere in this codebase — `schelling_oracle` / `outcome_manager`
+    /// only resolve *already-ended* markets to a discrete outcome. Rather
+    /// than fabricate a live price-feed integration, `oracle_probability_bps`
+    /// is accepted as a trusted, caller-supplied estimate (the same pattern
+    /// this codebase already uses for e.g.
+    /// `schelling_oracle::dispute_outcome`'s caller-supplied
+    /// `total_pool_amount`). Off-chain callers (a keeper bot backed by a real
+    /// forecasting model, a DAO vote, etc.) are expected to supply it; this
+    /// contract only validates it is in `0..=10_000` and computes the
+    /// resulting edge.
+    ///
+    /// For each market: `market_implied_probability_bps` is read from the
+    /// live `prediction_market` instance's `outcome_stakes`
+    /// (`stakes[1] * 10_000 / (stakes[1] + stakes[2])`, or `5_000` if no one
+    /// has staked yet). `edge_bps = |oracle_probability_bps -
+    /// market_implied_probability_bps|`. If `edge_bps` is at least
+    /// `edge_threshold_bps`, the pool stakes
+    /// `min(tvl * edge_bps / 10_000, tvl * max_allocation_bps_per_market /
+    /// 10_000, remaining liquid balance)` on whichever side the oracle
+    /// estimate favors over the market's own pricing.
+    ///
+    /// This only supports binary (2-outcome) markets — the edge/Kelly math
+    /// here is a "yes/no" simplification (see the module doc comment); a
+    /// market with more than 2 outcomes is skipped with
+    /// `AllocationOutcome::SkippedNotBinary`.
+    ///
+    /// Individual markets that can't be allocated to (already resolved,
+    /// wrong stake token, edge too small, etc.) are skipped rather than
+    /// aborting the whole batch — the returned `Vec<AllocationOutcome>`
+    /// reports what happened to each input, in order.
+    pub fn allocate_capital(
+        env: Env,
+        markets: Vec<MarketAllocationInput>,
+    ) -> Result<Vec<AllocationOutcome>, LendingPoolError> {
+        let config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        if markets.is_empty() {
+            return Err(LendingPoolError::EmptyInput);
+        }
+
+        let tvl = compute_tvl(&env, &config)?;
+        if tvl < config.min_allocation_pool_size {
+            return Err(LendingPoolError::PoolTooSmall);
+        }
+
+        let mut liquid_remaining = token_balance(&env, &config.stake_token);
+        let mut results = Vec::new(&env);
+        let now = env.ledger().timestamp();
+        let contract_address = env.current_contract_address();
+
+        for input in markets.iter() {
+            if input.oracle_probability_bps > MAX_BPS {
+                results.push_back(AllocationOutcome::SkippedInvalidOracleProbability);
+                continue;
+            }
+            if get_allocation(&env, input.call_id)
+                .map(|a| !a.settled)
+                .unwrap_or(false)
+            {
+                results.push_back(AllocationOutcome::SkippedAlreadyOpen);
+                continue;
+            }
+
+            let market_address = match resolve_market_address(&env, &config, input.call_id) {
+                Ok(addr) => addr,
+                Err(_) => {
+                    results.push_back(AllocationOutcome::SkippedMarketUnavailable);
+                    continue;
+                }
+            };
+            let market = PredictionMarketClient::new(&env, &market_address);
+            let call = match market.try_get_call(&input.call_id) {
+                Ok(Ok(call)) => call,
+                _ => {
+                    results.push_back(AllocationOutcome::SkippedMarketUnavailable);
+                    continue;
+                }
+            };
+
+            if call.stake_token != config.stake_token {
+                results.push_back(AllocationOutcome::SkippedTokenMismatch);
+                continue;
+            }
+            if call.outcome_count != 2 {
+                results.push_back(AllocationOutcome::SkippedNotBinary);
+                continue;
+            }
+            if call.settled || call.cancelled || call.voided || call.outcome != 0 || now >= call.end_ts
+            {
+                results.push_back(AllocationOutcome::SkippedMarketUnavailable);
+                continue;
+            }
+
+            let stakes_1 = call.outcome_stakes.get(1).unwrap_or(0);
+            let stakes_2 = call.outcome_stakes.get(2).unwrap_or(0);
+            let total_stakes = match stakes_1.checked_add(stakes_2) {
+                Some(v) => v,
+                None => return Err(LendingPoolError::Overflow),
+            };
+            let market_implied_bps: u32 = if total_stakes <= 0 {
+                5_000
+            } else {
+                let bps = match stakes_1
+                    .checked_mul(BPS_SCALE)
+                    .and_then(|v| v.checked_div(total_stakes))
+                {
+                    Some(v) => v,
+                    None => return Err(LendingPoolError::Overflow),
+                };
+                bps as u32
+            };
+
+            let oracle_bps = input.oracle_probability_bps;
+            let edge_bps: u32 = if oracle_bps > market_implied_bps {
+                oracle_bps - market_implied_bps
+            } else {
+                market_implied_bps - oracle_bps
+            };
+            if edge_bps < config.edge_threshold_bps {
+                results.push_back(AllocationOutcome::SkippedEdgeTooSmall);
+                continue;
+            }
+
+            let position: u32 = if oracle_bps > market_implied_bps { 1 } else { 2 };
+
+            let raw_alloc = match tvl
+                .checked_mul(edge_bps as i128)
+                .and_then(|v| v.checked_div(BPS_SCALE))
+            {
+                Some(v) => v,
+                None => return Err(LendingPoolError::Overflow),
+            };
+            let cap = match tvl
+                .checked_mul(config.max_allocation_bps_per_market as i128)
+                .and_then(|v| v.checked_div(BPS_SCALE))
+            {
+                Some(v) => v,
+                None => return Err(LendingPoolError::Overflow),
+            };
+            let mut amount = core::cmp::min(raw_alloc, cap);
+            amount = core::cmp::min(amount, liquid_remaining);
+
+            if amount <= 0 {
+                results.push_back(AllocationOutcome::SkippedInsufficientLiquidity);
+                continue;
+            }
+
+            authorize_stake_transfer(&env, &call.stake_token, &contract_address, &market_address, amount);
+            match market.try_stake_on_call(&contract_address, &input.call_id, &amount, &position) {
+                Ok(Ok(_)) => {
+                    liquid_remaining = match liquid_remaining.checked_sub(amount) {
+                        Some(v) => v,
+                        None => return Err(LendingPoolError::Overflow),
+                    };
+                    let locked = get_total_allocated_locked(&env);
+                    set_total_allocated_locked(
+                        &env,
+                        locked.checked_add(amount).ok_or(LendingPoolError::Overflow)?,
+                    );
+                    set_allocation(
+                        &env,
+                        &Allocation {
+                            call_id: input.call_id,
+                            market_address: market_address.clone(),
+                            position,
+                            amount,
+                            settled: false,
+                            won: false,
+                            payout: 0,
+                            created_at: now,
+                        },
+                    );
+                    add_open_call_id(&env, input.call_id);
+                    emit_capital_allocated(&env, input.call_id, &market_address, position, amount);
+                    results.push_back(AllocationOutcome::Allocated(amount, position));
+                }
+                _ => {
+                    results.push_back(AllocationOutcome::SkippedStakeRejected);
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Permissionless: once `call_id`'s market has resolved, claim the
+    /// pool's own settled stake (if it won) via `outcome_manager`, deduct
+    /// the protocol fee from any realized profit, and update
+    /// `total_yield_earned` / the LP share price. Returns the net yield
+    /// recorded for this allocation (can be negative on a loss).
+    pub fn harvest_yield(env: Env, call_id: u64) -> Result<i128, LendingPoolError> {
+        let config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        let mut allocation = get_allocation(&env, call_id).ok_or(LendingPoolError::AllocationNotFound)?;
+        if allocation.settled {
+            return Err(LendingPoolError::AlreadyHarvested);
+        }
+
+        let market = PredictionMarketClient::new(&env, &allocation.market_address);
+        let call = market
+            .try_get_call(&call_id)
+            .map_err(|_| LendingPoolError::MarketCallFailed)?
+            .map_err(|_| LendingPoolError::MarketCallFailed)?;
+
+        if call.outcome == 0 {
+            return Err(LendingPoolError::MarketNotResolved);
+        }
+
+        let contract_address = env.current_contract_address();
+        let won = call.outcome == allocation.position;
+        let mut payout: i128 = 0;
+
+        if won {
+            let total_winning_stake = call.outcome_stakes.get(allocation.position).unwrap_or(0);
+            let total_losing_stake = call
+                .outcome_stakes
+                .get(other_position(allocation.position))
+                .unwrap_or(0);
+
+            let balance_before = token_balance(&env, &config.stake_token);
+            xcontract::claim_payout_for_market(
+                &env,
+                &config,
+                call_id,
+                &contract_address,
+                allocation.amount,
+                total_winning_stake,
+                total_losing_stake,
+            )?;
+            let balance_after = token_balance(&env, &config.stake_token);
+            payout = balance_after
+                .checked_sub(balance_before)
+                .ok_or(LendingPoolError::Overflow)?;
+        }
+
+        let gross_change = payout
+            .checked_sub(allocation.amount)
+            .ok_or(LendingPoolError::Overflow)?;
+
+        allocation.settled = true;
+        allocation.won = won;
+        allocation.payout = payout;
+        set_allocation(&env, &allocation);
+        remove_open_call_id(&env, call_id);
+
+        let locked = get_total_allocated_locked(&env);
+        set_total_allocated_locked(
+            &env,
+            locked
+                .checked_sub(allocation.amount)
+                .ok_or(LendingPoolError::Overflow)?,
+        );
+
+        let (protocol_fee, net_yield) = if gross_change > 0 {
+            let fee = gross_change
+                .checked_mul(config.protocol_fee_bps as i128)
+                .ok_or(LendingPoolError::Overflow)?
+                .checked_div(BPS_SCALE)
+                .ok_or(LendingPoolError::Overflow)?;
+            let net = gross_change.checked_sub(fee).ok_or(LendingPoolError::Overflow)?;
+            if fee > 0 {
+                transfer_token(&env, &config.stake_token, &contract_address, &config.treasury, fee);
+                let total_fees = get_total_fees_paid(&env);
+                set_total_fees_paid(&env, total_fees.checked_add(fee).ok_or(LendingPoolError::Overflow)?);
+            }
+            (fee, net)
+        } else {
+            (0, gross_change)
+        };
+
+        let total_yield = get_total_yield_earned(&env);
+        set_total_yield_earned(
+            &env,
+            total_yield
+                .checked_add(net_yield)
+                .ok_or(LendingPoolError::Overflow)?,
+        );
+        record_yield_event(&env, net_yield);
+
+        emit_yield_harvested(&env, call_id, won, gross_change, protocol_fee, net_yield);
+        Ok(net_yield)
+    }
+
+    // ─── Views ────────────────────────────────────────────────────────────
+
+    pub fn get_pool_stats(env: Env) -> Result<PoolStats, LendingPoolError> {
+        let config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        let liquid = token_balance(&env, &config.stake_token);
+        let locked = get_total_allocated_locked(&env);
+        let tvl = liquid.checked_add(locked).ok_or(LendingPoolError::Overflow)?;
+
+        Ok(PoolStats {
+            total_deposited: get_total_deposited(&env),
+            total_value_locked: tvl,
+            total_yield_earned: get_total_yield_earned(&env),
+            current_apy_bps: compute_apy_bps(&env, tvl),
+            total_lp_shares: get_total_lp_shares(&env),
+            liquid_balance: liquid,
+            total_allocated_locked: locked,
+            open_market_count: get_open_call_ids(&env).len(),
+            min_deposit: config.min_deposit,
+            max_pool_size: config.max_pool_size,
+            protocol_fee_bps: config.protocol_fee_bps,
+            max_allocation_bps_per_market: config.max_allocation_bps_per_market,
+        })
+    }
+
+    pub fn get_user_lp_shares(env: Env, user: Address) -> i128 {
+        get_lp_shares(&env, &user)
+    }
+
+    pub fn get_allocation(env: Env, call_id: u64) -> Option<Allocation> {
+        get_allocation(&env, call_id)
+    }
+
+    pub fn get_open_call_ids(env: Env) -> Vec<u64> {
+        get_open_call_ids(&env)
+    }
+
+    pub fn get_config(env: Env) -> Result<PoolConfig, LendingPoolError> {
+        get_config(&env).ok_or(LendingPoolError::NotInitialized)
+    }
+
+    // ─── Admin-tunable parameters ───────────────────────────────────────
+
+    pub fn set_max_alloc_bps_per_market(env: Env, new_bps: u32) -> Result<(), LendingPoolError> {
+        let mut config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        config.admin.require_auth();
+        if new_bps == 0 || new_bps > MAX_BPS {
+            return Err(LendingPoolError::InvalidBps);
+        }
+        config.max_allocation_bps_per_market = new_bps;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    pub fn set_protocol_fee_bps(env: Env, new_bps: u32) -> Result<(), LendingPoolError> {
+        let mut config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        config.admin.require_auth();
+        if new_bps > MAX_BPS {
+            return Err(LendingPoolError::InvalidBps);
+        }
+        config.protocol_fee_bps = new_bps;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    pub fn set_edge_threshold_bps(env: Env, new_bps: u32) -> Result<(), LendingPoolError> {
+        let mut config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        config.admin.require_auth();
+        if new_bps > MAX_BPS {
+            return Err(LendingPoolError::InvalidBps);
+        }
+        config.edge_threshold_bps = new_bps;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    pub fn set_min_deposit(env: Env, new_min: i128) -> Result<(), LendingPoolError> {
+        let mut config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        config.admin.require_auth();
+        if new_min <= 0 {
+            return Err(LendingPoolError::InvalidConfig);
+        }
+        config.min_deposit = new_min;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    pub fn set_max_pool_size(env: Env, new_max: i128) -> Result<(), LendingPoolError> {
+        let mut config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
+        config.admin.require_auth();
+        if new_max <= 0 {
+            return Err(LendingPoolError::InvalidConfig);
+        }
+        config.max_pool_size = new_max;
+        set_config(&env, &config);
+        Ok(())
+    }
+}

--- a/packages/contracts/lending_pool/src/storage.rs
+++ b/packages/contracts/lending_pool/src/storage.rs
@@ -1,0 +1,157 @@
+use crate::types::{Allocation, PoolConfig, YieldEvent};
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    TotalLpShares,
+    TotalDeposited,
+    TotalYieldEarned,
+    TotalFeesPaid,
+    TotalAllocatedLocked,
+    LpShares(Address),
+    Allocation(u64),
+    OpenCallIds,
+    YieldEvents,
+}
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+pub fn set_config(env: &Env, config: &PoolConfig) {
+    env.storage().instance().set(&DataKey::Config, config);
+}
+
+pub fn get_config(env: &Env) -> Option<PoolConfig> {
+    env.storage().instance().get(&DataKey::Config)
+}
+
+// ─── LP share ledger ─────────────────────────────────────────────────────────
+
+pub fn get_total_lp_shares(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalLpShares)
+        .unwrap_or(0)
+}
+
+pub fn set_total_lp_shares(env: &Env, amount: i128) {
+    env.storage().instance().set(&DataKey::TotalLpShares, &amount);
+}
+
+pub fn get_lp_shares(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::LpShares(user.clone()))
+        .unwrap_or(0)
+}
+
+pub fn set_lp_shares(env: &Env, user: &Address, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LpShares(user.clone()), &amount);
+}
+
+// ─── Lifetime counters ───────────────────────────────────────────────────────
+
+pub fn get_total_deposited(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalDeposited)
+        .unwrap_or(0)
+}
+
+pub fn set_total_deposited(env: &Env, amount: i128) {
+    env.storage().instance().set(&DataKey::TotalDeposited, &amount);
+}
+
+pub fn get_total_yield_earned(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalYieldEarned)
+        .unwrap_or(0)
+}
+
+pub fn set_total_yield_earned(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalYieldEarned, &amount);
+}
+
+pub fn get_total_fees_paid(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalFeesPaid)
+        .unwrap_or(0)
+}
+
+pub fn set_total_fees_paid(env: &Env, amount: i128) {
+    env.storage().instance().set(&DataKey::TotalFeesPaid, &amount);
+}
+
+// ─── Allocated (locked) capital ──────────────────────────────────────────────
+
+pub fn get_total_allocated_locked(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalAllocatedLocked)
+        .unwrap_or(0)
+}
+
+pub fn set_total_allocated_locked(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalAllocatedLocked, &amount);
+}
+
+// ─── Allocations ─────────────────────────────────────────────────────────────
+
+pub fn get_allocation(env: &Env, call_id: u64) -> Option<Allocation> {
+    env.storage().instance().get(&DataKey::Allocation(call_id))
+}
+
+pub fn set_allocation(env: &Env, allocation: &Allocation) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Allocation(allocation.call_id), allocation);
+}
+
+pub fn get_open_call_ids(env: &Env) -> Vec<u64> {
+    env.storage()
+        .instance()
+        .get(&DataKey::OpenCallIds)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn set_open_call_ids(env: &Env, ids: &Vec<u64>) {
+    env.storage().instance().set(&DataKey::OpenCallIds, ids);
+}
+
+pub fn add_open_call_id(env: &Env, call_id: u64) {
+    let mut ids = get_open_call_ids(env);
+    ids.push_back(call_id);
+    set_open_call_ids(env, &ids);
+}
+
+pub fn remove_open_call_id(env: &Env, call_id: u64) {
+    let ids = get_open_call_ids(env);
+    let mut filtered = Vec::new(env);
+    for id in ids.iter() {
+        if id != call_id {
+            filtered.push_back(id);
+        }
+    }
+    set_open_call_ids(env, &filtered);
+}
+
+// ─── Yield history (rolling APY window) ──────────────────────────────────────
+
+pub fn get_yield_events(env: &Env) -> Vec<YieldEvent> {
+    env.storage()
+        .instance()
+        .get(&DataKey::YieldEvents)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn set_yield_events(env: &Env, events: &Vec<YieldEvent>) {
+    env.storage().instance().set(&DataKey::YieldEvents, events);
+}

--- a/packages/contracts/lending_pool/src/test.rs
+++ b/packages/contracts/lending_pool/src/test.rs
@@ -1,0 +1,612 @@
+#![cfg(test)]
+
+extern crate std;
+
+use crate::types::AllocationOutcome;
+use crate::{LendingPool, LendingPoolClient};
+use backit_shared::{build_message, OUTCOME_DOWN, OUTCOME_UP};
+use outcome_manager::{OutcomeManager, OutcomeManagerClient, SignedOutcome};
+use prediction_market::{ConditionType, MarketInitArgs, PredictionMarketClient};
+use prediction_market_factory::{PredictionMarketFactory, PredictionMarketFactoryClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Bytes, BytesN, Env, Vec,
+};
+
+fn install_market_wasm(env: &Env) -> BytesN<32> {
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let release_v1 = workspace_root.join("target/wasm32v1-none/release");
+    let release_unknown = workspace_root.join("target/wasm32-unknown-unknown/release");
+    let candidates = [
+        release_v1.join("prediction_market.optimized.wasm"),
+        release_v1.join("prediction_market.wasm"),
+        release_unknown.join("prediction_market.optimized.wasm"),
+    ];
+
+    let wasm_path = candidates
+        .iter()
+        .find(|path| path.exists())
+        .unwrap_or_else(|| {
+            panic!(
+                "missing Soroban-compatible prediction_market WASM — run:\n  \
+                 cd packages/contracts/prediction_market && cargo build --release --target wasm32v1-none"
+            )
+        });
+
+    let wasm_bytes = std::fs::read(wasm_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", wasm_path.display()));
+    env.deployer().upload_contract_wasm(wasm_bytes.as_slice())
+}
+
+fn default_market_args(
+    env: &Env,
+    stake_token: &Address,
+    end_ts: u64,
+    outcome_count: u32,
+) -> MarketInitArgs {
+    MarketInitArgs {
+        stake_token: stake_token.clone(),
+        stake_amount: 1_000,
+        start_price: 100_000_000,
+        end_ts,
+        token_address: stake_token.clone(),
+        pair_id: Bytes::from_slice(env, b"XLM-USDC"),
+        metadata_hash: BytesN::from_array(env, &[1u8; 32]),
+        condition: ConditionType::PercentUp(5),
+        outcome_count,
+    }
+}
+
+fn setup_token(env: &Env, admin: &Address) -> Address {
+    let token = env.register_stellar_asset_contract_v2(admin.clone());
+    let sac = token.address();
+    let stellar = StellarAssetClient::new(env, &sac);
+    stellar.mint(admin, &1_000_000_000_000);
+    sac
+}
+
+fn gen_keypair(env: &Env) -> (BytesN<32>, BytesN<32>) {
+    use ed25519_dalek::SigningKey;
+    use rand::RngCore;
+
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    let signing_key = SigningKey::from_bytes(&seed);
+    let public_key = signing_key.verifying_key();
+    (
+        BytesN::from_array(env, &seed),
+        BytesN::from_array(env, &public_key.to_bytes()),
+    )
+}
+
+fn sign_outcome(
+    env: &Env,
+    secret: &BytesN<32>,
+    call_id: u64,
+    outcome: u32,
+    price: i128,
+    timestamp: u64,
+) -> BytesN<64> {
+    use ed25519_dalek::{Signer, SigningKey};
+
+    let msg = build_message(env, call_id, outcome, price, timestamp);
+    let mut msg_bytes = [0u8; 128];
+    let msg_len = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_bytes[..msg_len]);
+    let signing_key = SigningKey::from_bytes(&secret.to_array());
+    let signature = signing_key.sign(&msg_bytes[..msg_len]);
+    BytesN::from_array(env, &signature.to_bytes())
+}
+
+struct TestSetup<'a> {
+    env: Env,
+    creator: Address,
+    user: Address,
+    counterparty: Address,
+    treasury: Address,
+    token: Address,
+    factory: PredictionMarketFactoryClient<'a>,
+    outcome_mgr: OutcomeManagerClient<'a>,
+    pool: LendingPoolClient<'a>,
+    oracle_secret: BytesN<32>,
+    oracle_pubkey: BytesN<32>,
+}
+
+fn setup_full_stack<'a>() -> TestSetup<'a> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+    let counterparty = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token = setup_token(&env, &admin);
+
+    let market_wasm = install_market_wasm(&env);
+    let factory_id = env.register(PredictionMarketFactory, ());
+    let factory = PredictionMarketFactoryClient::new(&env, &factory_id);
+
+    let (oracle_secret, oracle_pubkey) = gen_keypair(&env);
+    let outcome_id = env.register(OutcomeManager, ());
+    let outcome_mgr = OutcomeManagerClient::new(&env, &outcome_id);
+    let fee_collector = Address::generate(&env);
+
+    let mut oracles = Vec::new(&env);
+    oracles.push_back(oracle_pubkey.clone());
+
+    // quorum=1, dispute_window_secs=0, fee_bps=100 (1%): a single oracle
+    // submission finalizes immediately, matching parlay_betting's own
+    // reference test setup.
+    outcome_mgr.initialize(&admin, &oracles, &1u32, &fee_collector, &100u32, &0u64);
+    factory.initialize(&admin, &outcome_id, &market_wasm, &1_000);
+    factory.whitelist_token(&token);
+    outcome_mgr.set_factory(&factory_id);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool = LendingPoolClient::new(&env, &pool_id);
+    pool.initialize(
+        &admin,
+        &treasury,
+        &token,
+        &factory_id,
+        &outcome_id,
+        &100_000i128,      // min_deposit
+        &1_000_000_000i128, // max_pool_size
+        &1_000_000i128,     // min_allocation_pool_size
+    );
+
+    let token_client = TokenClient::new(&env, &token);
+    token_client.transfer(&admin, &user, &100_000_000);
+    token_client.transfer(&admin, &counterparty, &100_000_000);
+
+    TestSetup {
+        env,
+        creator,
+        user,
+        counterparty,
+        treasury,
+        token,
+        factory,
+        outcome_mgr,
+        pool,
+        oracle_secret,
+        oracle_pubkey,
+    }
+}
+
+/// Deploy a market and have `counterparty` stake `counter_stake` on
+/// `counter_position`, so the market's `outcome_stakes` reflect a
+/// non-trivial (and, for our test numbers, deliberately lopsided) implied
+/// probability before the pool ever looks at it.
+fn deploy_market_with_counter_stake(
+    setup: &TestSetup,
+    end_ts: u64,
+    counter_stake: i128,
+    counter_position: u32,
+    outcome_count: u32,
+) -> (Address, u64) {
+    let env = &setup.env;
+    let args = default_market_args(env, &setup.token, end_ts, outcome_count);
+    let market_addr = setup.factory.deploy_market(&setup.creator, &args);
+    let market = PredictionMarketClient::new(env, &market_addr);
+    let call_id = market.get_call_id();
+    market.stake_on_call(&setup.counterparty, &call_id, &counter_stake, &counter_position);
+    (market_addr, call_id)
+}
+
+fn resolve_market(setup: &TestSetup, call_id: u64, outcome: u32, end_ts: u64) {
+    let env = &setup.env;
+    env.ledger().set_timestamp(end_ts + 1);
+    let signed = SignedOutcome {
+        call_id,
+        outcome,
+        price: 110_000_000,
+        timestamp: end_ts + 1,
+        oracle_pubkey: setup.oracle_pubkey.clone(),
+        signature: sign_outcome(
+            env,
+            &setup.oracle_secret,
+            call_id,
+            outcome,
+            110_000_000,
+            end_ts + 1,
+        ),
+    };
+    setup.outcome_mgr.submit_outcome_for_market(&signed, &end_ts);
+}
+
+// ─── Deposit / withdraw cycle ────────────────────────────────────────────────
+
+#[test]
+fn first_deposit_mints_shares_one_to_one() {
+    let setup = setup_full_stack();
+    let token = TokenClient::new(&setup.env, &setup.token);
+
+    let minted = setup.pool.deposit(&setup.user, &10_000_000i128);
+    assert_eq!(minted, 10_000_000);
+    assert_eq!(setup.pool.get_user_lp_shares(&setup.user), 10_000_000);
+
+    let stats = setup.pool.get_pool_stats();
+    assert_eq!(stats.total_lp_shares, 10_000_000);
+    assert_eq!(stats.total_deposited, 10_000_000);
+    assert_eq!(stats.total_value_locked, 10_000_000);
+    assert_eq!(stats.liquid_balance, 10_000_000);
+    assert_eq!(token.balance(&setup.pool.address), 10_000_000);
+}
+
+#[test]
+fn deposit_below_minimum_is_rejected() {
+    let setup = setup_full_stack();
+    let result = setup.pool.try_deposit(&setup.user, &1_000i128);
+    assert!(result.is_err());
+}
+
+#[test]
+fn deposit_above_max_pool_size_is_rejected() {
+    let setup = setup_full_stack();
+    // max_pool_size is 1_000_000_000 — a single deposit that would exceed it
+    // outright must be rejected rather than silently truncated.
+    let result = setup.pool.try_deposit(&setup.user, &2_000_000_000i128);
+    assert!(result.is_err());
+}
+
+#[test]
+fn withdraw_full_cycle_returns_principal_1_to_1_before_any_yield() {
+    let setup = setup_full_stack();
+    let token = TokenClient::new(&setup.env, &setup.token);
+    let balance_before = token.balance(&setup.user);
+
+    let minted = setup.pool.deposit(&setup.user, &5_000_000i128);
+    let out = setup.pool.withdraw(&setup.user, &minted);
+
+    assert_eq!(out, 5_000_000);
+    assert_eq!(token.balance(&setup.user), balance_before);
+    assert_eq!(setup.pool.get_user_lp_shares(&setup.user), 0);
+    assert_eq!(setup.pool.get_pool_stats().total_lp_shares, 0);
+}
+
+#[test]
+fn withdraw_more_shares_than_owned_is_rejected() {
+    let setup = setup_full_stack();
+    let minted = setup.pool.deposit(&setup.user, &1_000_000i128);
+    let result = setup.pool.try_withdraw(&setup.user, &(minted + 1));
+    assert!(result.is_err());
+}
+
+#[test]
+fn withdraw_blocked_while_capital_is_locked_in_open_market() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    setup.pool.deposit(&setup.user, &10_000_000i128);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (_market, call_id) =
+        deploy_market_with_counter_stake(&setup, end_ts, 3_000_000, OUTCOME_DOWN, 2);
+
+    let mut markets = Vec::new(env);
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id,
+        oracle_probability_bps: 5_000,
+    });
+    setup.pool.allocate_capital(&markets);
+
+    // 5% of the 10,000,000 TVL (500,000) is now locked in the open market,
+    // leaving 9,500,000 liquid. Withdrawing all 10,000,000 worth of shares
+    // must fail; withdrawing an amount within the liquid balance succeeds.
+    let stats = setup.pool.get_pool_stats();
+    assert_eq!(stats.total_allocated_locked, 500_000);
+    assert_eq!(stats.liquid_balance, 9_500_000);
+
+    let result = setup.pool.try_withdraw(&setup.user, &10_000_000i128);
+    assert!(result.is_err());
+
+    let out = setup.pool.withdraw(&setup.user, &9_000_000i128);
+    assert_eq!(out, 9_000_000);
+}
+
+// ─── Capital allocation: Kelly-edge math across multiple markets ────────────
+
+/// Builds the shared two-market fixture used by the allocation/harvest tests
+/// below. Hand-computed math (TVL = 10,000,000 throughout allocation):
+///
+/// - call_1: counterparty stakes 3,000,000 on DOWN, nobody on UP yet, so
+///   `market_implied_bps(UP) = 0`. `oracle_probability_bps = 5,000` ⇒
+///   `edge = 5,000` (50%), well above the 100-bps default threshold. The
+///   pool favors UP (oracle > implied). `raw_alloc = 10,000,000 * 5,000 /
+///   10,000 = 5,000,000`, capped at `max_allocation_bps_per_market` (default
+///   500 = 5%): `cap = 10,000,000 * 500 / 10,000 = 500,000`. Allocated:
+///   500,000 on position 1.
+/// - call_2: counterparty stakes 1,000,000 on UP, so
+///   `market_implied_bps(UP) = 10,000`. Same `oracle_probability_bps =
+///   5,000` ⇒ `edge = 5,000`, but now oracle < implied so the pool favors
+///   DOWN. Same cap math ⇒ 500,000 allocated on position 2.
+fn setup_two_market_scenario<'a>() -> (TestSetup<'a>, u64, u64, u64, u64) {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+
+    setup.pool.deposit(&setup.user, &10_000_000i128);
+
+    let end_ts_1 = env.ledger().timestamp() + 3600;
+    let end_ts_2 = end_ts_1 + 3600;
+    let (_market_1, call_1) =
+        deploy_market_with_counter_stake(&setup, end_ts_1, 3_000_000, OUTCOME_DOWN, 2);
+    let (_market_2, call_2) =
+        deploy_market_with_counter_stake(&setup, end_ts_2, 1_000_000, OUTCOME_UP, 2);
+
+    let mut markets = Vec::new(env);
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id: call_1,
+        oracle_probability_bps: 5_000,
+    });
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id: call_2,
+        oracle_probability_bps: 5_000,
+    });
+    let results = setup.pool.allocate_capital(&markets);
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results.get(0).unwrap(),
+        AllocationOutcome::Allocated(500_000, OUTCOME_UP)
+    );
+    assert_eq!(
+        results.get(1).unwrap(),
+        AllocationOutcome::Allocated(500_000, OUTCOME_DOWN)
+    );
+
+    (setup, call_1, call_2, end_ts_1, end_ts_2)
+}
+
+#[test]
+fn allocate_capital_stakes_kelly_edge_across_multiple_markets() {
+    let (setup, call_1, call_2, _end_ts_1, _end_ts_2) = setup_two_market_scenario();
+
+    let alloc_1 = setup.pool.get_allocation(&call_1).unwrap();
+    assert_eq!(alloc_1.position, OUTCOME_UP);
+    assert_eq!(alloc_1.amount, 500_000);
+    assert!(!alloc_1.settled);
+
+    let alloc_2 = setup.pool.get_allocation(&call_2).unwrap();
+    assert_eq!(alloc_2.position, OUTCOME_DOWN);
+    assert_eq!(alloc_2.amount, 500_000);
+    assert!(!alloc_2.settled);
+
+    // Staking doesn't change TVL — it just moves capital from "liquid" to
+    // "locked", so LP share price is untouched by allocation alone.
+    let stats = setup.pool.get_pool_stats();
+    assert_eq!(stats.total_value_locked, 10_000_000);
+    assert_eq!(stats.total_allocated_locked, 1_000_000);
+    assert_eq!(stats.liquid_balance, 9_000_000);
+    assert_eq!(stats.open_market_count, 2);
+}
+
+#[test]
+fn allocate_capital_below_min_pool_size_is_rejected() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    // Below the 1,000,000 min_allocation_pool_size configured in setup.
+    setup.pool.deposit(&setup.user, &500_000i128);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (_market, call_id) =
+        deploy_market_with_counter_stake(&setup, end_ts, 3_000_000, OUTCOME_DOWN, 2);
+
+    let mut markets = Vec::new(env);
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id,
+        oracle_probability_bps: 5_000,
+    });
+    let result = setup.pool.try_allocate_capital(&markets);
+    assert!(result.is_err());
+}
+
+#[test]
+fn allocate_capital_skips_non_binary_and_small_edge_markets() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+    setup.pool.deposit(&setup.user, &10_000_000i128);
+
+    // A 3-outcome market: this pool's Kelly-edge math only supports binary
+    // markets, so it must be skipped rather than mis-handled.
+    let end_ts_1 = env.ledger().timestamp() + 3600;
+    let (_market_1, call_1) =
+        deploy_market_with_counter_stake(&setup, end_ts_1, 1_000_000, 1, 3);
+
+    // A binary market whose implied probability already matches the oracle
+    // estimate exactly — zero edge, below the default 100-bps threshold.
+    let end_ts_2 = end_ts_1 + 3600;
+    let (_market_2, call_2) =
+        deploy_market_with_counter_stake(&setup, end_ts_2, 1_000_000, OUTCOME_UP, 2);
+    // market_implied_bps(UP) = 10,000 (all stakes on UP so far); an oracle
+    // estimate that agrees exactly produces edge = 0.
+
+    let mut markets = Vec::new(env);
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id: call_1,
+        oracle_probability_bps: 5_000,
+    });
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id: call_2,
+        oracle_probability_bps: 10_000,
+    });
+    let results = setup.pool.allocate_capital(&markets);
+
+    assert_eq!(results.get(0).unwrap(), AllocationOutcome::SkippedNotBinary);
+    assert_eq!(results.get(1).unwrap(), AllocationOutcome::SkippedEdgeTooSmall);
+
+    // Nothing was actually staked.
+    let stats = setup.pool.get_pool_stats();
+    assert_eq!(stats.total_allocated_locked, 0);
+    assert_eq!(stats.liquid_balance, 10_000_000);
+}
+
+// ─── Yield harvesting: win/loss, protocol fee, APY, LP share price growth ───
+
+#[test]
+fn harvest_yield_on_a_win_applies_the_protocol_fee() {
+    let (setup, call_1, _call_2, end_ts_1, _end_ts_2) = setup_two_market_scenario();
+
+    // Market 1 resolves UP: the pool's 500,000 stake on position 1 is the
+    // *sole* winning stake against a 3,000,000 losing pot (counterparty).
+    // outcome_manager fee_bps = 100 (1%): total_fee = 3,000,000 * 100 /
+    // 10,000 = 30,000; net_losing = 2,970,000; since the pool is the sole
+    // winner, prize_share = 2,970,000 and payout = 500,000 + 2,970,000 =
+    // 3,470,000. gross_change = 3,470,000 - 500,000 = 2,970,000. Lending
+    // pool's own protocol_fee_bps = 1,000 (10%, default): fee = 297,000,
+    // net_yield = 2,673,000.
+    resolve_market(&setup, call_1, OUTCOME_UP, end_ts_1);
+    let net_yield = setup.pool.harvest_yield(&call_1);
+    assert_eq!(net_yield, 2_673_000);
+
+    let token = TokenClient::new(&setup.env, &setup.token);
+    assert_eq!(token.balance(&setup.treasury), 297_000);
+
+    let alloc = setup.pool.get_allocation(&call_1).unwrap();
+    assert!(alloc.settled);
+    assert!(alloc.won);
+    assert_eq!(alloc.payout, 3_470_000);
+
+    let stats = setup.pool.get_pool_stats();
+    assert_eq!(stats.total_yield_earned, 2_673_000);
+    // call_2 (500,000) is still open.
+    assert_eq!(stats.total_allocated_locked, 500_000);
+}
+
+#[test]
+fn harvest_yield_on_a_loss_records_negative_yield_with_no_fee() {
+    let (setup, _call_1, call_2, _end_ts_1, end_ts_2) = setup_two_market_scenario();
+
+    // Market 2 resolves UP: the pool staked DOWN (500,000) and loses it
+    // outright — nothing to claim, gross_change = 0 - 500,000 = -500,000,
+    // and losses never incur the protocol fee.
+    resolve_market(&setup, call_2, OUTCOME_UP, end_ts_2);
+    let net_yield = setup.pool.harvest_yield(&call_2);
+    assert_eq!(net_yield, -500_000);
+
+    let token = TokenClient::new(&setup.env, &setup.token);
+    assert_eq!(token.balance(&setup.treasury), 0);
+
+    let alloc = setup.pool.get_allocation(&call_2).unwrap();
+    assert!(alloc.settled);
+    assert!(!alloc.won);
+    assert_eq!(alloc.payout, 0);
+
+    assert_eq!(setup.pool.get_pool_stats().total_yield_earned, -500_000);
+}
+
+#[test]
+fn harvest_yield_twice_is_rejected() {
+    let (setup, call_1, _call_2, end_ts_1, _end_ts_2) = setup_two_market_scenario();
+    resolve_market(&setup, call_1, OUTCOME_UP, end_ts_1);
+    setup.pool.harvest_yield(&call_1);
+
+    let result = setup.pool.try_harvest_yield(&call_1);
+    assert!(result.is_err());
+}
+
+#[test]
+fn harvest_yield_before_resolution_is_rejected() {
+    let (setup, call_1, _call_2, _end_ts_1, _end_ts_2) = setup_two_market_scenario();
+    let result = setup.pool.try_harvest_yield(&call_1);
+    assert!(result.is_err());
+}
+
+#[test]
+fn pool_apy_and_lp_share_price_grow_after_net_positive_yield() {
+    let (setup, call_1, call_2, end_ts_1, end_ts_2) = setup_two_market_scenario();
+
+    resolve_market(&setup, call_1, OUTCOME_UP, end_ts_1);
+    setup.pool.harvest_yield(&call_1);
+    resolve_market(&setup, call_2, OUTCOME_UP, end_ts_2);
+    setup.pool.harvest_yield(&call_2);
+
+    // Combined net yield: +2,673,000 (call_1 win) - 500,000 (call_2 loss)
+    // = 2,173,000. TVL grows from 10,000,000 to 12,173,000 even though
+    // total_lp_shares (10,000,000) hasn't changed — the LP share price
+    // (tvl / total_lp_shares) has grown from 1.0 to 1.2173.
+    let stats = setup.pool.get_pool_stats();
+    assert_eq!(stats.total_yield_earned, 2_173_000);
+    assert_eq!(stats.total_value_locked, 12_173_000);
+    assert_eq!(stats.total_allocated_locked, 0);
+    assert_eq!(stats.total_lp_shares, 10_000_000);
+    // Rolling 7-day APY, annualized: 2,173,000 * 10,000 * 365 / (7 *
+    // 12,173,000) = 93,080 bps (~930%, since both harvests landed within
+    // the same hour of simulated time — see `compute_apy_bps`'s doc
+    // comment on why a fast-realized profit produces an outsized figure).
+    assert_eq!(stats.current_apy_bps, 93_080);
+
+    // A brand-new deposit now must mint fewer shares per token than
+    // `user`'s original 1:1 deposit did, proving the share price grew:
+    // 1,217,300 * 10,000,000 / 12,173,000 = 1,000,000 shares exactly.
+    // `counterparty` already holds tokens from `setup_full_stack`'s initial
+    // funding and hasn't deposited into the pool yet, so it stands in here
+    // as the "new depositor".
+    let minted = setup.pool.deposit(&setup.counterparty, &1_217_300i128);
+    assert_eq!(minted, 1_000_000);
+    assert_eq!(setup.pool.get_user_lp_shares(&setup.counterparty), 1_000_000);
+    assert_eq!(setup.pool.get_pool_stats().total_lp_shares, 11_000_000);
+}
+
+// ─── Configurable protocol fee ───────────────────────────────────────────────
+
+#[test]
+fn protocol_fee_bps_is_configurable_and_applied() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+
+    // Bump the protocol's cut of profits from the 10% default to 20%.
+    setup.pool.set_protocol_fee_bps(&2_000u32);
+    assert_eq!(setup.pool.get_pool_stats().protocol_fee_bps, 2_000);
+
+    setup.pool.deposit(&setup.user, &10_000_000i128);
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (_market, call_id) =
+        deploy_market_with_counter_stake(&setup, end_ts, 3_000_000, OUTCOME_DOWN, 2);
+
+    let mut markets = Vec::new(env);
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id,
+        oracle_probability_bps: 5_000,
+    });
+    setup.pool.allocate_capital(&markets);
+
+    resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
+    // Same win math as before: gross_change = 2,970,000. At 20% protocol
+    // fee: fee = 594,000, net_yield = 2,376,000.
+    let net_yield = setup.pool.harvest_yield(&call_id);
+    assert_eq!(net_yield, 2_376_000);
+
+    let token = TokenClient::new(env, &setup.token);
+    assert_eq!(token.balance(&setup.treasury), 594_000);
+}
+
+#[test]
+fn max_allocation_bps_per_market_is_configurable() {
+    let setup = setup_full_stack();
+    let env = &setup.env;
+
+    // Raise the per-market cap from the 5% default to 10%.
+    setup.pool.set_max_alloc_bps_per_market(&1_000u32);
+    setup.pool.deposit(&setup.user, &10_000_000i128);
+
+    let end_ts = env.ledger().timestamp() + 3600;
+    let (_market, call_id) =
+        deploy_market_with_counter_stake(&setup, end_ts, 3_000_000, OUTCOME_DOWN, 2);
+
+    let mut markets = Vec::new(env);
+    markets.push_back(crate::types::MarketAllocationInput {
+        call_id,
+        oracle_probability_bps: 5_000,
+    });
+    let results = setup.pool.allocate_capital(&markets);
+
+    // edge = 5,000 bps still implies raw_alloc = 5,000,000, but now the cap
+    // is 10,000,000 * 1,000 / 10,000 = 1,000,000 — double the default-cap
+    // test's 500,000.
+    assert_eq!(
+        results.get(0).unwrap(),
+        AllocationOutcome::Allocated(1_000_000, OUTCOME_UP)
+    );
+}

--- a/packages/contracts/lending_pool/src/types.rs
+++ b/packages/contracts/lending_pool/src/types.rs
@@ -1,0 +1,135 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Pool-wide configuration, set once at `initialize` and tunable afterwards
+/// via admin-only setters.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PoolConfig {
+    pub admin: Address,
+    /// Recipient of the protocol's cut of realized profits.
+    pub treasury: Address,
+    /// The USDC-equivalent SAC (or native XLM sentinel) this pool denominates
+    /// deposits, allocations and yield in.
+    pub stake_token: Address,
+    /// Factory used to resolve a `call_id` to its deployed market address.
+    pub prediction_market_factory: Address,
+    /// `outcome_manager` instance used to claim settled winnings.
+    pub outcome_manager: Address,
+    /// Smallest single deposit accepted.
+    pub min_deposit: i128,
+    /// Hard cap on total value locked; deposits that would push the pool
+    /// above this are rejected, bounding concentration risk.
+    pub max_pool_size: i128,
+    /// Minimum total value locked required before `allocate_capital` will
+    /// stake anything (avoids dust-sized, gas-inefficient allocations).
+    pub min_allocation_pool_size: i128,
+    /// Per-market allocation cap, in basis points of TVL. Default 500 (5%).
+    pub max_allocation_bps_per_market: u32,
+    /// Protocol's cut of realized profit on a harvested market, in basis
+    /// points. Default 1000 (10%).
+    pub protocol_fee_bps: u32,
+    /// Minimum `edge` (see `allocate_capital`) required before the pool
+    /// bothers allocating to a market, in basis points. Default 100 (1%).
+    pub edge_threshold_bps: u32,
+}
+
+/// A single open (unsettled) stake the pool currently holds in a
+/// `prediction_market` instance, staked as the pool contract itself.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Allocation {
+    pub call_id: u64,
+    pub market_address: Address,
+    /// The outcome position (1 or 2 — this pool only allocates to binary
+    /// markets, see `allocate_capital`'s doc comment) the pool staked on.
+    pub position: u32,
+    /// Principal staked, in `stake_token` base units.
+    pub amount: i128,
+    /// `true` once `harvest_yield` has processed this call's resolution.
+    pub settled: bool,
+    /// `true` if the pool's staked position matched the resolved outcome.
+    pub won: bool,
+    /// Gross tokens recovered from the claim (0 if the pool lost the stake).
+    pub payout: i128,
+    pub created_at: u64,
+}
+
+/// One realized profit-or-loss data point, recorded every time
+/// `harvest_yield` settles an allocation. Used to compute a rolling 7-day
+/// APY estimate; entries older than the window are pruned opportunistically.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct YieldEvent {
+    pub timestamp: u64,
+    /// `payout - amount_staked`, net of the protocol fee already deducted to
+    /// the treasury (positive on a win, `-amount_staked` on a total loss).
+    pub net_yield: i128,
+}
+
+/// Read-only performance snapshot, see [`crate::LendingPool::get_pool_stats`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PoolStats {
+    /// Lifetime sum of all `deposit` amounts (never decreases).
+    pub total_deposited: i128,
+    /// Current total pool value: liquid balance + capital locked in open
+    /// allocations. This is the number LP share price is derived from.
+    pub total_value_locked: i128,
+    /// Lifetime net-of-protocol-fee yield credited to the pool (can be
+    /// negative if losses outweigh wins).
+    pub total_yield_earned: i128,
+    /// Annualized rolling 7-day yield, in basis points (can be negative).
+    pub current_apy_bps: i128,
+    pub total_lp_shares: i128,
+    /// Token balance currently held directly by the pool contract.
+    pub liquid_balance: i128,
+    /// Principal currently staked in unsettled markets.
+    pub total_allocated_locked: i128,
+    pub open_market_count: u32,
+    pub min_deposit: i128,
+    pub max_pool_size: i128,
+    pub protocol_fee_bps: u32,
+    pub max_allocation_bps_per_market: u32,
+}
+
+/// Caller-supplied per-market input to [`crate::LendingPool::allocate_capital`].
+///
+/// `oracle_probability_bps` is the caller's estimate of the probability
+/// (0..=10_000) that outcome position `1` wins. See the doc comment on
+/// `allocate_capital` for why this is a trusted caller-supplied value rather
+/// than a live oracle feed.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct MarketAllocationInput {
+    pub call_id: u64,
+    pub oracle_probability_bps: u32,
+}
+
+/// Outcome of considering a single market during `allocate_capital`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum AllocationOutcome {
+    /// The pool staked `amount` on `position`.
+    Allocated(i128, u32),
+    /// `edge` (see `allocate_capital`) was below `edge_threshold_bps`.
+    SkippedEdgeTooSmall,
+    /// The pool already has an open (unsettled) allocation for this `call_id`.
+    SkippedAlreadyOpen,
+    /// The market has more than 2 outcomes; this pool's Kelly-edge math only
+    /// supports binary (yes/no) markets.
+    SkippedNotBinary,
+    /// The market is closed to new stakes, already resolved, or otherwise
+    /// unavailable (lookup failed, settled/cancelled/voided).
+    SkippedMarketUnavailable,
+    /// The market's `stake_token` doesn't match this pool's `stake_token`.
+    SkippedTokenMismatch,
+    /// `oracle_probability_bps` was out of the valid `0..=10_000` range.
+    SkippedInvalidOracleProbability,
+    /// The computed allocation amount was zero or the pool ran out of
+    /// liquid capital partway through a multi-market batch.
+    SkippedInsufficientLiquidity,
+    /// `prediction_market::stake_on_call` itself rejected the stake (e.g.
+    /// below the market's own minimum, or the staking cutoff window is
+    /// active).
+    SkippedStakeRejected,
+}

--- a/packages/contracts/lending_pool/src/xcontract.rs
+++ b/packages/contracts/lending_pool/src/xcontract.rs
@@ -1,0 +1,144 @@
+//! Raw cross-contract call helpers for `prediction_market_factory` and
+//! `outcome_manager`.
+//!
+//! This crate deliberately does **not** take a real Cargo dependency on
+//! either of those contract crates (unlike `prediction-market`, which it does
+//! depend on — see `lib.rs`'s use of `PredictionMarketClient`). Linking two
+//! or more `#[contract]` crates' generated code into the *same* WASM binary
+//! makes every one of their `#[contractimpl]`-exported function names a WASM
+//! export of *this* binary too, and several of those names collide across
+//! `prediction_market_factory` / `outcome_manager` / `prediction_market`
+//! (e.g. all three export a same-named `get_factory`/`get_config`/`pause`
+//! function for their own unrelated purposes) — `rust-lld` fails with
+//! "duplicate symbol" as soon as more than one of them is a production
+//! dependency of the same deployable contract. `parlay_betting` sidesteps
+//! this by depending on `prediction-market` alone and reaching
+//! `outcome_manager` only via `env.invoke_contract`; `outcome_manager` itself
+//! does the same thing to reach its registry/factory (see its
+//! `call_types.rs` mirror of `call_registry`'s types). This module follows
+//! the identical pattern for the two contracts this pool talks to besides
+//! `prediction_market`.
+//!
+//! Both contract crates remain real `[dev-dependencies]` so the test suite
+//! can deploy and drive real instances of them (their exports only collide
+//! when linked into one WASM binary — deploying them as separate contract
+//! instances during a native test run has no such conflict).
+
+use soroban_sdk::{contracterror, Address, Env, IntoVal, Symbol};
+
+use crate::errors::LendingPoolError;
+use crate::types::PoolConfig;
+
+/// Mirrors `prediction_market_factory::errors::FactoryError` 1:1 so this
+/// crate can decode its `Result<Address, FactoryError>` return value without
+/// depending on that crate (see module doc comment).
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+enum FactoryMirrorError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    InvalidStakeAmount = 4,
+    InvalidEndTime = 5,
+    InvalidOutcomeCount = 6,
+    TokenNotWhitelisted = 7,
+    ContractPaused = 8,
+    MarketWasmNotSet = 9,
+    MarketNotFound = 10,
+    StrategyNotFound = 11,
+    StrategyAlreadyExecuted = 12,
+    StrategyCancelled = 13,
+    StrategyExpired = 14,
+    TooManyActions = 15,
+    StrategyNotExecutable = 16,
+}
+
+/// Mirrors `outcome_manager::errors::OutcomeError` 1:1 so this crate can
+/// decode a panic-turned-host-error from `claim_payout_for_market` (see
+/// module doc comment).
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+enum OutcomeMirrorError {
+    AlreadyInitialized = 1,
+    InvalidQuorum = 2,
+    UnauthorizedOracle = 3,
+    AlreadySettled = 4,
+    DuplicateSubmission = 5,
+    InvalidOutcome = 6,
+    CallNotSettled = 7,
+    AlreadyClaimed = 8,
+    NothingToClaim = 9,
+    InvalidWinningStake = 10,
+    Overflow = 11,
+    CallNotFinalized = 12,
+    InvalidFeeBps = 13,
+    ContractPaused = 14,
+    MaxOraclesReached = 15,
+    SubmissionWindowExpired = 16,
+    EmptyBatch = 17,
+    LengthMismatch = 18,
+    NotInitialized = 19,
+    FeeCollectorNotSet = 20,
+    ObservationOutOfOrder = 21,
+    InsufficientPriceObservations = 22,
+    NoPriceObservations = 23,
+    ZeroTimeWindow = 24,
+    RegistryNotSet = 25,
+    DisputeWindowExpired = 26,
+    FactoryNotSet = 27,
+    InvalidMarket = 28,
+    ObservationOutsideWindow = 29,
+    NotRecoveryAgent = 30,
+    RecoveryGracePeriodNotElapsed = 31,
+}
+
+/// Resolve `call_id`'s deployed market address via the configured
+/// `prediction_market_factory` instance's `get_market` view function.
+pub fn resolve_market_address(
+    env: &Env,
+    config: &PoolConfig,
+    call_id: u64,
+) -> Result<Address, LendingPoolError> {
+    let args = (call_id,).into_val(env);
+    let result: Result<Address, FactoryMirrorError> = env.invoke_contract(
+        &config.prediction_market_factory,
+        &Symbol::new(env, "get_market"),
+        args,
+    );
+    result.map_err(|_| LendingPoolError::MarketCallFailed)
+}
+
+/// Claim this pool's payout for `call_id` via `outcome_manager`'s
+/// `claim_payout_for_market`, which itself calls back into
+/// `prediction_market::release_escrow` to move the tokens into this
+/// contract's balance. That function has no `Result` return type of its own
+/// — failures surface as a panic-turned-host-error, so this uses
+/// `try_invoke_contract` (not the plain `invoke_contract` used above) to
+/// catch that as a `Result` instead of aborting this contract's whole
+/// transaction.
+pub fn claim_payout_for_market(
+    env: &Env,
+    config: &PoolConfig,
+    call_id: u64,
+    staker: &Address,
+    staker_winning_stake: i128,
+    total_winning_stake: i128,
+    total_losing_stake: i128,
+) -> Result<(), LendingPoolError> {
+    let args = (
+        call_id,
+        staker.clone(),
+        staker_winning_stake,
+        total_winning_stake,
+        total_losing_stake,
+    )
+        .into_val(env);
+    let result: Result<Result<(), soroban_sdk::ConversionError>, Result<OutcomeMirrorError, soroban_sdk::InvokeError>> =
+        env.try_invoke_contract(&config.outcome_manager, &Symbol::new(env, "claim_payout_for_market"), args);
+    match result {
+        Ok(Ok(())) => Ok(()),
+        _ => Err(LendingPoolError::MarketCallFailed),
+    }
+}


### PR DESCRIPTION


## Summary
- New standalone `lending_pool` crate: `deposit`/`withdraw` against an internal LP-share ledger (NAV-style, share price starts 1:1 and grows with harvested yield), `allocate_capital` (permissionless, once pool ≥ configurable minimum) and `harvest_yield` (permissionless)
- Kelly-edge allocation: `edge = |market_implied_probability - oracle_probability|`, capital allocated proportional to `edge * pool_size`, capped at a configurable % per market (default 5%); oracle probability is caller-supplied per market (mirrors the caller-supplied-input pattern already used by `schelling_oracle`), since no live oracle price feed exists in this codebase for still-open markets
- `harvest_yield` claims the pool's own settled payout from `outcome_manager` (staking/claiming as itself, mirroring `parlay_betting`'s escrow model), deducts a configurable protocol fee from realized profit only, and updates a rolling 7-day APY
- Cross-contract wiring to `prediction_market_factory`/`outcome_manager` is via raw `env.invoke_contract` (a new `xcontract.rs`, mirroring `outcome_manager`'s own existing pattern for reaching `call_registry`) rather than generated clients as real dependencies — linking two `#[contract]` crates' generated code into one deployable WASM causes duplicate-symbol link errors; both are `dev-dependencies` only, used by the test harness
- `get_pool_stats` exposes `total_deposited`, `total_value_locked`, `total_yield_earned`, `current_apy`; events: `Deposited`, `Withdrawn`, `CapitalAllocated`, `YieldHarvested`

## Acceptance criteria
- [x] `deposit`/`withdraw` with LP shares, 1:1 starting price growing with yield
- [x] `allocate_capital(env)` callable by anyone once pool reaches minimum size
- [x] Kelly-edge allocation, capped per market, staking the oracle-favored side
- [x] `total_deposited`/`total_value_locked`/`total_yield_earned`/`current_apy` (7-day rolling)
- [x] Configurable protocol fee on profits (default 10%) to treasury
- [x] `get_pool_stats(env) -> PoolStats`
- [x] `Deposited`, `Withdrawn`, `CapitalAllocated`, `YieldHarvested` events
- [x] Tests: deposit/withdraw cycle, multi-market allocation, yield calculation, LP share price growth, protocol fee deduction

## Test plan
- [x] `cargo test -p lending-pool` — 16/16 passing, against real deployed `prediction_market`/`prediction_market_factory`/`outcome_manager` instances (no mocks), with hand-computed allocation/yield/APY/share-price numbers
- [x] `cargo build --release -p lending-pool` (native) and `--target wasm32v1-none` — both succeed
- [x] `cargo test --workspace` — 266/266 passing, 0 failed
- [x] `cargo build --release --workspace` succeeds

closes #466 