### PR TITLE
Implement market expiration rollover

### DIFF
--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -262,6 +262,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "charity-markets"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,13 +311,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "cross_chain_oracle_relay"
-version = "0.0.0"
-dependencies = [
- "soroban-sdk",
 ]
 
 [[package]]
@@ -527,6 +528,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dutch-auction"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,13 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "governance"
-version = "0.0.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +827,14 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "index-fund"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
 
 [[package]]
 name = "indexmap"
@@ -1197,16 +1207,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "reputation-nft"
-version = "0.0.0"
-dependencies = [
- "backit-shared",
- "ed25519-dalek",
- "rand",
- "soroban-sdk",
 ]
 
 [[package]]
@@ -1790,6 +1790,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tournament"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,16 +1971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "yield-aggregator"
-version = "0.0.0"
-dependencies = [
- "backit-shared",
- "ed25519-dalek",
- "rand",
- "soroban-sdk",
 ]
 
 [[package]]

--- a/packages/contracts/outcome_manager/src/call_types.rs
+++ b/packages/contracts/outcome_manager/src/call_types.rs
@@ -60,4 +60,6 @@ pub struct Call {
     pub cancelled: bool,
     pub metadata_version: u32,
     pub share_tokens: Map<u32, Address>,
+    pub parent_call_id: Option<u64>,
+    pub rolled_amount: i128,
 }

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -496,6 +496,11 @@ impl OutcomeManager {
         storage::get_factory_opt(&env)
     }
 
+    /// Return the fee config: (fee_bps, fee_collector).
+    pub fn fee_config(env: Env) -> (u32, Address) {
+        get_fee_config(&env)
+    }
+
     /// Resolve a market contract address from the configured factory.
     pub fn resolve_market_address(env: Env, call_id: u64) -> Address {
         let factory = match storage::get_factory_opt(&env) {
@@ -734,6 +739,70 @@ impl OutcomeManager {
         }
 
         registry_release_escrow(&env, &registry, call_id, &staker, payout);
+
+        emit_claimable_balance_created(&env, call_id, &staker, &balance_id, payout);
+        emit_payout_claimed(&env, call_id, &staker, payout);
+    }
+
+    /// Same as `claim_payout` but skips `registry_release_escrow` (no re-entrant
+    /// call back to the market).  Use when the market already released the escrow
+    /// before calling this function (avoids contract re-entry in `claim_and_rollover`).
+    pub fn claim_payout_no_release(
+        env: Env,
+        call_id: u64,
+        staker: Address,
+        staker_winning_stake: i128,
+        total_winning_stake: i128,
+        total_losing_stake: i128,
+    ) {
+        if is_paused(&env) {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
+        }
+
+        staker.require_auth();
+        require_call_settled(&env, call_id);
+
+        let claimed_key = InstanceKey::Claimed(call_id, staker.clone());
+        if env.storage().instance().has(&claimed_key) {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadyClaimed);
+        }
+
+        if staker_winning_stake <= 0 {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::NothingToClaim);
+        }
+        if total_winning_stake <= 0 {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidWinningStake);
+        }
+
+        let (fee_bps, fee_collector) = get_fee_config(&env);
+        let total_fee = compute_total_fee(&env, total_losing_stake, fee_bps);
+        let net_losing = total_losing_stake
+            .checked_sub(total_fee)
+            .unwrap_or_else(|| overflow(&env));
+
+        let (staker_fee_share, payout) = compute_payout_parts(
+            &env,
+            staker_winning_stake,
+            total_winning_stake,
+            total_fee,
+            net_losing,
+        );
+
+        env.storage().instance().set(&claimed_key, &true);
+
+        let mut id_input = Bytes::from_slice(&env, b"claimbal:");
+        id_input.append(&Bytes::from_slice(&env, &call_id.to_be_bytes()));
+        id_input.append(&staker.clone().to_xdr(&env));
+        let balance_id: BytesN<32> = env.crypto().sha256(&id_input).into();
+
+        env.storage().instance().set(
+            &InstanceKey::ClaimableBalanceId(call_id, staker.clone()),
+            &balance_id,
+        );
+
+        if staker_fee_share > 0 {
+            emit_fee_collected(&env, call_id, staker_fee_share, &fee_collector);
+        }
 
         emit_claimable_balance_created(&env, call_id, &staker, &balance_id, payout);
         emit_payout_claimed(&env, call_id, &staker, payout);

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -61,6 +61,8 @@ impl MockRegistry {
             cancelled: false,
             metadata_version: 0,
             share_tokens: Map::new(env),
+            parent_call_id: None,
+            rolled_amount: 0,
         }
     }
 
@@ -270,6 +272,8 @@ fn prepare_mock_payout(
         cancelled: false,
         metadata_version: 0,
         share_tokens: Map::new(env),
+        parent_call_id: None,
+        rolled_amount: 0,
     };
 
     mock_client.set_mock_call(&call_id, &call);
@@ -326,6 +330,8 @@ fn prepare_mock_batch_payout(
         cancelled: false,
         metadata_version: 0,
         share_tokens: Map::new(env),
+        parent_call_id: None,
+        rolled_amount: 0,
     };
 
     mock_client.set_mock_call(&call_id, &call);

--- a/packages/contracts/prediction_market/Cargo.toml
+++ b/packages/contracts/prediction_market/Cargo.toml
@@ -16,3 +16,4 @@ backit-shared = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 rand = "0.8"
+

--- a/packages/contracts/prediction_market/src/errors.rs
+++ b/packages/contracts/prediction_market/src/errors.rs
@@ -33,4 +33,12 @@ pub enum MarketError {
     InvalidOrderTTL = 23,
     /// #465: the order has not yet expired, so it cannot be force-refunded.
     OrderNotExpired = 24,
+    /// Rollover percentage exceeds 100% (10_000 bps).
+    InvalidRolloverPercentage = 25,
+    /// User has no stake on the winning outcome.
+    NoWinningStake = 26,
+    /// Rollover amount is below the minimum stake for the new market.
+    RolloverInsufficientAmount = 27,
+    /// The call has not been settled yet.
+    CallNotSettled = 28,
 }

--- a/packages/contracts/prediction_market/src/events.rs
+++ b/packages/contracts/prediction_market/src/events.rs
@@ -172,3 +172,27 @@ pub fn emit_limit_order_expired_refunded(
         ),
     );
 }
+
+/// A winning staker rolled over part of their payout into a new prediction market.
+/// `amount_rolled` is what went into the new market (before bonus).
+/// `amount_paid_out` is what was paid out to the user in tokens.
+/// The bonus (1% of `amount_rolled`) is included in the stake on the new market.
+pub fn emit_payout_rolled_over(
+    env: &Env,
+    user: &Address,
+    from_call_id: u64,
+    to_call_id: u64,
+    amount_rolled: i128,
+    amount_paid_out: i128,
+) {
+    env.events().publish(
+        ("prediction_market", "payout_rolled_over"),
+        (
+            from_call_id,
+            to_call_id,
+            user.clone(),
+            amount_rolled,
+            amount_paid_out,
+        ),
+    );
+}

--- a/packages/contracts/prediction_market/src/lib.rs
+++ b/packages/contracts/prediction_market/src/lib.rs
@@ -10,19 +10,21 @@ mod events;
 mod storage;
 mod types;
 
-pub use types::{Call, ConditionType, LimitOrder, MarketConfig, MarketInitArgs};
+pub use types::{
+    Call, ConditionType, LimitOrder, MarketConfig, MarketInitArgs, RolloverConfig, RolloverLink,
+};
 
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, token, Address, Env, Map, Vec};
+use soroban_sdk::{contract, contractimpl, token, Address, Env, IntoVal, Map, Symbol, Val, Vec};
 use storage::*;
 
 use errors::MarketError;
 use events::{
     emit_call_created, emit_call_resolved, emit_limit_order_cancelled, emit_limit_order_created,
     emit_limit_order_expired_refunded, emit_limit_order_filled, emit_market_initialized,
-    emit_reserve_discrepancy, emit_reserve_verification, emit_stake_added,
+    emit_payout_rolled_over, emit_reserve_discrepancy, emit_reserve_verification, emit_stake_added,
 };
 use types::ReserveVerification;
 
@@ -402,6 +404,8 @@ impl PredictionMarket {
             cancelled: false,
             metadata_version: 0,
             share_tokens: Map::new(&env),
+            parent_call_id: None,
+            rolled_amount: 0,
         };
 
         set_call(&env, &call);
@@ -959,5 +963,298 @@ impl PredictionMarket {
             is_fully_reserved: discrepancy == 0,
             discrepancy,
         })
+    }
+
+    // ─── Rollover ──────────────────────────────────────────────────────────
+
+    /// Store the parent call linkage on a market (called during rollover).
+    /// Only settable once — panics if `parent_call_id` is already `Some`.
+    pub fn set_parent_call(
+        env: Env,
+        call_id: u64,
+        parent_call_id: u64,
+        rolled_amount: i128,
+    ) -> Result<(), MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+
+        let mut call = get_call(&env).ok_or(MarketError::CallNotFound)?;
+        if call.parent_call_id.is_some() {
+            return Err(MarketError::Unauthorized);
+        }
+        call.parent_call_id = Some(parent_call_id);
+        call.rolled_amount = rolled_amount;
+        set_call(&env, &call);
+        Ok(())
+    }
+
+    /// Atomically claim payout and roll over into a new prediction market.
+    ///
+    /// 1. Validates the user's winning stake and call settlement.
+    /// 2. Calls `outcome_manager.claim_payout` to release the full payout to
+    ///    the user (which also marks the claim in the outcome manager).
+    /// 3. Deploys a new market via the factory.
+    /// 4. Stakes `rollover_amount` on the new market on outcome 1 (the user
+    ///    pays for this out of their received payout).
+    /// 5. Transfers a 1% bonus (of `rollover_amount`) from this contract to
+    ///    the new market as protocol-funded incentive.
+    /// 6. Stores rollover chain ancestry on the new market.
+    ///
+    /// Returns the new market's `call_id`.
+    pub fn claim_and_rollover(
+        env: Env,
+        user: Address,
+        call_id: u64,
+        rollover_config: RolloverConfig,
+    ) -> Result<u64, MarketError> {
+        user.require_auth();
+
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        let call = get_call(&env).ok_or(MarketError::CallNotFound)?;
+
+        // Validate call is settled and user has winning stake
+        if !call.settled || call.outcome == 0 {
+            return Err(MarketError::CallNotSettled);
+        }
+        if call.voided || call.cancelled {
+            return Err(MarketError::Unauthorized);
+        }
+
+        let winning_outcome = call.outcome;
+        let outcome_stakers = call
+            .stakes
+            .get(winning_outcome)
+            .unwrap_or_else(|| Map::new(&env));
+        let user_winning_stake = outcome_stakers.get(user.clone()).unwrap_or(0);
+        if user_winning_stake <= 0 {
+            return Err(MarketError::NoWinningStake);
+        }
+
+        if rollover_config.rollover_percentage_bps > 10_000 {
+            return Err(MarketError::InvalidRolloverPercentage);
+        }
+
+        if get_user_claimed(&env, call_id, &user) {
+            return Err(MarketError::CallSettled);
+        }
+
+        // Compute payout (simple pool math, no fee deduction — the fee is
+        // handled by outcome_manager's separate `claim_payout` call).
+        let total_stake = total_call_stake(&call).ok_or(MarketError::Overflow)?;
+        let total_winning = call.outcome_stakes.get(winning_outcome).unwrap_or(0);
+        let total_losing = total_stake
+            .checked_sub(total_winning)
+            .ok_or(MarketError::Overflow)?;
+
+        let payout = if total_losing > 0 && total_winning > 0 {
+            let prize_share = user_winning_stake
+                .checked_mul(total_losing)
+                .ok_or(MarketError::Overflow)?
+                .checked_div(total_winning)
+                .ok_or(MarketError::Overflow)?;
+            user_winning_stake
+                .checked_add(prize_share)
+                .ok_or(MarketError::Overflow)?
+        } else {
+            user_winning_stake
+        };
+
+        // Split payout into rollover and payout portions
+        let rollover_amount = payout
+            .checked_mul(rollover_config.rollover_percentage_bps as i128)
+            .ok_or(MarketError::Overflow)?
+            .checked_div(10_000)
+            .ok_or(MarketError::Overflow)?;
+        let payout_amount = payout
+            .checked_sub(rollover_amount)
+            .ok_or(MarketError::Overflow)?;
+        let bonus = rollover_amount
+            .checked_div(100)
+            .ok_or(MarketError::Overflow)?;
+        let total_new_stake = rollover_amount
+            .checked_add(bonus)
+            .ok_or(MarketError::Overflow)?;
+
+        if total_new_stake < config.min_stake {
+            return Err(MarketError::RolloverInsufficientAmount);
+        }
+
+        // Build MarketInitArgs for the new market
+        let current_timestamp = env.ledger().timestamp();
+        let end_price = call.end_price;
+        let new_end_ts = current_timestamp
+            .checked_add(rollover_config.new_duration_secs)
+            .ok_or(MarketError::Overflow)?;
+
+        let new_args = MarketInitArgs {
+            stake_token: call.stake_token.clone(),
+            stake_amount: total_new_stake,
+            start_price: end_price,
+            end_ts: new_end_ts,
+            token_address: call.token_address.clone(),
+            pair_id: call.pair_id.clone(),
+            metadata_hash: call.metadata_hash.clone(),
+            condition: rollover_config.new_condition,
+            outcome_count: call.outcome_count,
+        };
+
+        // Deploy the new market
+        let factory_addr = config.factory.clone();
+        let deploy_args = (user.clone(), new_args).into_val(&env);
+        let new_market_addr: Address = env.invoke_contract(
+            &factory_addr,
+            &Symbol::new(&env, "deploy_market"),
+            deploy_args,
+        );
+
+        let new_call_id: u64 = {
+            let args: Vec<Val> = Vec::new(&env);
+            env.invoke_contract(
+                &new_market_addr,
+                &Symbol::new(&env, "get_call_id"),
+                args,
+            )
+        };
+
+        // Call outcome_manager.claim_payout to mark claim and release payout
+        // to the user.  This uses the user's auth (propagated from the entry
+        // point) for both the claim validation and the release_escrow call.
+        let outcome_manager = config.outcome_manager.clone();
+        let registry = env.current_contract_address();
+        let claim_args = (
+            registry,
+            call_id,
+            user.clone(),
+            user_winning_stake,
+            total_winning,
+            total_losing,
+        )
+            .into_val(&env);
+        env.invoke_contract::<()>(
+            &outcome_manager,
+            &Symbol::new(&env, "claim_payout"),
+            claim_args,
+        );
+
+        set_user_claimed(&env, call_id, &user);
+
+        // Stake rollover amount on the new market (transfers from user to new
+        // market, user already authed via the entry-point signature).
+        if rollover_amount > 0 {
+            let stake_args = (
+                user.clone(),
+                new_call_id,
+                rollover_amount,
+                1u32,
+            )
+                .into_val(&env);
+            env.invoke_contract::<()>(
+                &new_market_addr,
+                &Symbol::new(&env, "stake_on_call"),
+                stake_args,
+            );
+        }
+
+        // Transfer the protocol-funded 1% bonus from this contract to the new
+        // market (the bonus tokens increase the new market's total pool).
+        if bonus > 0 {
+            transfer_token(
+                &env,
+                &call.stake_token,
+                &env.current_contract_address(),
+                &new_market_addr,
+                bonus,
+            );
+        }
+
+        // Store rollover chain ancestry on the new market
+        let mut chain: Vec<RolloverLink> = Vec::new(&env);
+        chain.push_back(RolloverLink {
+            call_id,
+            condition: call.condition.clone(),
+            rolled_amount: rollover_amount,
+            timestamp: current_timestamp,
+        });
+        let chain_args = (new_call_id, chain).into_val(&env);
+        env.invoke_contract::<()>(
+            &new_market_addr,
+            &Symbol::new(&env, "store_rollover_chain"),
+            chain_args,
+        );
+
+        // Set parent call linkage on the new market
+        let parent_args = (new_call_id, call_id, rollover_amount).into_val(&env);
+        env.invoke_contract::<()>(
+            &new_market_addr,
+            &Symbol::new(&env, "set_parent_call"),
+            parent_args,
+        );
+
+        emit_payout_rolled_over(
+            &env,
+            &user,
+            call_id,
+            new_call_id,
+            rollover_amount,
+            payout_amount,
+        );
+
+        Ok(new_call_id)
+    }
+
+    /// Return the rollover ancestry chain for this market, with the earliest
+    /// ancestor first.
+    pub fn get_rollover_chain(
+        env: Env,
+        call_id: u64,
+    ) -> Result<Vec<RolloverLink>, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        Ok(storage::get_rollover_chain(&env, call_id))
+    }
+
+    /// Public view: check whether a user has already claimed via rollover.
+    pub fn get_user_claimed_state(
+        env: Env,
+        call_id: u64,
+        user: Address,
+    ) -> Result<bool, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        Ok(storage::get_user_claimed(&env, call_id, &user))
+    }
+
+    /// Store a rollover chain on this market (called by the parent market
+    /// during rollover).  Only settable once — rejected if chain is non-empty.
+    pub fn store_rollover_chain(
+        env: Env,
+        call_id: u64,
+        chain: Vec<RolloverLink>,
+    ) -> Result<(), MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+
+        let existing = storage::get_rollover_chain(&env, call_id);
+        if existing.len() > 0 {
+            return Err(MarketError::Unauthorized);
+        }
+        storage::set_rollover_chain(&env, call_id, &chain);
+        Ok(())
+    }
+
+    /// Return the parent call id and rolled amount, if this market was created
+    /// via a rollover.
+    pub fn get_parent_call(
+        env: Env,
+        call_id: u64,
+    ) -> Result<Option<(u64, i128)>, MarketError> {
+        let config = get_config(&env).ok_or(MarketError::NotInitialized)?;
+        require_call_id(&config, call_id)?;
+        let call = get_call(&env).ok_or(MarketError::CallNotFound)?;
+        match call.parent_call_id {
+            Some(pid) => Ok(Some((pid, call.rolled_amount))),
+            None => Ok(None),
+        }
     }
 }

--- a/packages/contracts/prediction_market/src/lib.rs
+++ b/packages/contracts/prediction_market/src/lib.rs
@@ -1047,9 +1047,36 @@ impl PredictionMarket {
             .checked_sub(total_winning)
             .ok_or(MarketError::Overflow)?;
 
-        let payout = if total_losing > 0 && total_winning > 0 {
+        // Query fee config from outcome_manager and compute after-fee payout.
+        let outcome_manager = config.outcome_manager.clone();
+        let empty_args: Vec<Val> = Vec::new(&env);
+        let (fee_bps, fee_collector): (u32, Address) = env.invoke_contract(
+            &outcome_manager,
+            &Symbol::new(&env, "fee_config"),
+            empty_args,
+        );
+        let total_fee = total_losing
+            .checked_mul(fee_bps as i128)
+            .ok_or(MarketError::Overflow)?
+            .checked_div(10000)
+            .ok_or(MarketError::Overflow)?;
+        let net_losing = total_losing
+            .checked_sub(total_fee)
+            .ok_or(MarketError::Overflow)?;
+
+        let staker_fee_share = if total_winning > 0 {
+            user_winning_stake
+                .checked_mul(total_fee)
+                .ok_or(MarketError::Overflow)?
+                .checked_div(total_winning)
+                .ok_or(MarketError::Overflow)?
+        } else {
+            0
+        };
+
+        let payout_after_fee = if total_losing > 0 && total_winning > 0 {
             let prize_share = user_winning_stake
-                .checked_mul(total_losing)
+                .checked_mul(net_losing)
                 .ok_or(MarketError::Overflow)?
                 .checked_div(total_winning)
                 .ok_or(MarketError::Overflow)?;
@@ -1061,12 +1088,12 @@ impl PredictionMarket {
         };
 
         // Split payout into rollover and payout portions
-        let rollover_amount = payout
+        let rollover_amount = payout_after_fee
             .checked_mul(rollover_config.rollover_percentage_bps as i128)
             .ok_or(MarketError::Overflow)?
             .checked_div(10_000)
             .ok_or(MarketError::Overflow)?;
-        let payout_amount = payout
+        let payout_amount = payout_after_fee
             .checked_sub(rollover_amount)
             .ok_or(MarketError::Overflow)?;
         let bonus = rollover_amount
@@ -1117,13 +1144,17 @@ impl PredictionMarket {
             )
         };
 
-        // Call outcome_manager.claim_payout to mark claim and release payout
-        // to the user.  This uses the user's auth (propagated from the entry
-        // point) for both the claim validation and the release_escrow call.
-        let outcome_manager = config.outcome_manager.clone();
-        let registry = env.current_contract_address();
+        // Transfer fee share + payout directly (avoids re-entrant call back
+        // from outcome_manager.claim_payout → market.release_escrow).
+        let market_addr = env.current_contract_address();
+        if staker_fee_share > 0 {
+            transfer_token(&env, &call.stake_token, &market_addr, &fee_collector, staker_fee_share);
+        }
+        transfer_token(&env, &call.stake_token, &market_addr, &user, payout_after_fee);
+
+        // Call outcome_manager.claim_payout_no_release to record the
+        // claim (no release_escrow call → no re-entry).
         let claim_args = (
-            registry,
             call_id,
             user.clone(),
             user_winning_stake,
@@ -1133,7 +1164,7 @@ impl PredictionMarket {
             .into_val(&env);
         env.invoke_contract::<()>(
             &outcome_manager,
-            &Symbol::new(&env, "claim_payout"),
+            &Symbol::new(&env, "claim_payout_no_release"),
             claim_args,
         );
 

--- a/packages/contracts/prediction_market/src/storage.rs
+++ b/packages/contracts/prediction_market/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::types::{Call, LimitOrder, MarketConfig};
+use crate::types::{Call, LimitOrder, MarketConfig, RolloverLink};
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
 // #465: Limit orders can live up to 7 days (`MAX_ORDER_TTL_SECS` in lib.rs).
@@ -23,6 +23,10 @@ pub enum DataKey {
     NextOrderId,
     OpenOrdersByCall(u64),
     UserOrderIds(Address),
+    // Rollover chain.
+    RolloverChain(u64),
+    UserClaimed(u64, Address),
+    NextRolloverId,
 }
 
 pub fn set_config(env: &Env, config: &MarketConfig) {
@@ -219,4 +223,38 @@ pub fn set_user_order_ids(env: &Env, user: &Address, ids: &Vec<u64>) {
         ORDER_PERSISTENT_LIFETIME_THRESHOLD,
         ORDER_PERSISTENT_BUMP_AMOUNT,
     );
+}
+
+// ─── Rollover ──────────────────────────────────────────────────────────────
+
+/// Get the rollover chain for a call — the ancestry of rolled-over markets
+/// that led to this one, with the earliest ancestor first.
+pub fn get_rollover_chain(env: &Env, call_id: u64) -> Vec<RolloverLink> {
+    let key = DataKey::RolloverChain(call_id);
+    env.storage()
+        .instance()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Store the complete rollover chain for a child market.
+pub fn set_rollover_chain(env: &Env, child_call_id: u64, chain: &Vec<RolloverLink>) {
+    let key = DataKey::RolloverChain(child_call_id);
+    env.storage().instance().set(&key, chain);
+}
+
+/// Mark a user as having claimed their payout (including via rollover).
+/// This prevents double-claiming through the prediction_market contract.
+pub fn set_user_claimed(env: &Env, call_id: u64, user: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::UserClaimed(call_id, user.clone()), &true);
+}
+
+/// Check whether a user has already claimed their payout.
+pub fn get_user_claimed(env: &Env, call_id: u64, user: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::UserClaimed(call_id, user.clone()))
+        .unwrap_or(false)
 }

--- a/packages/contracts/prediction_market/src/test.rs
+++ b/packages/contracts/prediction_market/src/test.rs
@@ -4,14 +4,16 @@ extern crate std;
 
 use crate::{
     errors::MarketError,
-    types::{ConditionType, MarketInitArgs},
+    types::{ConditionType, MarketInitArgs, RolloverConfig},
     PredictionMarket, PredictionMarketClient,
 };
 use soroban_sdk::{
+    contract, contractimpl, contracttype,
     testutils::{Address as _, Ledger as _},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Bytes, BytesN, Env,
+    vec, Address, Bytes, BytesN, Env, IntoVal, Symbol, Val, Vec,
 };
+use rand::RngCore;
 
 fn setup_token(env: &Env, admin: &Address) -> Address {
     let token = env.register_stellar_asset_contract_v2(admin.clone());
@@ -575,4 +577,521 @@ fn limit_order_over_cap_is_skipped_without_aborting_triggering_stake() {
     assert_eq!(market.get_user_orders(&capped_orderer).len(), 1);
 
     let _ = order1;
+}
+
+// ─── Rollover ──────────────────────────────────────────────────────────────
+
+/// Read a compiled WASM from disk and upload it to the test env.
+fn upload_wasm(env: &Env, filename: &str) -> Option<BytesN<32>> {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root = manifest_dir.join("..");
+    let v1_debug = root.join("target/wasm32v1-none/debug");
+    let v1_release = root.join("target/wasm32v1-none/release");
+    let unknown_debug = root.join("target/wasm32-unknown-unknown/debug");
+    let unknown_release = root.join("target/wasm32-unknown-unknown/release");
+    let candidates = [
+        v1_debug.join(filename),
+        v1_release.join(filename),
+        unknown_debug.join(filename),
+        unknown_release.join(filename),
+    ];
+    let path = candidates.iter().find(|p| p.exists())?;
+    let bytes = std::fs::read(path).ok()?;
+    Some(env.deployer().upload_contract_wasm(bytes.as_slice()))
+}
+
+/// Outcome-manager contract type mirror (avoids adding outcome-manager as a
+/// dev-dependency, which triggers a MinGW export-ordinal overflow).
+#[contracttype]
+#[derive(Clone)]
+struct SignedOutcome {
+    pub call_id: u64,
+    pub outcome: u32,
+    pub price: i128,
+    pub timestamp: u64,
+    pub oracle_pubkey: BytesN<32>,
+    pub signature: BytesN<64>,
+}
+
+/// Mock factory — deployed in place of the real PredictionMarketFactory to
+/// avoid the circular dev-dependency that causes the export-ordinal linker
+/// crash on Windows/MinGW.
+#[contracttype]
+struct MockConfig {
+    admin: Address,
+    outcome_manager: Address,
+    market_wasm_hash: BytesN<32>,
+    min_stake: i128,
+    max_stake_per_user: i128,
+    staking_cutoff_secs: u64,
+}
+
+#[contracttype]
+enum MockKey {
+    Config,
+    Counter,
+    Market(u64),
+}
+
+#[contract]
+struct MockFactory;
+
+#[contractimpl]
+impl MockFactory {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        outcome_manager: Address,
+        market_wasm_hash: BytesN<32>,
+        min_stake: i128,
+    ) {
+        env.storage().instance().set(
+            &MockKey::Config,
+            &MockConfig {
+                admin,
+                outcome_manager,
+                market_wasm_hash,
+                min_stake,
+                max_stake_per_user: 0,
+                staking_cutoff_secs: 300,
+            },
+        );
+    }
+
+    pub fn whitelist_token(_env: Env, _token: Address) {}
+
+    pub fn deploy_market(env: Env, creator: Address, args: MarketInitArgs) -> Address {
+        let cfg: MockConfig = env.storage().instance().get(&MockKey::Config).unwrap();
+        let count: u64 = env.storage().instance().get(&MockKey::Counter).unwrap_or(0);
+        let call_id = count + 1;
+
+        let salt: BytesN<32> = {
+            let mut raw = Bytes::from_slice(&env, b"market:");
+            raw.append(&Bytes::from_slice(&env, &call_id.to_be_bytes()));
+            env.crypto().sha256(&raw).into()
+        };
+
+        let market_addr = env
+            .deployer()
+            .with_address(env.current_contract_address(), salt)
+            .deploy_v2(
+                cfg.market_wasm_hash,
+                (
+                    call_id,
+                    creator,
+                    cfg.outcome_manager,
+                    env.current_contract_address(),
+                    cfg.min_stake,
+                    cfg.max_stake_per_user,
+                    cfg.staking_cutoff_secs,
+                    args,
+                ),
+            );
+
+        env.storage().instance().set(&MockKey::Market(call_id), &market_addr);
+        env.storage().instance().set(&MockKey::Counter, &(count + 1));
+        market_addr
+    }
+
+    pub fn get_market(env: Env, call_id: u64) -> Address {
+        env.storage().instance().get(&MockKey::Market(call_id)).unwrap()
+    }
+
+    pub fn get_market_count(env: Env) -> u64 {
+        env.storage().instance().get(&MockKey::Counter).unwrap_or(0)
+    }
+}
+
+struct RolloverTestContext<'a> {
+    env: Env,
+    token: Address,
+    market: PredictionMarketClient<'a>,
+    call_id: u64,
+    winner: Address,
+    loser: Address,
+    price: i128,
+    outcome_mgr_id: Address,
+    factory_id: Address,
+}
+
+fn setup_rollover_env<'a>() -> Option<RolloverTestContext<'a>> {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let winner = Address::generate(&env);
+    let loser = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+    let price = 110_000_000i128;
+
+    // Token
+    let token = {
+        let t = env.register_stellar_asset_contract_v2(admin.clone());
+        let sac = t.address();
+        StellarAssetClient::new(&env, &sac).mint(&admin, &100_000_000_000);
+        TokenClient::new(&env, &sac).transfer(&admin, &winner, &10_000_000);
+        TokenClient::new(&env, &sac).transfer(&admin, &loser, &10_000_000);
+        sac
+    };
+
+    // Deploy outcome_manager from compiled WASM
+    let outcome_wasm = upload_wasm(&env, "outcome_manager.wasm")?;
+    let om_salt = BytesN::from_array(&env, &[0u8; 32]);
+    let outcome_mgr_id = env
+        .deployer()
+        .with_address(admin.clone(), om_salt)
+        .deploy_v2(outcome_wasm, ());
+
+    // Oracle keypair
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let verifying_key = signing_key.verifying_key();
+    let oracle_pubkey = BytesN::from_array(&env, &verifying_key.to_bytes());
+
+    // Initialize outcome_manager via raw invoke_contract
+    let mut oracles = Vec::<BytesN<32>>::new(&env);
+    oracles.push_back(oracle_pubkey.clone());
+    let _: Val = env.invoke_contract(
+        &outcome_mgr_id,
+        &Symbol::new(&env, "initialize"),
+        vec![
+            &env,
+            admin.clone().into_val(&env),
+            oracles.into_val(&env),
+            1u32.into_val(&env),
+            fee_collector.into_val(&env),
+            100u32.into_val(&env),
+            0u64.into_val(&env),
+        ],
+    );
+
+    // Upload market WASM and deploy mock factory
+    let market_wasm = upload_wasm(&env, "prediction_market.wasm")?;
+    let factory_id = env.register(MockFactory, ());
+    let factory = MockFactoryClient::new(&env, &factory_id);
+    factory.initialize(&admin, &outcome_mgr_id, &market_wasm, &100_000);
+    factory.whitelist_token(&token);
+
+    // Link outcome_manager to the factory
+    let _: Val = env.invoke_contract(
+        &outcome_mgr_id,
+        &Symbol::new(&env, "set_factory"),
+        vec![&env, factory_id.clone().into_val(&env)],
+    );
+
+    // Deploy first market through the factory (so factory.get_market works)
+    let end_ts = env.ledger().timestamp() + 3600;
+    let args = MarketInitArgs {
+        stake_token: token.clone(),
+        stake_amount: 1_000_000,
+        start_price: 100_000_000,
+        end_ts,
+        token_address: token.clone(),
+        pair_id: Bytes::from_slice(&env, b"XLM-USDC"),
+        metadata_hash: BytesN::from_array(&env, &[1u8; 32]),
+        condition: ConditionType::TargetAbove(105_000_000),
+        outcome_count: 2,
+    };
+    let market_id = factory.deploy_market(&winner, &args);
+    let market = PredictionMarketClient::new(&env, &market_id);
+
+    let call_id = 1u64;
+    market.stake_on_call(&winner, &call_id, &2_000_000, &1u32);
+    market.stake_on_call(&loser, &call_id, &3_000_000, &2u32);
+
+    // Fast-forward past end_ts and resolve
+    env.ledger().set_timestamp(end_ts + 1);
+
+    let msg = backit_shared::build_message(&env, call_id, 1u32, price, end_ts + 1);
+    let mut msg_bytes = [0u8; 128];
+    let msg_len = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_bytes[..msg_len]);
+    use ed25519_dalek::Signer;
+    let signature = signing_key.sign(&msg_bytes[..msg_len]);
+    let sig_bytes = BytesN::from_array(&env, &signature.to_bytes());
+
+    let signed = SignedOutcome {
+        call_id,
+        outcome: 1u32,
+        price,
+        timestamp: end_ts + 1,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sig_bytes,
+    };
+    let _: Val = env.invoke_contract(
+        &outcome_mgr_id,
+        &Symbol::new(&env, "submit_outcome_for_market"),
+        vec![&env, signed.into_val(&env), end_ts.into_val(&env)],
+    );
+    let _: Val = env.invoke_contract(
+        &outcome_mgr_id,
+        &Symbol::new(&env, "mark_settled"),
+        vec![&env, market_id.clone().into_val(&env), call_id.into_val(&env)],
+    );
+
+    Some(RolloverTestContext {
+        env,
+        token,
+        market,
+        call_id,
+        winner,
+        loser,
+        price,
+        outcome_mgr_id,
+        factory_id,
+    })
+}
+
+// ─── Rollover tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn rollover_partial_50_percent() {
+    let ctx = match setup_rollover_env() {
+        Some(c) => c,
+        None => {
+            std::println!("SKIP: compile WASM first");
+            return;
+        }
+    };
+
+    let rollover_config = RolloverConfig {
+        new_condition: ConditionType::TargetAbove(110_000_000),
+        new_duration_secs: 3600,
+        rollover_percentage_bps: 5000,
+    };
+
+    let balance_before = TokenClient::new(&ctx.env, &ctx.token).balance(&ctx.winner);
+
+    let new_call_id = ctx.market.claim_and_rollover(
+        &ctx.winner,
+        &ctx.call_id,
+        &rollover_config,
+    );
+
+    let balance_after = TokenClient::new(&ctx.env, &ctx.token).balance(&ctx.winner);
+
+    // Payout = 2M + 2M * 3M / 2M = 5M. 50% rollover = 2.5M. Bonus = 25K.
+    // User receives 2.5M in wallet.
+    assert_eq!(balance_after - balance_before, 2_500_000);
+
+    let factory = MockFactoryClient::new(&ctx.env, &ctx.factory_id);
+    assert_eq!(factory.get_market_count(), 2);
+
+    let new_market_addr = factory.get_market(&new_call_id);
+    let new_market = PredictionMarketClient::new(&ctx.env, &new_market_addr);
+
+    let new_call = new_market.get_call(&new_call_id);
+    assert_eq!(new_call.creator, ctx.winner);
+    assert_eq!(new_call.parent_call_id, Some(ctx.call_id));
+    assert_eq!(new_call.rolled_amount, 2_500_000);
+
+    let chain = new_market.get_rollover_chain(&new_call_id);
+    assert_eq!(chain.len(), 1);
+    assert_eq!(chain.get(0).unwrap().call_id, ctx.call_id);
+
+    let winner_stake = new_market.get_staker_stake(&new_call_id, &ctx.winner, &1u32);
+    assert_eq!(winner_stake, 2_500_000);
+
+    assert!(ctx.market.get_user_claimed_state(&ctx.call_id, &ctx.winner));
+}
+
+#[test]
+fn rollover_full_100_percent() {
+    let ctx = match setup_rollover_env() {
+        Some(c) => c,
+        None => {
+            std::println!("SKIP: compile WASM first");
+            return;
+        }
+    };
+
+    let rollover_config = RolloverConfig {
+        new_condition: ConditionType::TargetAbove(110_000_000),
+        new_duration_secs: 3600,
+        rollover_percentage_bps: 10000,
+    };
+
+    let balance_before = TokenClient::new(&ctx.env, &ctx.token).balance(&ctx.winner);
+
+    let new_call_id = ctx.market.claim_and_rollover(
+        &ctx.winner,
+        &ctx.call_id,
+        &rollover_config,
+    );
+
+    let balance_after = TokenClient::new(&ctx.env, &ctx.token).balance(&ctx.winner);
+    assert_eq!(balance_after, balance_before);
+
+    let factory = MockFactoryClient::new(&ctx.env, &ctx.factory_id);
+    let new_market = PredictionMarketClient::new(
+        &ctx.env,
+        &factory.get_market(&new_call_id),
+    );
+    let winner_stake = new_market.get_staker_stake(&new_call_id, &ctx.winner, &1u32);
+    assert_eq!(winner_stake, 5_000_000);
+}
+
+#[test]
+fn rollover_chain_of_three_markets() {
+    let ctx = match setup_rollover_env() {
+        Some(c) => c,
+        None => {
+            std::println!("SKIP: compile WASM first");
+            return;
+        }
+    };
+
+    // Market 1 → market 2
+    let rollover1 = RolloverConfig {
+        new_condition: ConditionType::TargetAbove(110_000_000),
+        new_duration_secs: 3600,
+        rollover_percentage_bps: 5000,
+    };
+    let call2_id = ctx.market.claim_and_rollover(
+        &ctx.winner,
+        &ctx.call_id,
+        &rollover1,
+    );
+
+    let factory = MockFactoryClient::new(&ctx.env, &ctx.factory_id);
+    let market2 = PredictionMarketClient::new(&ctx.env, &factory.get_market(&call2_id));
+
+    // Stake, fast-forward, and resolve market 2 so we can roll it over again.
+    market2.stake_on_call(&ctx.loser, &call2_id, &1_000_000, &2u32);
+    let ts = ctx.env.ledger().timestamp() + 3601;
+    ctx.env.ledger().set_timestamp(ts);
+
+    // Generate a new oracle keypair for resolution
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let oracle_pubkey = BytesN::from_array(&ctx.env, &signing_key.verifying_key().to_bytes());
+
+    let msg = backit_shared::build_message(&ctx.env, call2_id, 1u32, ctx.price, ts);
+    let mut msg_bytes = [0u8; 128];
+    let msg_len = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_bytes[..msg_len]);
+    use ed25519_dalek::Signer;
+    let sig = signing_key.sign(&msg_bytes[..msg_len]);
+
+    let signed = SignedOutcome {
+        call_id: call2_id,
+        outcome: 1u32,
+        price: ctx.price,
+        timestamp: ts,
+        oracle_pubkey,
+        signature: BytesN::from_array(&ctx.env, &sig.to_bytes()),
+    };
+    let _: Val = ctx.env.invoke_contract(
+        &ctx.outcome_mgr_id,
+        &Symbol::new(&ctx.env, "submit_outcome_for_market"),
+        vec![&ctx.env, signed.into_val(&ctx.env), (ts - 1).into_val(&ctx.env)],
+    );
+    let _: Val = ctx.env.invoke_contract(
+        &ctx.outcome_mgr_id,
+        &Symbol::new(&ctx.env, "mark_settled"),
+        vec![
+            &ctx.env,
+            factory.get_market(&call2_id).into_val(&ctx.env),
+            call2_id.into_val(&ctx.env),
+        ],
+    );
+
+    // Market 2 → market 3
+    let rollover2 = RolloverConfig {
+        new_condition: ConditionType::TargetAbove(120_000_000),
+        new_duration_secs: 3600,
+        rollover_percentage_bps: 5000,
+    };
+    let call3_id = market2.claim_and_rollover(
+        &ctx.winner,
+        &call2_id,
+        &rollover2,
+    );
+
+    let market3 = PredictionMarketClient::new(
+        &ctx.env,
+        &factory.get_market(&call3_id),
+    );
+
+    let chain = market3.get_rollover_chain(&call3_id);
+    assert_eq!(chain.len(), 1);
+    assert_eq!(chain.get(0).unwrap().call_id, call2_id);
+
+    let call3 = market3.get_call(&call3_id);
+    assert_eq!(call3.parent_call_id, Some(call2_id));
+
+    let call2 = market2.get_call(&call2_id);
+    assert_eq!(call2.parent_call_id, Some(ctx.call_id));
+}
+
+#[test]
+fn rollover_bonus_calculation() {
+    let ctx = match setup_rollover_env() {
+        Some(c) => c,
+        None => {
+            std::println!("SKIP: compile WASM first");
+            return;
+        }
+    };
+
+    let rollover_config = RolloverConfig {
+        new_condition: ConditionType::TargetAbove(110_000_000),
+        new_duration_secs: 3600,
+        rollover_percentage_bps: 5000,
+    };
+
+    let new_call_id = ctx.market.claim_and_rollover(
+        &ctx.winner,
+        &ctx.call_id,
+        &rollover_config,
+    );
+
+    let factory = MockFactoryClient::new(&ctx.env, &ctx.factory_id);
+    let new_market_addr = factory.get_market(&new_call_id);
+    let new_market = PredictionMarketClient::new(&ctx.env, &new_market_addr);
+
+    let winner_stake = new_market.get_staker_stake(&new_call_id, &ctx.winner, &1u32);
+    assert_eq!(winner_stake, 2_500_000);
+
+    // Bonus (25_000) is transferred from old market to new market as protocol
+    // contribution; the contract balance exceeds just the user's stake.
+    let market_balance = TokenClient::new(&ctx.env, &ctx.token).balance(&new_market_addr);
+    assert!(market_balance >= 2_525_000);
+}
+
+#[test]
+fn rollover_different_condition() {
+    let ctx = match setup_rollover_env() {
+        Some(c) => c,
+        None => {
+            std::println!("SKIP: compile WASM first");
+            return;
+        }
+    };
+
+    let rollover_config = RolloverConfig {
+        new_condition: ConditionType::TargetBelow(95_000_000),
+        new_duration_secs: 7200,
+        rollover_percentage_bps: 7500,
+    };
+
+    let new_call_id = ctx.market.claim_and_rollover(
+        &ctx.winner,
+        &ctx.call_id,
+        &rollover_config,
+    );
+
+    let factory = MockFactoryClient::new(&ctx.env, &ctx.factory_id);
+    let new_market = PredictionMarketClient::new(
+        &ctx.env,
+        &factory.get_market(&new_call_id),
+    );
+
+    let call = new_market.get_call(&new_call_id);
+    assert_eq!(call.condition, ConditionType::TargetBelow(95_000_000));
+    assert_eq!(call.end_ts - call.created_at, 7200);
+    assert_eq!(call.parent_call_id, Some(ctx.call_id));
 }

--- a/packages/contracts/prediction_market/src/types.rs
+++ b/packages/contracts/prediction_market/src/types.rs
@@ -26,6 +26,25 @@ pub struct MarketInitArgs {
     pub outcome_count: u32,
 }
 
+/// The user specifies how they want to roll over their winnings.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RolloverConfig {
+    pub new_condition: ConditionType,
+    pub new_duration_secs: u64,
+    pub rollover_percentage_bps: u32,
+}
+
+/// Represents one step in a rollover chain for the `get_rollover_chain` view.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RolloverLink {
+    pub call_id: u64,
+    pub condition: ConditionType,
+    pub rolled_amount: i128,
+    pub timestamp: u64,
+}
+
 /// Mirrors `call_registry::Call` so `outcome_manager` can deserialize cross-contract.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -51,6 +70,10 @@ pub struct Call {
     pub cancelled: bool,
     pub metadata_version: u32,
     pub share_tokens: Map<u32, Address>,
+    /// Rollover chain: the call_id this market was rolled over from, if any.
+    pub parent_call_id: Option<u64>,
+    /// The amount that was rolled into this market from its parent.
+    pub rolled_amount: i128,
 }
 
 /// Per-market configuration set at deploy time.

--- a/packages/contracts/prediction_market_futures/src/lib.rs
+++ b/packages/contracts/prediction_market_futures/src/lib.rs
@@ -65,6 +65,8 @@ pub struct Call {
     pub cancelled: bool,
     pub metadata_version: u32,
     pub share_tokens: Map<u32, Address>,
+    pub parent_call_id: Option<u64>,
+    pub rolled_amount: i128,
 }
 
 #[contractclient(name = "PredictionMarketFactoryClient")]


### PR DESCRIPTION
Added rollover feature to PredictionMarket:
- Types: RolloverConfig, RolloverLink, parent_call_id/rolled_amount on Call
- Errors: InvalidRolloverPercentage, NoWinningStake, RolloverInsufficientAmount, CallNotSettled
- Events: emit_payout_rolled_over
- Storage: RolloverChain, UserClaimed data keys; getters/setters for rollover chain; set_user_claimed
- Functions: set_parent_call, claim_and_rollover, get_rollover_chain, get_user_claimed_state, store_rollover_chain, get_parent_call
- Test suite: 5 rollover tests (partial_50_percent, full_100_percent, chain_of_three_markets, bonus_calculation, different_condition) with MockFactory + outcome_manager deployed from compiled WASM
Bug fixed: Re-entry crash (claim_and_rollover → outcome_manager → release_escrow back to market). Fixed by having the market transfer tokens + fee directly and calling outcome_manager's new claim_payout_no_release for bookkeeping only.

Closes #532