### PR TITLE
feat(backend): event sourcing audit trail with PostgreSQL event store

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { LoggerModule } from './common/logger/logger.module';
 import { AlertsModule } from './alerts/alerts.module';
 import { StakesModule } from './stakes/stakes.module';
+import { EventStoreModule } from './event-store/event-store.module';
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { StakesModule } from './stakes/stakes.module';
     CommentsModule,
     AlertsModule,
     StakesModule,
+    EventStoreModule,
   ],
   controllers: [],
   providers: [{ provide: APP_INTERCEPTOR, useClass: LoggingInterceptor }],

--- a/packages/backend/src/audit/interceptors/audit.interceptor.ts
+++ b/packages/backend/src/audit/interceptors/audit.interceptor.ts
@@ -6,6 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Observable, throwError } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { Request, Response } from 'express';
@@ -39,6 +40,7 @@ export class AuditInterceptor implements NestInterceptor {
   constructor(
     private readonly auditService: AuditService,
     private readonly reflector: Reflector,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   intercept(ctx: ExecutionContext, next: CallHandler): Observable<unknown> {
@@ -77,6 +79,9 @@ export class AuditInterceptor implements NestInterceptor {
     // ── Request payload snapshot (strip sensitive fields) ─────────────────
     const requestPayload = sanitize(req.body as Record<string, unknown>);
 
+    const ip = req.ip;
+    const userAgent = req.headers['user-agent'];
+
     const startedAt = Date.now();
 
     return next.handle().pipe(
@@ -90,6 +95,16 @@ export class AuditInterceptor implements NestInterceptor {
           responsePayload: sanitize(responseBody),
           httpStatus: res.statusCode,
           status: AuditStatus.SUCCESS,
+        });
+
+        this.eventEmitter.emit('admin.action', {
+          actorId,
+          actionType,
+          targetResource,
+          status: AuditStatus.SUCCESS,
+          httpStatus: res.statusCode,
+          ip,
+          userAgent,
         });
 
         this.logger.debug(
@@ -114,6 +129,17 @@ export class AuditInterceptor implements NestInterceptor {
           httpStatus,
           status: AuditStatus.FAILURE,
           note: err.message,
+        });
+
+        this.eventEmitter.emit('admin.action', {
+          actorId,
+          actionType,
+          targetResource,
+          status: AuditStatus.FAILURE,
+          httpStatus,
+          note: err.message,
+          ip,
+          userAgent,
         });
 
         this.logger.warn(

--- a/packages/backend/src/database/migrations/1760000030000-CreateEventStore.ts
+++ b/packages/backend/src/database/migrations/1760000030000-CreateEventStore.ts
@@ -1,0 +1,151 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Event sourcing audit trail (Issue #533).
+ *
+ * Creates the append-only `event_store` table plus `aggregate_snapshots`
+ * for compaction. Append-only is enforced twice over: EventStoreService
+ * never exposes an update/delete method, and — belt and suspenders, since a
+ * stray `UPDATE event_store ...` in a psql session would otherwise silently
+ * corrupt history — BEFORE UPDATE/DELETE triggers reject any mutation at
+ * the database layer.
+ */
+export class CreateEventStore1760000030000 implements MigrationInterface {
+  name = 'CreateEventStore1760000030000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "event_store_aggregate_type_enum" AS ENUM (
+          'CALL', 'USER', 'STAKE', 'PAYOUT', 'ORACLE', 'ADMIN'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "event_store_event_type_enum" AS ENUM (
+          'call.created',
+          'call.resolved',
+          'stake.placed',
+          'stake.withdrawn',
+          'payout.claimed',
+          'user.registered',
+          'user.followed',
+          'admin.action',
+          'oracle.submitted'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "event_store" (
+        "id"              uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "sequence"        bigserial NOT NULL,
+        "aggregateType"   "event_store_aggregate_type_enum" NOT NULL,
+        "aggregateId"     character varying(128) NOT NULL,
+        "eventType"       "event_store_event_type_enum" NOT NULL,
+        "payload"         jsonb NOT NULL,
+        "metadata"        jsonb,
+        "ledgerSequence"  bigint,
+        "createdAt"       timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_event_store" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_event_store_sequence"
+        ON "event_store" ("sequence")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_event_store_aggregate"
+        ON "event_store" ("aggregateType", "aggregateId", "sequence")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_event_store_aggregateType"
+        ON "event_store" ("aggregateType")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_event_store_createdAt"
+        ON "event_store" ("createdAt")
+    `);
+
+    // ── Append-only enforcement ─────────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION event_store_prevent_mutation()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'event_store is append-only: % is not permitted', TG_OP;
+      END;
+      $$ LANGUAGE plpgsql
+    `);
+
+    await queryRunner.query(`
+      CREATE TRIGGER "trg_event_store_no_update"
+        BEFORE UPDATE ON "event_store"
+        FOR EACH ROW EXECUTE FUNCTION event_store_prevent_mutation()
+    `);
+
+    await queryRunner.query(`
+      CREATE TRIGGER "trg_event_store_no_delete"
+        BEFORE DELETE ON "event_store"
+        FOR EACH ROW EXECUTE FUNCTION event_store_prevent_mutation()
+    `);
+
+    // ── Compaction snapshots ────────────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "aggregate_snapshots" (
+        "id"            uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "aggregateType" "event_store_aggregate_type_enum" NOT NULL,
+        "aggregateId"   character varying(128) NOT NULL,
+        "sequence"      bigint NOT NULL,
+        "version"       integer NOT NULL,
+        "state"         jsonb NOT NULL,
+        "createdAt"     timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_aggregate_snapshots" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_aggregate_snapshots_lookup"
+        ON "aggregate_snapshots" ("aggregateType", "aggregateId", "sequence" DESC)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_aggregate_snapshots_lookup"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "aggregate_snapshots"`);
+
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS "trg_event_store_no_delete" ON "event_store"`,
+    );
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS "trg_event_store_no_update" ON "event_store"`,
+    );
+    await queryRunner.query(
+      `DROP FUNCTION IF EXISTS event_store_prevent_mutation()`,
+    );
+
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_event_store_createdAt"`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_event_store_aggregateType"`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_event_store_aggregate"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_event_store_sequence"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "event_store"`);
+
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "event_store_event_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "event_store_aggregate_type_enum"`,
+    );
+  }
+}

--- a/packages/backend/src/event-store/dto/query-events.dto.ts
+++ b/packages/backend/src/event-store/dto/query-events.dto.ts
@@ -1,0 +1,67 @@
+import {
+  IsOptional,
+  IsEnum,
+  IsString,
+  IsInt,
+  Min,
+  Max,
+  IsDateString,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { AggregateType } from '../entities/event-store-entry.entity';
+
+export class QueryEventsDto {
+  @ApiPropertyOptional({
+    enum: AggregateType,
+    description: 'Filter by aggregate type',
+  })
+  @IsOptional()
+  @IsEnum(AggregateType)
+  aggregate_type?: AggregateType;
+
+  @ApiPropertyOptional({ description: 'Filter by aggregate ID' })
+  @IsOptional()
+  @IsString()
+  aggregate_id?: string;
+
+  @ApiPropertyOptional({
+    description: 'Start of date range (ISO 8601)',
+    example: '2024-01-01T00:00:00Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @ApiPropertyOptional({
+    description: 'End of date range (ISO 8601)',
+    example: '2024-12-31T23:59:59Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page number (1-based)',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Results per page',
+    default: 50,
+    minimum: 1,
+    maximum: 500,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit?: number = 50;
+}

--- a/packages/backend/src/event-store/entities/aggregate-snapshot.entity.ts
+++ b/packages/backend/src/event-store/entities/aggregate-snapshot.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { AggregateType } from './event-store-entry.entity';
+
+/**
+ * A point-in-time snapshot of an aggregate's replayed state, taken every N
+ * events (see EventStoreService.SNAPSHOT_INTERVAL). Lets replayAggregate()
+ * start from the latest snapshot instead of the beginning of the stream.
+ */
+@Entity('aggregate_snapshots')
+@Index(['aggregateType', 'aggregateId', 'sequence'])
+export class AggregateSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'enum', enum: AggregateType, update: false })
+  aggregateType: AggregateType;
+
+  @Column({ type: 'varchar', length: 128, update: false })
+  aggregateId: string;
+
+  /** The `sequence` of the last event folded into this snapshot's state. */
+  @Column({ type: 'bigint', update: false })
+  sequence: string;
+
+  /** How many events (from the start of the aggregate's stream) this snapshot represents. */
+  @Column({ type: 'int', update: false })
+  version: number;
+
+  @Column({ type: 'jsonb', update: false })
+  state: Record<string, unknown>;
+
+  @CreateDateColumn({ type: 'timestamptz', update: false })
+  createdAt: Date;
+}

--- a/packages/backend/src/event-store/entities/event-store-entry.entity.ts
+++ b/packages/backend/src/event-store/entities/event-store-entry.entity.ts
@@ -1,0 +1,94 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  Generated,
+} from 'typeorm';
+
+export enum AggregateType {
+  CALL = 'CALL',
+  USER = 'USER',
+  STAKE = 'STAKE',
+  PAYOUT = 'PAYOUT',
+  ORACLE = 'ORACLE',
+  ADMIN = 'ADMIN',
+}
+
+/**
+ * Domain event names. Matches the EventEmitter2 event names emitted
+ * elsewhere in the app (e.g. `this.eventEmitter.emit('call.created', ...)`),
+ * so a listener can subscribe with `@OnEvent(DomainEventType.CALL_CREATED)`.
+ */
+export enum DomainEventType {
+  CALL_CREATED = 'call.created',
+  CALL_RESOLVED = 'call.resolved',
+  STAKE_PLACED = 'stake.placed',
+  STAKE_WITHDRAWN = 'stake.withdrawn',
+  PAYOUT_CLAIMED = 'payout.claimed',
+  USER_REGISTERED = 'user.registered',
+  USER_FOLLOWED = 'user.followed',
+  ADMIN_ACTION = 'admin.action',
+  ORACLE_SUBMITTED = 'oracle.submitted',
+}
+
+export interface EventMetadata {
+  correlationId: string;
+  userAddress?: string | null;
+  ip?: string | null;
+  userAgent?: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Append-only event store row. Immutability is enforced both at the
+ * application layer (no update/remove methods on EventStoreService) and at
+ * the database layer (BEFORE UPDATE/DELETE triggers added in the migration).
+ */
+@Entity('event_store')
+@Index(['aggregateType', 'aggregateId', 'sequence'])
+export class EventStoreEntry {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /**
+   * Global, gapless, monotonically increasing ordering key (Postgres
+   * bigserial). This — not `createdAt`, which can collide at millisecond
+   * resolution — is what guarantees replay ordering.
+   */
+  @Column({ type: 'bigint', update: false })
+  @Generated('increment')
+  @Index({ unique: true })
+  sequence: string;
+
+  @Column({ type: 'enum', enum: AggregateType, update: false })
+  @Index()
+  aggregateType: AggregateType;
+
+  @Column({ type: 'varchar', length: 128, update: false })
+  aggregateId: string;
+
+  @Column({ type: 'enum', enum: DomainEventType, update: false })
+  eventType: DomainEventType;
+
+  /** Event payload — the data describing what happened. */
+  @Column({ type: 'jsonb', update: false })
+  payload: Record<string, unknown>;
+
+  /** correlation_id, user_address, ip, user_agent, etc. */
+  @Column({ type: 'jsonb', nullable: true, update: false })
+  metadata: EventMetadata | null;
+
+  /**
+   * The Stellar ledger sequence this event corresponds to, when it is the
+   * backend-side record of an on-chain action. Null for purely off-chain
+   * events (e.g. a user follow).
+   */
+  @Column({ type: 'bigint', nullable: true, update: false })
+  ledgerSequence: string | null;
+
+  @CreateDateColumn({ type: 'timestamptz', update: false })
+  @Index()
+  createdAt: Date;
+}

--- a/packages/backend/src/event-store/event-store.listener.spec.ts
+++ b/packages/backend/src/event-store/event-store.listener.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventStoreListener } from './event-store.listener';
+import { EventStoreService } from './event-store.service';
+import {
+  AggregateType,
+  DomainEventType,
+} from './entities/event-store-entry.entity';
+
+describe('EventStoreListener', () => {
+  let listener: EventStoreListener;
+
+  const eventStore = {
+    append: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventStoreListener,
+        { provide: EventStoreService, useValue: eventStore },
+      ],
+    }).compile();
+
+    listener = module.get(EventStoreListener);
+  });
+
+  it('appends call.created under the CALL aggregate', async () => {
+    await listener.onCallCreated({
+      id: 'call-1',
+      creatorAddress: 'GA1',
+      title: 'BTC > 100k',
+    });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.CALL,
+      'call-1',
+      DomainEventType.CALL_CREATED,
+      expect.objectContaining({ id: 'call-1' }),
+      { userAddress: 'GA1' },
+    );
+  });
+
+  it('appends call.resolved under the CALL aggregate', async () => {
+    await listener.onCallResolved({ callId: 42, outcome: 'YES' });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.CALL,
+      '42',
+      DomainEventType.CALL_RESOLVED,
+      expect.objectContaining({ callId: 42 }),
+      undefined,
+    );
+  });
+
+  it('appends stake.placed under a composite STAKE aggregate id', async () => {
+    await listener.onStakePlaced({
+      userAddress: 'GA1',
+      callId: 'call-1',
+      amount: 50,
+    });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.STAKE,
+      'call-1:GA1',
+      DomainEventType.STAKE_PLACED,
+      expect.objectContaining({ amount: 50 }),
+      { userAddress: 'GA1' },
+    );
+  });
+
+  it('appends payout.claimed under a composite PAYOUT aggregate id', async () => {
+    await listener.onPayoutClaimed({
+      userAddress: 'GA1',
+      callId: 'call-1',
+      amount: 100,
+    });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.PAYOUT,
+      'call-1:GA1',
+      DomainEventType.PAYOUT_CLAIMED,
+      expect.objectContaining({ amount: 100 }),
+      { userAddress: 'GA1' },
+    );
+  });
+
+  it('appends user.registered under the USER aggregate', async () => {
+    await listener.onUserRegistered({ userId: 'u1', walletAddress: 'GA1' });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.USER,
+      'GA1',
+      DomainEventType.USER_REGISTERED,
+      expect.objectContaining({ userId: 'u1' }),
+      { userAddress: 'GA1' },
+    );
+  });
+
+  it('appends user.followed keyed by the followed user', async () => {
+    await listener.onUserFollowed({
+      followerAddress: 'GA1',
+      followingAddress: 'GA2',
+    });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.USER,
+      'GA2',
+      DomainEventType.USER_FOLLOWED,
+      expect.objectContaining({ followerAddress: 'GA1' }),
+      { userAddress: 'GA1' },
+    );
+  });
+
+  it('appends admin.action under the ADMIN aggregate, carrying ip/userAgent', async () => {
+    await listener.onAdminAction({
+      actorId: 'admin-1',
+      actionType: 'MARKET_MANUALLY_RESOLVED',
+      targetResource: 'call:call-1',
+      status: 'SUCCESS',
+      ip: '1.2.3.4',
+      userAgent: 'jest',
+    });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.ADMIN,
+      'call:call-1',
+      DomainEventType.ADMIN_ACTION,
+      expect.objectContaining({ actorId: 'admin-1' }),
+      { userAddress: 'admin-1', ip: '1.2.3.4', userAgent: 'jest' },
+    );
+  });
+
+  it('appends oracle.submitted under the ORACLE aggregate', async () => {
+    await listener.onOracleSubmitted({
+      callId: 7,
+      observedPrice: '110',
+      outcome: 'YES',
+    });
+
+    expect(eventStore.append).toHaveBeenCalledWith(
+      AggregateType.ORACLE,
+      '7',
+      DomainEventType.ORACLE_SUBMITTED,
+      expect.objectContaining({ observedPrice: '110' }),
+      undefined,
+    );
+  });
+
+  it('swallows append() failures so a broken audit trail never breaks the feature that triggered it', async () => {
+    eventStore.append.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(
+      listener.onCallCreated({
+        id: 'call-1',
+        creatorAddress: 'GA1',
+        title: 'x',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend/src/event-store/event-store.listener.ts
+++ b/packages/backend/src/event-store/event-store.listener.ts
@@ -1,0 +1,213 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { EventStoreService } from './event-store.service';
+import {
+  AggregateType,
+  DomainEventType,
+} from './entities/event-store-entry.entity';
+
+interface CallCreatedPayload {
+  id: string;
+  creatorAddress: string;
+  title: string;
+  [key: string]: unknown;
+}
+
+interface CallResolvedPayload {
+  callId: string | number;
+  outcome: string;
+  finalPrice?: string;
+  [key: string]: unknown;
+}
+
+interface StakePayload {
+  userAddress: string;
+  callId: string;
+  amount: number;
+  [key: string]: unknown;
+}
+
+interface PayoutClaimedPayload {
+  userAddress: string;
+  callId: string;
+  amount: number;
+  txHash?: string;
+  [key: string]: unknown;
+}
+
+interface UserRegisteredPayload {
+  userId: string;
+  walletAddress: string;
+  [key: string]: unknown;
+}
+
+interface UserFollowedPayload {
+  followingAddress: string;
+  followerAddress: string;
+  [key: string]: unknown;
+}
+
+interface AdminActionPayload {
+  actorId: string;
+  actionType: string;
+  targetResource: string;
+  status: string;
+  ip?: string;
+  userAgent?: string;
+  [key: string]: unknown;
+}
+
+interface OracleSubmittedPayload {
+  callId: string | number;
+  observedPrice: string;
+  outcome: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Bridges the app's existing EventEmitter2 domain events onto the
+ * append-only event_store. Each handler's only job is to figure out which
+ * aggregate the event belongs to and hand the payload to
+ * EventStoreService.append() — the store itself is oblivious to what any
+ * given event means.
+ */
+@Injectable()
+export class EventStoreListener {
+  private readonly logger = new Logger(EventStoreListener.name);
+
+  constructor(private readonly eventStore: EventStoreService) {}
+
+  @OnEvent(DomainEventType.CALL_CREATED)
+  async onCallCreated(payload: CallCreatedPayload): Promise<void> {
+    await this.record(
+      AggregateType.CALL,
+      payload.id,
+      DomainEventType.CALL_CREATED,
+      payload,
+      {
+        userAddress: payload.creatorAddress,
+      },
+    );
+  }
+
+  @OnEvent(DomainEventType.CALL_RESOLVED)
+  async onCallResolved(payload: CallResolvedPayload): Promise<void> {
+    await this.record(
+      AggregateType.CALL,
+      String(payload.callId),
+      DomainEventType.CALL_RESOLVED,
+      payload,
+    );
+  }
+
+  @OnEvent(DomainEventType.STAKE_PLACED)
+  async onStakePlaced(payload: StakePayload): Promise<void> {
+    await this.record(
+      AggregateType.STAKE,
+      stakeAggregateId(payload),
+      DomainEventType.STAKE_PLACED,
+      payload,
+      { userAddress: payload.userAddress },
+    );
+  }
+
+  @OnEvent(DomainEventType.STAKE_WITHDRAWN)
+  async onStakeWithdrawn(payload: StakePayload): Promise<void> {
+    await this.record(
+      AggregateType.STAKE,
+      stakeAggregateId(payload),
+      DomainEventType.STAKE_WITHDRAWN,
+      payload,
+      { userAddress: payload.userAddress },
+    );
+  }
+
+  @OnEvent(DomainEventType.PAYOUT_CLAIMED)
+  async onPayoutClaimed(payload: PayoutClaimedPayload): Promise<void> {
+    await this.record(
+      AggregateType.PAYOUT,
+      `${payload.callId}:${payload.userAddress}`,
+      DomainEventType.PAYOUT_CLAIMED,
+      payload,
+      { userAddress: payload.userAddress },
+    );
+  }
+
+  @OnEvent(DomainEventType.USER_REGISTERED)
+  async onUserRegistered(payload: UserRegisteredPayload): Promise<void> {
+    await this.record(
+      AggregateType.USER,
+      payload.walletAddress,
+      DomainEventType.USER_REGISTERED,
+      payload,
+      { userAddress: payload.walletAddress },
+    );
+  }
+
+  @OnEvent(DomainEventType.USER_FOLLOWED)
+  async onUserFollowed(payload: UserFollowedPayload): Promise<void> {
+    await this.record(
+      AggregateType.USER,
+      payload.followingAddress,
+      DomainEventType.USER_FOLLOWED,
+      payload,
+      { userAddress: payload.followerAddress },
+    );
+  }
+
+  @OnEvent(DomainEventType.ADMIN_ACTION)
+  async onAdminAction(payload: AdminActionPayload): Promise<void> {
+    await this.record(
+      AggregateType.ADMIN,
+      payload.targetResource,
+      DomainEventType.ADMIN_ACTION,
+      payload,
+      {
+        userAddress: payload.actorId,
+        ip: payload.ip,
+        userAgent: payload.userAgent,
+      },
+    );
+  }
+
+  @OnEvent(DomainEventType.ORACLE_SUBMITTED)
+  async onOracleSubmitted(payload: OracleSubmittedPayload): Promise<void> {
+    await this.record(
+      AggregateType.ORACLE,
+      String(payload.callId),
+      DomainEventType.ORACLE_SUBMITTED,
+      payload,
+    );
+  }
+
+  /**
+   * Writing to the audit trail must never take down the feature that
+   * triggered it — same "log but never bubble" contract AuditService uses.
+   */
+  private async record(
+    aggregateType: AggregateType,
+    aggregateId: string,
+    eventType: DomainEventType,
+    payload: Record<string, unknown>,
+    metadata?: { userAddress?: string; ip?: string; userAgent?: string },
+  ): Promise<void> {
+    try {
+      await this.eventStore.append(
+        aggregateType,
+        aggregateId,
+        eventType,
+        payload,
+        metadata,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to append ${eventType} for ${aggregateType}:${aggregateId}`,
+        (err as Error).stack,
+      );
+    }
+  }
+}
+
+function stakeAggregateId(payload: StakePayload): string {
+  return `${payload.callId}:${payload.userAddress}`;
+}

--- a/packages/backend/src/event-store/event-store.module.ts
+++ b/packages/backend/src/event-store/event-store.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventStoreEntry } from './entities/event-store-entry.entity';
+import { AggregateSnapshot } from './entities/aggregate-snapshot.entity';
+import { EventStoreService } from './event-store.service';
+import { EventStoreListener } from './event-store.listener';
+import { EventsController } from './events.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EventStoreEntry, AggregateSnapshot])],
+  providers: [EventStoreService, EventStoreListener],
+  controllers: [EventsController],
+  exports: [EventStoreService],
+})
+export class EventStoreModule {}

--- a/packages/backend/src/event-store/event-store.service.spec.ts
+++ b/packages/backend/src/event-store/event-store.service.spec.ts
@@ -1,0 +1,303 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventStoreService } from './event-store.service';
+import {
+  AggregateType,
+  DomainEventType,
+  EventStoreEntry,
+} from './entities/event-store-entry.entity';
+import { AggregateSnapshot } from './entities/aggregate-snapshot.entity';
+import { correlationStorage } from '../common/middleware/correlation-id.middleware';
+
+describe('EventStoreService', () => {
+  let service: EventStoreService;
+
+  const eventRepo = {
+    create: jest.fn((v) => v),
+    save: jest.fn(),
+    find: jest.fn(),
+    count: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const snapshotRepo = {
+    create: jest.fn((v) => v),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    eventRepo.count.mockResolvedValue(0);
+    snapshotRepo.findOne.mockResolvedValue(null);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventStoreService,
+        { provide: getRepositoryToken(EventStoreEntry), useValue: eventRepo },
+        {
+          provide: getRepositoryToken(AggregateSnapshot),
+          useValue: snapshotRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get(EventStoreService);
+  });
+
+  describe('append', () => {
+    it('persists an immutable event row via a single save() call', async () => {
+      eventRepo.save.mockResolvedValue({ id: 'evt-1', sequence: '1' });
+
+      const result = await service.append(
+        AggregateType.CALL,
+        'call-1',
+        DomainEventType.CALL_CREATED,
+        { title: 'BTC > 100k' },
+        { userAddress: 'GA1' },
+      );
+
+      expect(eventRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aggregateType: AggregateType.CALL,
+          aggregateId: 'call-1',
+          eventType: DomainEventType.CALL_CREATED,
+          payload: { title: 'BTC > 100k' },
+        }),
+      );
+      expect(eventRepo.save).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ id: 'evt-1', sequence: '1' });
+    });
+
+    it('stamps a correlation_id from the request-scoped AsyncLocalStorage when none is passed explicitly', async () => {
+      eventRepo.save.mockImplementation(async (v) => v);
+
+      await correlationStorage.run({ correlationId: 'corr-abc' }, async () => {
+        await service.append(
+          AggregateType.USER,
+          'GA1',
+          DomainEventType.USER_REGISTERED,
+          { walletAddress: 'GA1' },
+        );
+      });
+
+      expect(eventRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ correlationId: 'corr-abc' }),
+        }),
+      );
+    });
+
+    it('falls back to "unknown" correlation_id outside of a request context', async () => {
+      eventRepo.save.mockImplementation(async (v) => v);
+
+      await service.append(
+        AggregateType.USER,
+        'GA1',
+        DomainEventType.USER_REGISTERED,
+        { walletAddress: 'GA1' },
+      );
+
+      expect(eventRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ correlationId: 'unknown' }),
+        }),
+      );
+    });
+
+    it('an explicit metadata.correlationId wins over the ambient one', async () => {
+      eventRepo.save.mockImplementation(async (v) => v);
+
+      await correlationStorage.run({ correlationId: 'ambient' }, async () => {
+        await service.append(
+          AggregateType.USER,
+          'GA1',
+          DomainEventType.USER_REGISTERED,
+          { walletAddress: 'GA1' },
+          { correlationId: 'explicit' },
+        );
+      });
+
+      expect(eventRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ correlationId: 'explicit' }),
+        }),
+      );
+    });
+
+    it('a snapshot-check failure never propagates out of append()', async () => {
+      eventRepo.save.mockResolvedValue({ id: 'evt-1', sequence: '1' });
+      eventRepo.count.mockRejectedValue(new Error('db down'));
+
+      await expect(
+        service.append(
+          AggregateType.CALL,
+          'call-1',
+          DomainEventType.CALL_CREATED,
+          {},
+        ),
+      ).resolves.toEqual({ id: 'evt-1', sequence: '1' });
+    });
+  });
+
+  describe('getEvents', () => {
+    it('returns the full stream for an aggregate ordered oldest-first', async () => {
+      const rows = [{ sequence: '1' }, { sequence: '2' }];
+      eventRepo.find.mockResolvedValue(rows);
+
+      const result = await service.getEvents(AggregateType.CALL, 'call-1');
+
+      expect(eventRepo.find).toHaveBeenCalledWith({
+        where: { aggregateType: AggregateType.CALL, aggregateId: 'call-1' },
+        order: { sequence: 'ASC' },
+      });
+      expect(result).toBe(rows);
+    });
+  });
+
+  describe('getEventsSince', () => {
+    it('queries by createdAt and orders oldest-first', async () => {
+      eventRepo.find.mockResolvedValue([]);
+      const since = new Date('2026-01-01T00:00:00Z');
+
+      await service.getEventsSince(since);
+
+      expect(eventRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ order: { sequence: 'ASC' } }),
+      );
+    });
+  });
+
+  describe('replayAggregate', () => {
+    it('folds events in sequence order, later events overriding earlier keys', async () => {
+      snapshotRepo.findOne.mockResolvedValue(null);
+      eventRepo.find.mockResolvedValue([
+        {
+          sequence: '1',
+          eventType: DomainEventType.CALL_CREATED,
+          payload: { status: 'OPEN', title: 'BTC > 100k' },
+          createdAt: new Date('2026-01-01T00:00:00Z'),
+        },
+        {
+          sequence: '2',
+          eventType: DomainEventType.CALL_RESOLVED,
+          payload: { status: 'RESOLVED_YES' },
+          createdAt: new Date('2026-01-02T00:00:00Z'),
+        },
+      ] as unknown as EventStoreEntry[]);
+
+      const result = await service.replayAggregate(
+        AggregateType.CALL,
+        'call-1',
+      );
+
+      expect(result.version).toBe(2);
+      expect(result.lastSequence).toBe('2');
+      expect(result.lastEventType).toBe(DomainEventType.CALL_RESOLVED);
+      // title survives from the first event; status is overridden by the second
+      expect(result.state).toEqual({
+        status: 'RESOLVED_YES',
+        title: 'BTC > 100k',
+      });
+    });
+
+    it('starts from the latest snapshot instead of replaying the full history', async () => {
+      snapshotRepo.findOne.mockResolvedValue({
+        sequence: '5',
+        version: 5,
+        state: { status: 'OPEN', title: 'BTC > 100k' },
+      });
+      eventRepo.find.mockResolvedValue([
+        {
+          sequence: '6',
+          eventType: DomainEventType.CALL_RESOLVED,
+          payload: { status: 'RESOLVED_YES' },
+          createdAt: new Date('2026-01-03T00:00:00Z'),
+        },
+      ] as unknown as EventStoreEntry[]);
+
+      const result = await service.replayAggregate(
+        AggregateType.CALL,
+        'call-1',
+      );
+
+      // only events *after* the snapshot's sequence are pulled from the DB
+      expect(eventRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            aggregateType: AggregateType.CALL,
+            aggregateId: 'call-1',
+          }),
+        }),
+      );
+      expect(result.version).toBe(6);
+      expect(result.state).toEqual({
+        status: 'RESOLVED_YES',
+        title: 'BTC > 100k',
+      });
+    });
+
+    it('returns an empty state for an aggregate with no events', async () => {
+      snapshotRepo.findOne.mockResolvedValue(null);
+      eventRepo.find.mockResolvedValue([]);
+
+      const result = await service.replayAggregate(AggregateType.CALL, 'ghost');
+
+      expect(result).toEqual({
+        aggregateType: AggregateType.CALL,
+        aggregateId: 'ghost',
+        version: 0,
+        lastSequence: null,
+        lastEventType: null,
+        lastEventAt: null,
+        state: {},
+      });
+    });
+  });
+
+  describe('snapshot compaction', () => {
+    it('does not snapshot before the interval is reached', async () => {
+      eventRepo.save.mockResolvedValue({ id: 'evt-1', sequence: '5' });
+      eventRepo.count.mockResolvedValue(5); // below the 20-event interval
+
+      await service.append(
+        AggregateType.CALL,
+        'call-1',
+        DomainEventType.CALL_CREATED,
+        {},
+      );
+
+      expect(snapshotRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('snapshots once the unsnapshotted event count reaches the interval', async () => {
+      eventRepo.save.mockResolvedValue({ id: 'evt-20', sequence: '20' });
+      eventRepo.count.mockResolvedValue(20); // hits the 20-event interval
+      eventRepo.find.mockResolvedValue(
+        Array.from({ length: 20 }, (_, i) => ({
+          sequence: String(i + 1),
+          eventType: DomainEventType.CALL_CREATED,
+          payload: { n: i + 1 },
+          createdAt: new Date(),
+        })) as unknown as EventStoreEntry[],
+      );
+
+      await service.append(
+        AggregateType.CALL,
+        'call-1',
+        DomainEventType.CALL_CREATED,
+        {},
+      );
+
+      expect(snapshotRepo.save).toHaveBeenCalledTimes(1);
+      expect(snapshotRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aggregateType: AggregateType.CALL,
+          aggregateId: 'call-1',
+          sequence: '20',
+          version: 20,
+        }),
+      );
+    });
+  });
+});

--- a/packages/backend/src/event-store/event-store.service.ts
+++ b/packages/backend/src/event-store/event-store.service.ts
@@ -1,0 +1,251 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
+import {
+  AggregateType,
+  DomainEventType,
+  EventMetadata,
+  EventStoreEntry,
+} from './entities/event-store-entry.entity';
+import { AggregateSnapshot } from './entities/aggregate-snapshot.entity';
+import { correlationStorage } from '../common/middleware/correlation-id.middleware';
+
+export interface AggregateState {
+  aggregateType: AggregateType;
+  aggregateId: string;
+  /** Number of events folded into this state, from the beginning of the stream. */
+  version: number;
+  /** `sequence` of the last event folded in — the replay's high-water mark. */
+  lastSequence: string | null;
+  lastEventType: DomainEventType | null;
+  lastEventAt: Date | null;
+  /**
+   * Generic fold of every event's payload applied in order (later events
+   * override earlier keys on conflict). Aggregate-specific read models can
+   * layer their own reducers on top of getEvents()/getEventsSince() — this
+   * is intentionally the lowest-common-denominator projection.
+   */
+  state: Record<string, unknown>;
+}
+
+@Injectable()
+export class EventStoreService {
+  private readonly logger = new Logger(EventStoreService.name);
+
+  /** Take a compaction snapshot every N events appended to an aggregate. */
+  private readonly snapshotInterval = 20;
+
+  constructor(
+    @InjectRepository(EventStoreEntry)
+    private readonly eventRepo: Repository<EventStoreEntry>,
+    @InjectRepository(AggregateSnapshot)
+    private readonly snapshotRepo: Repository<AggregateSnapshot>,
+  ) {}
+
+  /**
+   * Atomically append a single immutable event to the store. A single
+   * INSERT is already atomic in Postgres; there is deliberately no
+   * multi-statement transaction here since nothing else needs to commit
+   * alongside it. Never mutates or removes prior rows.
+   */
+  async append(
+    aggregateType: AggregateType,
+    aggregateId: string,
+    eventType: DomainEventType,
+    payload: Record<string, unknown>,
+    metadata?: Partial<EventMetadata>,
+    ledgerSequence?: string | number | null,
+  ): Promise<EventStoreEntry> {
+    const correlationId =
+      metadata?.correlationId ?? correlationStorage.getStore()?.correlationId;
+
+    const entry = this.eventRepo.create({
+      aggregateType,
+      aggregateId,
+      eventType,
+      payload,
+      metadata: {
+        ...metadata,
+        correlationId: correlationId ?? 'unknown',
+      },
+      ledgerSequence:
+        ledgerSequence === undefined || ledgerSequence === null
+          ? null
+          : String(ledgerSequence),
+    });
+
+    const saved = await this.eventRepo.save(entry);
+
+    // Best-effort compaction — a failure here must never fail the append itself.
+    try {
+      await this.maybeSnapshot(aggregateType, aggregateId);
+    } catch (err) {
+      this.logger.warn(
+        `Snapshot check failed for ${aggregateType}:${aggregateId}: ${(err as Error).message}`,
+      );
+    }
+
+    return saved;
+  }
+
+  /** Full event stream for a single aggregate, oldest first. */
+  async getEvents(
+    aggregateType: AggregateType,
+    aggregateId: string,
+  ): Promise<EventStoreEntry[]> {
+    return this.eventRepo.find({
+      where: { aggregateType, aggregateId },
+      order: { sequence: 'ASC' },
+    });
+  }
+
+  /** All events across every aggregate created at or after `since`, oldest first. */
+  async getEventsSince(since: Date): Promise<EventStoreEntry[]> {
+    return this.eventRepo.find({
+      where: { createdAt: MoreThanOrEqual(since) },
+      order: { sequence: 'ASC' },
+    });
+  }
+
+  /** Filtered, paginated listing backing GET /admin/events. */
+  async queryEvents(filter: {
+    aggregateType?: AggregateType;
+    aggregateId?: string;
+    from?: Date;
+    to?: Date;
+    page?: number;
+    limit?: number;
+  }): Promise<{ data: EventStoreEntry[]; total: number }> {
+    const {
+      aggregateType,
+      aggregateId,
+      from,
+      to,
+      page = 1,
+      limit = 50,
+    } = filter;
+
+    const qb = this.eventRepo
+      .createQueryBuilder('event')
+      .orderBy('event.sequence', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (aggregateType)
+      qb.andWhere('event.aggregateType = :aggregateType', { aggregateType });
+    if (aggregateId)
+      qb.andWhere('event.aggregateId = :aggregateId', { aggregateId });
+    if (from) qb.andWhere('event.createdAt >= :from', { from });
+    if (to) qb.andWhere('event.createdAt <= :to', { to });
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total };
+  }
+
+  /**
+   * Rebuild an aggregate's current state by replaying its event stream.
+   * Starts from the latest snapshot (if one exists) instead of the
+   * beginning of history, then folds in any events appended since.
+   */
+  async replayAggregate(
+    aggregateType: AggregateType,
+    aggregateId: string,
+  ): Promise<AggregateState> {
+    const snapshot = await this.findLatestSnapshot(aggregateType, aggregateId);
+
+    const events = await this.eventRepo.find({
+      where: {
+        aggregateType,
+        aggregateId,
+        ...(snapshot
+          ? {
+              sequence: MoreThanOrEqual(String(BigInt(snapshot.sequence) + 1n)),
+            }
+          : {}),
+      },
+      order: { sequence: 'ASC' },
+    });
+
+    const state: AggregateState = snapshot
+      ? {
+          aggregateType,
+          aggregateId,
+          version: snapshot.version,
+          lastSequence: snapshot.sequence,
+          lastEventType: null,
+          lastEventAt: null,
+          state: { ...snapshot.state },
+        }
+      : {
+          aggregateType,
+          aggregateId,
+          version: 0,
+          lastSequence: null,
+          lastEventType: null,
+          lastEventAt: null,
+          state: {},
+        };
+
+    for (const event of events) {
+      state.state = { ...state.state, ...event.payload };
+      state.lastSequence = event.sequence;
+      state.lastEventType = event.eventType;
+      state.lastEventAt = event.createdAt;
+      state.version += 1;
+    }
+
+    return state;
+  }
+
+  private async findLatestSnapshot(
+    aggregateType: AggregateType,
+    aggregateId: string,
+  ): Promise<AggregateSnapshot | null> {
+    return this.snapshotRepo.findOne({
+      where: { aggregateType, aggregateId },
+      order: { sequence: 'DESC' },
+    });
+  }
+
+  /**
+   * If more than `snapshotInterval` events have accumulated since the last
+   * snapshot for this aggregate, replay and persist a fresh one.
+   */
+  private async maybeSnapshot(
+    aggregateType: AggregateType,
+    aggregateId: string,
+  ): Promise<void> {
+    const snapshot = await this.findLatestSnapshot(aggregateType, aggregateId);
+
+    const unsnapshotted = await this.eventRepo.count({
+      where: {
+        aggregateType,
+        aggregateId,
+        ...(snapshot
+          ? {
+              sequence: MoreThanOrEqual(String(BigInt(snapshot.sequence) + 1n)),
+            }
+          : {}),
+      },
+    });
+
+    if (unsnapshotted < this.snapshotInterval) return;
+
+    const replayed = await this.replayAggregate(aggregateType, aggregateId);
+    if (!replayed.lastSequence) return;
+
+    await this.snapshotRepo.save(
+      this.snapshotRepo.create({
+        aggregateType,
+        aggregateId,
+        sequence: replayed.lastSequence,
+        version: replayed.version,
+        state: replayed.state,
+      }),
+    );
+
+    this.logger.debug(
+      `Snapshotted ${aggregateType}:${aggregateId} @ sequence ${replayed.lastSequence}`,
+    );
+  }
+}

--- a/packages/backend/src/event-store/events.controller.spec.ts
+++ b/packages/backend/src/event-store/events.controller.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventsController } from './events.controller';
+import { EventStoreService } from './event-store.service';
+import { AggregateType } from './entities/event-store-entry.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+
+describe('EventsController', () => {
+  let controller: EventsController;
+
+  const eventStoreService = {
+    queryEvents: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EventsController],
+      providers: [{ provide: EventStoreService, useValue: eventStoreService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AdminGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(EventsController);
+  });
+
+  it('maps aggregate_type/aggregate_id query params onto EventStoreService.queryEvents', async () => {
+    eventStoreService.queryEvents.mockResolvedValue({
+      data: [{ id: 'evt-1' }],
+      total: 1,
+    });
+
+    const result = await controller.findAll({
+      aggregate_type: AggregateType.CALL,
+      aggregate_id: 'call-1',
+      from: '2024-01-01T00:00:00Z',
+      to: '2024-12-31T23:59:59Z',
+      page: 2,
+      limit: 10,
+    });
+
+    expect(eventStoreService.queryEvents).toHaveBeenCalledWith({
+      aggregateType: AggregateType.CALL,
+      aggregateId: 'call-1',
+      from: new Date('2024-01-01T00:00:00Z'),
+      to: new Date('2024-12-31T23:59:59Z'),
+      page: 2,
+      limit: 10,
+    });
+    expect(result).toEqual({
+      data: [{ id: 'evt-1' }],
+      total: 1,
+      page: 2,
+      limit: 10,
+    });
+  });
+
+  it('defaults page/limit in the response when the query omits them', async () => {
+    eventStoreService.queryEvents.mockResolvedValue({ data: [], total: 0 });
+
+    const result = await controller.findAll({});
+
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(50);
+  });
+});

--- a/packages/backend/src/event-store/events.controller.ts
+++ b/packages/backend/src/event-store/events.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { EventStoreService } from './event-store.service';
+import { EventStoreEntry } from './entities/event-store-entry.entity';
+import { QueryEventsDto } from './dto/query-events.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+
+@ApiTags('admin')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard, AdminGuard)
+@Controller('admin/events')
+export class EventsController {
+  constructor(private readonly eventStoreService: EventStoreService) {}
+
+  /**
+   * GET /admin/events
+   *
+   * Lists event_store rows, optionally filtered by aggregate_type,
+   * aggregate_id, and a created_at date range. Newest first.
+   */
+  @Get()
+  @ApiOperation({
+    summary: 'List event store entries',
+    description:
+      'Returns a paginated list of append-only audit trail events. ' +
+      'Supports filtering by aggregate type, aggregate ID, and date range.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated event store results' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — admin access required',
+  })
+  async findAll(@Query() query: QueryEventsDto): Promise<{
+    data: EventStoreEntry[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const { data, total } = await this.eventStoreService.queryEvents({
+      aggregateType: query.aggregate_type,
+      aggregateId: query.aggregate_id,
+      from: query.from ? new Date(query.from) : undefined,
+      to: query.to ? new Date(query.to) : undefined,
+      page: query.page,
+      limit: query.limit,
+    });
+
+    return { data, total, page: query.page ?? 1, limit: query.limit ?? 50 };
+  }
+}

--- a/packages/backend/src/oracle/oracle.service.spec.ts
+++ b/packages/backend/src/oracle/oracle.service.spec.ts
@@ -18,6 +18,7 @@ jest.mock('../utils/retry', () => {
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SorobanRpc } from '@stellar/stellar-sdk';
 import { OracleService } from './oracle.service';
 import { OracleCall, OracleCallStatus } from './entities/oracle-call.entity';
@@ -77,6 +78,9 @@ describe('OracleService', () => {
   const signingService = {
     signOutcome: jest.fn().mockReturnValue('sig'),
   };
+  const eventEmitter = {
+    emit: jest.fn(),
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -117,6 +121,7 @@ describe('OracleService', () => {
         },
         { provide: PriceFetcherService, useValue: priceFetcherRepo },
         { provide: CoinGeckoService, useValue: coinGeckoRepo },
+        { provide: EventEmitter2, useValue: eventEmitter },
       ],
     }).compile();
 
@@ -230,6 +235,18 @@ describe('OracleService', () => {
         operation: expect.any(String),
         success: true,
       }),
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'oracle.submitted',
+      expect.objectContaining({
+        callId: 1,
+        observedPrice: '110',
+        outcome: 'YES',
+      }),
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'call.resolved',
+      expect.objectContaining({ callId: 1, outcome: 'YES', finalPrice: '110' }),
     );
   });
 

--- a/packages/backend/src/oracle/oracle.service.ts
+++ b/packages/backend/src/oracle/oracle.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, IsNull, DeepPartial } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SorobanRpc, Contract, xdr } from '@stellar/stellar-sdk';
 import { OracleCall, OracleCallStatus } from './entities/oracle-call.entity';
 import { OracleOutcome } from './entities/oracle-outcome.entity';
@@ -59,6 +60,7 @@ export class OracleService {
     private readonly ipfsService: IpfsService,
     private readonly priceFetcherService: PriceFetcherService,
     private readonly coinGeckoService: CoinGeckoService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   // ─── Core CRUD ────────────────────────────────────────────────────────────
@@ -579,6 +581,22 @@ export class OracleService {
     call.resolvedAt = new Date();
     call.processedAt = new Date();
     await this.oracleCallRepository.save(call);
+
+    const resolvedOutcome =
+      outcome === OracleCallStatus.RESOLVED_YES ? 'YES' : 'NO';
+
+    this.eventEmitter.emit('oracle.submitted', {
+      callId,
+      observedPrice,
+      outcome: resolvedOutcome,
+      horizonPrice: horizonMidpoint,
+    });
+
+    this.eventEmitter.emit('call.resolved', {
+      callId,
+      outcome: resolvedOutcome,
+      finalPrice: observedPrice,
+    });
 
     // Record successful operation in health logs (storing both prices)
     await this.oracleHealthService.recordOperation({

--- a/packages/backend/src/payouts/payouts.service.spec.ts
+++ b/packages/backend/src/payouts/payouts.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PayoutClaim, PayoutClaimStatus } from './entities/payout-claim.entity';
 import { PayoutsService } from './payouts.service';
 
@@ -13,12 +14,17 @@ describe('PayoutsService', () => {
     save: jest.fn(),
   };
 
+  const eventEmitter = {
+    emit: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PayoutsService,
         { provide: getRepositoryToken(PayoutClaim), useValue: repository },
+        { provide: EventEmitter2, useValue: eventEmitter },
       ],
     }).compile();
 
@@ -29,6 +35,7 @@ describe('PayoutsService', () => {
     repository.findOne.mockResolvedValue({
       callId: 'call-1',
       stakerAddress: 'GA1',
+      amount: '100',
       status: PayoutClaimStatus.PENDING,
     });
     repository.save.mockImplementation(async (value: any) => value);
@@ -41,6 +48,12 @@ describe('PayoutsService', () => {
     );
 
     expect(result.status).toBe(PayoutClaimStatus.CLAIMED);
+    expect(eventEmitter.emit).toHaveBeenCalledWith('payout.claimed', {
+      userAddress: 'GA1',
+      callId: 'call-1',
+      amount: 100,
+      txHash: 'tx-hash',
+    });
     expect(result.txHash).toBe('tx-hash');
   });
 

--- a/packages/backend/src/payouts/payouts.service.ts
+++ b/packages/backend/src/payouts/payouts.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LessThan, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PayoutClaim, PayoutClaimStatus } from './entities/payout-claim.entity';
 
 @Injectable()
@@ -8,6 +9,7 @@ export class PayoutsService {
   constructor(
     @InjectRepository(PayoutClaim)
     private readonly payoutClaimsRepository: Repository<PayoutClaim>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async listUserPayouts(stakerAddress: string): Promise<PayoutClaim[]> {
@@ -79,7 +81,16 @@ export class PayoutsService {
     claim.txHash = txHash;
     claim.claimedAt = claimedAt;
     claim.status = PayoutClaimStatus.CLAIMED;
-    return this.payoutClaimsRepository.save(claim);
+    const saved = await this.payoutClaimsRepository.save(claim);
+
+    this.eventEmitter.emit('payout.claimed', {
+      userAddress: saved.stakerAddress,
+      callId: saved.callId,
+      amount: Number(saved.amount),
+      txHash: saved.txHash,
+    });
+
+    return saved;
   }
 
   async markFailed(

--- a/packages/backend/src/user/users.service.spec.ts
+++ b/packages/backend/src/user/users.service.spec.ts
@@ -7,6 +7,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersService } from './users.service';
 import { Users } from './entities/users.entity';
 import { Follow } from './entities/follow.entity';
@@ -45,6 +46,10 @@ describe('UsersService', () => {
     del: jest.fn().mockResolvedValue(undefined),
   };
 
+  const eventEmitter = {
+    emit: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
@@ -59,6 +64,7 @@ describe('UsersService', () => {
           useValue: { initializePreferences: jest.fn().mockResolvedValue([]) },
         },
         { provide: IpfsService, useValue: ipfsService },
+        { provide: EventEmitter2, useValue: eventEmitter },
       ],
     }).compile();
 
@@ -97,6 +103,10 @@ describe('UsersService', () => {
 
     const result = await service.follow('A', 'B');
     expect(result.id).toBe('f1');
+    expect(eventEmitter.emit).toHaveBeenCalledWith('user.followed', {
+      followerAddress: 'A',
+      followingAddress: 'B',
+    });
   });
 
   it('returns paginated followers', async () => {

--- a/packages/backend/src/user/users.service.ts
+++ b/packages/backend/src/user/users.service.ts
@@ -9,6 +9,7 @@ import {
 import { Users } from './entities/users.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { RegisterDto } from './dto/register.dto';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
@@ -32,6 +33,7 @@ export class UsersService {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private readonly preferenceService: NotificationPreferencesService,
     private readonly ipfsService: IpfsService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   private generateReferralCode(): string {
@@ -79,6 +81,10 @@ export class UsersService {
     );
     await this.invalidateUserProfile(followerAddress);
     await this.invalidateUserProfile(followingAddress);
+    this.eventEmitter.emit('user.followed', {
+      followerAddress,
+      followingAddress,
+    });
     return result;
   }
 
@@ -161,6 +167,10 @@ export class UsersService {
           `Failed to initialize notification preferences for ${walletAddress}: ${msg}`,
         );
       });
+    this.eventEmitter.emit('user.registered', {
+      userId: savedUser.id,
+      walletAddress,
+    });
     return savedUser;
   }
 


### PR DESCRIPTION
## Summary

Implements the event sourcing audit trail described in #533: every state-changing operation now emits an immutable event to a new append-only `event_store` table, alongside the existing row-level `AuditModule`.

- **`event_store` table** (migration `1760000030000-CreateEventStore`): `id`, `sequence` (global bigserial ordering key), `aggregateType` (`CALL`/`USER`/`STAKE`/`PAYOUT`/`ORACLE`/`ADMIN`), `aggregateId`, `eventType`, `payload` (jsonb), `metadata` (jsonb — `correlationId`, `userAddress`, `ip`, `userAgent`), `ledgerSequence`, `createdAt`.
- **Append-only, enforced twice**: `EventStoreService` exposes no update/delete method, and the migration adds `BEFORE UPDATE`/`BEFORE DELETE` triggers on `event_store` that raise an exception — so a stray manual `UPDATE` can't silently corrupt history either.
- **`EventStoreService`**: `append()`, `getEvents()`, `getEventsSince()`, `replayAggregate()`, plus `queryEvents()` backing the admin endpoint.
- **Correlation IDs**: `append()` pulls `correlationId` from the existing `CorrelationIdMiddleware`'s `AsyncLocalStorage` automatically when the caller doesn't supply one, so every event is traceable without every call site having to thread it through.
- **`EventStoreListener`**: `@OnEvent` handlers for `call.created`, `call.resolved`, `stake.placed`, `stake.withdrawn`, `payout.claimed`, `user.registered`, `user.followed`, `admin.action`, `oracle.submitted`. Failures are swallowed and logged (same "never break the feature that triggered it" contract `AuditService` already uses) rather than bubbling up.
- **Compaction**: `AggregateSnapshot` (`aggregate_snapshots` table) — every 20 events for a given aggregate, `append()` replays and persists a snapshot so `replayAggregate()` only has to fold events since the last snapshot instead of the full history.
- **`GET /admin/events`**: filters by `aggregate_type`, `aggregate_id`, `from`, `to`, paginated, admin-guarded (same `JwtAuthGuard` + `AdminGuard` pattern as `AuditController`).

### Wiring real emitters

Several of the nine events had listeners already stubbed in `ActivityService` but nothing in the codebase ever emitted them. This PR wires `EventEmitter2.emit()` at the real state-changing call sites for five of the nine:

- `UsersService.register()` → `user.registered`, `UsersService.follow()` → `user.followed`
- `PayoutsService.markClaimed()` → `payout.claimed`
- `OracleService.resolveMarket()` → `oracle.submitted` and `call.resolved`
- `AuditInterceptor` (both the success and failure path, so every `@Audited()` admin action) → `admin.action`

`call.created`, `stake.placed`, and `stake.withdrawn` don't yet have a corresponding write path in the backend (calls/stakes are currently only written via on-chain indexing, which doesn't yet route those contract events) — the listeners are ready and will start recording as soon as those emitters land, same as the pre-existing `ActivityService` listeners for these events.

### CQRS note

Per the issue's technical pointer, `replayAggregate()`'s default fold (shallow-merge each event's payload, later events win) is intentionally the lowest-common-denominator projection — it's meant as the backbone for aggregate-specific read models to build on, not a final one.

## Test plan

- [x] `npx jest` — all 52 suites / 382 tests pass, including new `EventStoreService`, `EventStoreListener`, and `EventsController` specs (append, correlation ID fallback/override, replay with and without a snapshot, ordering, snapshot-interval triggering, and that a broken event-store write never breaks the caller)
- [x] `npx tsc --noEmit` — no new type errors
- [x] `nest build` — compiles cleanly
- [x] `npx eslint` on all touched/new files — no new lint errors beyond pre-existing repo debt in files I had to touch anyway (verified via `git stash` diff)
- [ ] Manual verification against a running Postgres instance (migration up/down, trigger rejects UPDATE/DELETE) — not run in this environment; would appreciate a second pass in CI/review

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)