### PR TITLE
Rename result_oracle to outcome_manager in deploy.sh, deploy predicti…

### DIFF
--- a/packages/contracts/scripts/deploy.sh
+++ b/packages/contracts/scripts/deploy.sh
@@ -4,13 +4,91 @@ set -euo pipefail
 NETWORK=${1:---network testnet}
 ENV_FILE="$(dirname "$0")/../.env.contracts"
 
+# Required environment variables (export these before running this script):
+#   STELLAR_SOURCE_ACCOUNT  - funded source account used to sign all deploy/invoke txs
+#   ADMIN_ADDRESS           - admin address for outcome_manager / call_registry / factory
+#   FEE_COLLECTOR_ADDRESS   - fee collector address for outcome_manager
+#   ORACLE_PUBKEYS          - comma-separated BytesN<32> hex oracle pubkeys, e.g. "aaaa...,bbbb..."
+# Optional (defaults shown):
+#   QUORUM=1
+#   FEE_BPS=0
+#   DISPUTE_WINDOW_SECS=3600
+#   MIN_STAKE=10000000
+
+: "${STELLAR_SOURCE_ACCOUNT:?Set STELLAR_SOURCE_ACCOUNT to a funded source account}"
+: "${ADMIN_ADDRESS:?Set ADMIN_ADDRESS to the admin address}"
+: "${FEE_COLLECTOR_ADDRESS:?Set FEE_COLLECTOR_ADDRESS to the outcome_manager fee collector address}"
+: "${ORACLE_PUBKEYS:?Set ORACLE_PUBKEYS to a comma-separated list of BytesN<32> hex oracle pubkeys}"
+QUORUM=${QUORUM:-1}
+FEE_BPS=${FEE_BPS:-0}
+DISPUTE_WINDOW_SECS=${DISPUTE_WINDOW_SECS:-3600}
+MIN_STAKE=${MIN_STAKE:-10000000}
+
 echo "Deploying contracts on ${NETWORK}..."
 
-CALL_REGISTRY_ID=$(stellar contract deploy --wasm target/wasm32-unknown-unknown/release/call_registry.wasm $NETWORK)
-RESULT_ORACLE_ID=$(stellar contract deploy --wasm target/wasm32-unknown-unknown/release/result_oracle.wasm $NETWORK)
+# Build a JSON array (`["aaaa...","bbbb..."]`) from the comma-separated pubkey list
+# for the outcome_manager `oracles: Vec<BytesN<32>>` constructor argument.
+IFS=',' read -ra ORACLE_ARR <<< "$ORACLE_PUBKEYS"
+ORACLES_JSON="["
+for i in "${!ORACLE_ARR[@]}"; do
+  [[ $i -gt 0 ]] && ORACLES_JSON+=","
+  ORACLES_JSON+="\"${ORACLE_ARR[$i]}\""
+done
+ORACLES_JSON+="]"
 
-stellar contract invoke --id "$CALL_REGISTRY_ID" $NETWORK -- initialize --oracle_id "$RESULT_ORACLE_ID"
-stellar contract invoke --id "$RESULT_ORACLE_ID" $NETWORK -- initialize --registry_id "$CALL_REGISTRY_ID"
+# 1. Deploy call_registry
+CALL_REGISTRY_ID=$(stellar contract deploy --wasm target/wasm32-unknown-unknown/release/call_registry.wasm $NETWORK --source "$STELLAR_SOURCE_ACCOUNT")
 
-printf 'CALL_REGISTRY_ID=%s\nRESULT_ORACLE_ID=%s\n' "$CALL_REGISTRY_ID" "$RESULT_ORACLE_ID" > "$ENV_FILE"
+# 2. Deploy outcome_manager (renamed from result_oracle)
+OUTCOME_MANAGER_ID=$(stellar contract deploy --wasm target/wasm32-unknown-unknown/release/outcome_manager.wasm $NETWORK --source "$STELLAR_SOURCE_ACCOUNT")
+
+stellar contract invoke --id "$CALL_REGISTRY_ID" $NETWORK -- initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --outcome_manager "$OUTCOME_MANAGER_ID" \
+  --min_stake "$MIN_STAKE"
+
+stellar contract invoke --id "$OUTCOME_MANAGER_ID" $NETWORK -- initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --oracles "$ORACLES_JSON" \
+  --quorum "$QUORUM" \
+  --fee_collector "$FEE_COLLECTOR_ADDRESS" \
+  --fee_bps "$FEE_BPS" \
+  --dispute_window_secs "$DISPUTE_WINDOW_SECS"
+
+# 3. Upload (do NOT deploy) prediction_market.wasm. The market contract's
+# `__constructor` requires per-market args (call_id, creator, min_stake, ...) that
+# only the factory knows at `deploy_market` time, so this workspace's pattern
+# (see prediction_market_factory/build.rs) is: upload the wasm once to install it
+# on the network and obtain its hash, then hand that hash to the factory, which
+# instantiates real market instances itself via `env.deployer().deploy_v2(...)`.
+MARKET_WASM_HASH=$(stellar contract upload --wasm target/wasm32-unknown-unknown/release/prediction_market.wasm $NETWORK --source "$STELLAR_SOURCE_ACCOUNT")
+
+# 4. Deploy prediction_market_factory (after prediction_market is uploaded, since
+# its constructor call below needs the market wasm hash) and initialize it.
+PREDICTION_MARKET_FACTORY_ID=$(stellar contract deploy --wasm target/wasm32-unknown-unknown/release/prediction_market_factory.wasm $NETWORK --source "$STELLAR_SOURCE_ACCOUNT")
+
+stellar contract invoke --id "$PREDICTION_MARKET_FACTORY_ID" $NETWORK -- initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --outcome_manager "$OUTCOME_MANAGER_ID" \
+  --market_wasm_hash "$MARKET_WASM_HASH" \
+  --min_stake "$MIN_STAKE"
+
+# Health checks: confirm each contract is live and was initialized correctly.
+echo "Verifying deployments..."
+
+stellar contract invoke --id "$CALL_REGISTRY_ID" $NETWORK -- get_config >/dev/null
+echo "  call_registry:               OK (get_config)"
+
+# outcome_manager has no get_config view; get_quorum reads back the quorum set
+# during initialize and panics if the contract was never initialized, so it
+# serves as the equivalent health check.
+stellar contract invoke --id "$OUTCOME_MANAGER_ID" $NETWORK -- get_quorum >/dev/null
+echo "  outcome_manager:              OK (get_quorum)"
+
+stellar contract invoke --id "$PREDICTION_MARKET_FACTORY_ID" $NETWORK -- get_config >/dev/null
+echo "  prediction_market_factory:    OK (get_config)"
+
+printf 'CALL_REGISTRY_ID=%s\nOUTCOME_MANAGER_CONTRACT_ADDRESS=%s\nPREDICTION_MARKET_WASM_HASH=%s\nPREDICTION_MARKET_FACTORY_ID=%s\n' \
+  "$CALL_REGISTRY_ID" "$OUTCOME_MANAGER_ID" "$MARKET_WASM_HASH" "$PREDICTION_MARKET_FACTORY_ID" > "$ENV_FILE"
+
 echo "Deployed. IDs saved to $ENV_FILE"


### PR DESCRIPTION


## Summary
- Renamed all `result_oracle`/`RESULT_ORACLE_ID` references to `outcome_manager`/`OUTCOME_MANAGER_ID`, including the `.env.contracts` key — changed to `OUTCOME_MANAGER_CONTRACT_ADDRESS` to match what `packages/backend/src/oracle/config/oracle.config.ts` actually reads (confirmed by read-only grep, no backend files touched)
- Added `prediction_market`: uploaded only (not deployed as a standalone instance) — confirmed via its `__constructor` needing per-market args that don't exist at deploy-script time, and that the factory's `build.rs` only needs the wasm file present
- Added `prediction_market_factory`: deployed after the upload, `initialize`d with `admin`, `outcome_manager` id, the uploaded `prediction_market` wasm hash, and `min_stake`
- Bundled fix: the pre-existing `initialize` calls for `call_registry`/`outcome_manager`/the factory were already broken (passed nonexistent `--oracle_id`/`--registry_id` args) — corrected against the real Rust signatures
- Health checks: `call_registry`/`prediction_market_factory` use `get_config`; `outcome_manager` has no `get_config`, so uses `get_quorum` (the closest genuine post-init readback) — documented in the script
- `.env.contracts` now writes `CALL_REGISTRY_ID`, `OUTCOME_MANAGER_CONTRACT_ADDRESS`, `PREDICTION_MARKET_WASM_HASH`, `PREDICTION_MARKET_FACTORY_ID`

## Acceptance criteria
- [x] All `result_oracle` references replaced with `outcome_manager`
- [x] `prediction_market` deployment step added (uploaded first, per the factory's wasm-hash-constructor requirement)
- [x] `prediction_market_factory` deployment step added, initialized with the admin address
- [x] Health-check verification per deployed contract
- [x] Contract IDs saved to `.env.contracts` in the format the backend actually expects
- [ ] End-to-end testnet run — **not performed**: no `stellar` CLI or network access in this sandbox (see Test plan)

## Test plan
- [x] `bash -n packages/contracts/scripts/deploy.sh` — syntax OK
- [x] Manual dry-run: traced every variable from definition through every downstream use; cross-checked every `invoke` argument name/order against the real Rust `initialize`/constructor signatures
- [ ] Real testnet run — could not be performed in this environment; recommend running once against actual testnet credentials before merging, per the issue's own acceptance criterion


closes #476 