### PR TITLE
feat(contracts): add multi-asset basket prediction calls

### DIFF
--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -262,6 +262,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "charity-markets"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,13 +311,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "cross_chain_oracle_relay"
-version = "0.0.0"
-dependencies = [
- "soroban-sdk",
 ]
 
 [[package]]
@@ -527,6 +528,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dutch-auction"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,13 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "governance"
-version = "0.0.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +827,14 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "index-fund"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
 
 [[package]]
 name = "indexmap"
@@ -1197,16 +1207,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "reputation-nft"
-version = "0.0.0"
-dependencies = [
- "backit-shared",
- "ed25519-dalek",
- "rand",
- "soroban-sdk",
 ]
 
 [[package]]
@@ -1790,6 +1790,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tournament"
+version = "0.0.0"
+dependencies = [
+ "backit-shared",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,16 +1971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "yield-aggregator"
-version = "0.0.0"
-dependencies = [
- "backit-shared",
- "ed25519-dalek",
- "rand",
- "soroban-sdk",
 ]
 
 [[package]]

--- a/packages/contracts/call_registry/src/errors.rs
+++ b/packages/contracts/call_registry/src/errors.rs
@@ -43,6 +43,10 @@ pub enum CallRegistryError {
     /// Raised by the reputation-weighted stake-limit calculations and any
     /// other checked-math call sites in this crate.
     Overflow = 18,
+    /// Basket call was created with zero conditions.
+    EmptyBasket = 19,
+    /// Condition type cannot be converted to a leaf condition.
+    InvalidCondition = 20,
 }
 
 /// Panics with [`CallRegistryError::Overflow`]. Shared helper for checked

--- a/packages/contracts/call_registry/src/events.rs
+++ b/packages/contracts/call_registry/src/events.rs
@@ -413,4 +413,3 @@ pub fn emit_stake_limit_updated(env: &Env, user: &Address, new_limit: i128) {
         (user.clone(), new_limit),
     );
 }
-

--- a/packages/contracts/call_registry/src/fuzz_tests.rs
+++ b/packages/contracts/call_registry/src/fuzz_tests.rs
@@ -323,9 +323,9 @@ fn test_fuzz_extreme_timestamp_near_max() {
     // Boundary timestamps: exact max, one under max, halfway through max, and 1 second in future
     let extreme_timestamps = [
         1000 + 2_592_000,       // exactly at the max duration limit
-        1000 + 2_592_000 - 1,  // one second under the limit
+        1000 + 2_592_000 - 1,   // one second under the limit
         1000 + 2_592_000 - 100, // 100 seconds under the limit
-        1000 + 2_592_000 / 2,  // halfway through the max duration
+        1000 + 2_592_000 / 2,   // halfway through the max duration
     ];
 
     for &end_ts in &extreme_timestamps {

--- a/packages/contracts/call_registry/src/lib.rs
+++ b/packages/contracts/call_registry/src/lib.rs
@@ -77,7 +77,6 @@ mod admin;
 mod duration;
 mod errors;
 mod events;
-mod withdrawal;
 #[cfg(test)]
 mod fuzz_tests;
 mod governance;
@@ -88,6 +87,7 @@ mod storage;
 #[cfg(test)]
 mod test;
 pub mod types;
+mod withdrawal;
 
 use backit_shared::{OUTCOME_DOWN, OUTCOME_UP};
 use errors::CallRegistryError;
@@ -120,28 +120,53 @@ fn build_start_price_message(env: &Env, call_id: u64, price: i128) -> Bytes {
     raw
 }
 
-fn evaluate_condition_impl(condition: &ConditionType, start_price: i128, end_price: i128) -> bool {
+fn evaluate_leaf_condition(
+    condition: &LeafConditionType,
+    start_price: i128,
+    end_price: i128,
+) -> bool {
     match condition {
-        ConditionType::TargetAbove(target) => end_price > *target,
-        ConditionType::TargetBelow(target) => end_price < *target,
-        ConditionType::PercentUp(percent) => {
+        LeafConditionType::TargetAbove(target) => end_price > *target,
+        LeafConditionType::TargetBelow(target) => end_price < *target,
+        LeafConditionType::PercentUp(percent) => {
             if start_price <= 0 {
                 return false;
             }
             end_price * 100 >= start_price * (100 + *percent as i128)
         }
-        ConditionType::PercentDown(percent) => {
+        LeafConditionType::PercentDown(percent) => {
             if start_price <= 0 {
                 return false;
             }
             end_price * 100 <= start_price * (100 - *percent as i128)
         }
-        ConditionType::Range(min, max) => {
+        LeafConditionType::Range(min, max) => {
             if min > max {
                 return false;
             }
             end_price >= *min && end_price <= *max
         }
+    }
+}
+
+fn to_leaf_condition(condition: ConditionType) -> Option<LeafConditionType> {
+    match condition {
+        ConditionType::TargetAbove(v) => Some(LeafConditionType::TargetAbove(v)),
+        ConditionType::TargetBelow(v) => Some(LeafConditionType::TargetBelow(v)),
+        ConditionType::PercentUp(v) => Some(LeafConditionType::PercentUp(v)),
+        ConditionType::PercentDown(v) => Some(LeafConditionType::PercentDown(v)),
+        ConditionType::Range(a, b) => Some(LeafConditionType::Range(a, b)),
+        ConditionType::Basket(_) => None,
+    }
+}
+
+fn evaluate_condition_impl(condition: &ConditionType, start_price: i128, end_price: i128) -> bool {
+    match condition {
+        ConditionType::Basket(_) => false,
+        other => match to_leaf_condition(other.clone()) {
+            Some(leaf) => evaluate_leaf_condition(&leaf, start_price, end_price),
+            None => false,
+        },
     }
 }
 
@@ -254,6 +279,12 @@ impl CallRegistry {
             return Err(CallRegistryError::InvalidOutcomeCount);
         }
 
+        if let ConditionType::Basket(ref basket) = condition {
+            if basket.conditions.is_empty() {
+                return Err(CallRegistryError::EmptyBasket);
+            }
+        }
+
         let current_timestamp = env.ledger().timestamp();
         if end_ts <= current_timestamp {
             return Err(CallRegistryError::InvalidEndTime);
@@ -306,6 +337,7 @@ impl CallRegistry {
             condition,
             settled: false,
             voided: false,
+            unresolvable: false,
             created_at: current_timestamp,
             cancelled: false,
             metadata_version: 0,
@@ -493,7 +525,7 @@ impl CallRegistry {
         emit_call_metadata_updated(
             &env,
             call_id,
-        &creator,
+            &creator,
             &old_hash,
             &new_metadata_hash,
             call.metadata_version,
@@ -874,6 +906,9 @@ impl CallRegistry {
         if call.voided {
             panic!("Call has been voided");
         }
+        if call.unresolvable {
+            panic!("Call is unresolvable");
+        }
 
         call.outcome = outcome;
         call.end_price = end_price;
@@ -1108,6 +1143,31 @@ impl CallRegistry {
     pub fn get_condition(env: Env, call_id: u64) -> Result<ConditionType, CallRegistryError> {
         let call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
         Ok(call.condition)
+    }
+
+    /// Return basket conditions for a call.
+    ///
+    /// For legacy single-asset calls, this returns a synthetic basket of length 1.
+    pub fn get_basket_conditions(
+        env: Env,
+        call_id: u64,
+    ) -> Result<Vec<AssetCondition>, CallRegistryError> {
+        let call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
+        match call.condition {
+            ConditionType::Basket(basket) => Ok(basket.conditions),
+            condition => {
+                let leaf =
+                    to_leaf_condition(condition).ok_or(CallRegistryError::InvalidCondition)?;
+                let mut conditions = Vec::new(&env);
+                conditions.push_back(AssetCondition {
+                    token_address: call.token_address,
+                    pair_id: call.pair_id,
+                    condition: leaf,
+                    weight_bps: 10_000,
+                });
+                Ok(conditions)
+            }
+        }
     }
 
     /// Evaluate whether price movement satisfies the supplied condition.
@@ -1408,11 +1468,7 @@ impl CallRegistry {
     /// * If the caller is not the call creator.
     /// * If any outcome has been staked on by a third party.
     /// * If the call is already settled or cancelled.
-    pub fn cancel_call(
-        env: Env,
-        creator: Address,
-        call_id: u64,
-    ) -> Result<(), CallRegistryError> {
+    pub fn cancel_call(env: Env, creator: Address, call_id: u64) -> Result<(), CallRegistryError> {
         creator.require_auth();
         reentrancy_guard!(&env);
 
@@ -1482,6 +1538,29 @@ impl CallRegistry {
         extend_storage_ttl(&env);
 
         emit_call_voided(&env, call_id, &config.admin);
+    }
+
+    /// Mark a call as unresolvable (outcome_manager only).
+    ///
+    /// Incomplete basket oracle data after the deadline triggers this path.
+    /// Unresolvable calls are also voided so all stakers can claim refunds.
+    pub fn mark_unresolvable(env: Env, call_id: u64) -> Result<Call, CallRegistryError> {
+        let config = get_config(&env).ok_or(CallRegistryError::NotInitialized)?;
+        config.outcome_manager.require_auth();
+
+        let mut call = get_call(&env, call_id).ok_or(CallRegistryError::CallNotFound)?;
+        if call.settled {
+            return Err(CallRegistryError::CallSettled);
+        }
+        if call.unresolvable {
+            panic!("Call already marked unresolvable");
+        }
+
+        call.unresolvable = true;
+        call.voided = true;
+        set_call(&env, &call);
+        extend_storage_ttl(&env);
+        Ok(call)
     }
 
     /// Claim a full refund for a voided call.
@@ -1671,12 +1750,7 @@ impl CallRegistry {
     /// * `staker`   -- address withdrawing their stake (must sign).
     /// * `call_id`  -- the call to withdraw from.
     /// * `position` -- outcome position (1..=outcome_count).
-    pub fn withdraw_stake(
-        env: Env,
-        staker: Address,
-        call_id: u64,
-        position: u32,
-    ) -> (i128, i128) {
+    pub fn withdraw_stake(env: Env, staker: Address, call_id: u64, position: u32) -> (i128, i128) {
         let config = get_config(&env).expect("not initialized");
         assert!(!config.paused, "Contract is paused");
         if storage::is_locked(&env) {

--- a/packages/contracts/call_registry/src/test.rs
+++ b/packages/contracts/call_registry/src/test.rs
@@ -29,7 +29,7 @@ impl MockToken {
 mod call_registry {
     use super::*;
     use crate::storage::DataKey;
-    use crate::types::ConditionType;
+    use crate::types::{AssetCondition, BasketCall, BasketLogic, ConditionType, LeafConditionType};
     use crate::{CallRegistry, CallRegistryClient};
     use ed25519_dalek::{Signer, SigningKey};
 
@@ -936,8 +936,15 @@ mod call_registry {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
         let call = create_call_with_default_condition(
-            &client, &creator, &stake_token, &100_000_000_i128,
-            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
         );
         client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
         let (refund, penalty) = client.withdraw_stake(&staker, &call.id, &1);
@@ -961,8 +968,15 @@ mod call_registry {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
         let call = create_call_with_default_condition(
-            &client, &creator, &stake_token, &100_000_000_i128,
-            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
         );
         client.stake_on_call(&staker, &call.id, &10_000_001_i128, &1);
         let (refund, penalty) = client.withdraw_stake(&staker, &call.id, &1);
@@ -986,8 +1000,15 @@ mod call_registry {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
         let call = create_call_with_default_condition(
-            &client, &creator, &stake_token, &100_000_000_i128,
-            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
         );
         client.withdraw_stake(&staker, &call.id, &1);
     }
@@ -1007,8 +1028,15 @@ mod call_registry {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
         let call = create_call_with_default_condition(
-            &client, &creator, &stake_token, &100_000_000_i128,
-            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
         );
         client.stake_on_call(&staker, &call.id, &50_000_000_i128, &1);
         env.ledger().set_timestamp(3000);
@@ -1030,8 +1058,15 @@ mod call_registry {
         let pair_id = Bytes::from_slice(&env, b"USDC/XLM");
         let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
         let call = create_call_with_default_condition(
-            &client, &creator, &stake_token, &100_000_000_i128,
-            &2000u64, &token_address, &pair_id, &metadata_hash, &2,
+            &client,
+            &creator,
+            &stake_token,
+            &100_000_000_i128,
+            &2000u64,
+            &token_address,
+            &pair_id,
+            &metadata_hash,
+            &2,
         );
         client.stake_on_call(&staker1, &call.id, &50_000_000_i128, &1);
         client.stake_on_call(&staker2, &call.id, &30_000_000_i128, &1);
@@ -2650,13 +2685,15 @@ mod call_registry {
         env: &Env,
         topic1: &str,
         topic2: &str,
-    ) -> Option<(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)> {
+    ) -> Option<(
+        Address,
+        soroban_sdk::Vec<soroban_sdk::Val>,
+        soroban_sdk::Val,
+    )> {
         let events = env.events().all();
         for i in 0..events.len() {
             let e = events.get(i).unwrap();
-            if e.1
-                == soroban_sdk::vec![env, topic1.into_val(env), topic2.into_val(env),]
-            {
+            if e.1 == soroban_sdk::vec![env, topic1.into_val(env), topic2.into_val(env),] {
                 return Some(e);
             }
         }
@@ -2992,8 +3029,8 @@ mod call_registry {
         // most recent top-level contract invocation, so this check must
         // happen immediately after `set_reputation_params` and before any
         // other client call (even read-only views like `get_config`).
-        let has_base_limit_event = find_event(&env, "call_registry", "admin_params_changed")
-            .is_some();
+        let has_base_limit_event =
+            find_event(&env, "call_registry", "admin_params_changed").is_some();
         assert!(has_base_limit_event);
 
         let config_after = client.get_config();
@@ -3075,6 +3112,85 @@ mod call_registry {
             &2,
         );
         client.stake_on_call(&user, &call.id, &300_000_001_i128, &1);
+    }
+
+    #[test]
+    fn test_empty_basket_rejected() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+
+        let creator = Address::generate(&env);
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+
+        let result = client.try_create_call(
+            &creator,
+            &crate::types::CallInitArgs {
+                stake_token,
+                stake_amount: 100_000_000,
+                start_price: TEST_START_PRICE,
+                end_ts: 2000,
+                token_address: Address::generate(&env),
+                pair_id: Bytes::from_slice(&env, b"BASKET"),
+                ipfs_cid: Bytes::from_slice(&env, b"QmBasket"),
+                metadata_hash: BytesN::from_array(&env, &[1u8; 32]),
+                condition: ConditionType::Basket(BasketCall {
+                    conditions: soroban_sdk::Vec::new(&env),
+                    logic: BasketLogic::AllOf,
+                }),
+                outcome_count: 2,
+            },
+        );
+
+        assert_eq!(result, Err(Ok(CallRegistryError::EmptyBasket)));
+    }
+
+    #[test]
+    fn test_get_basket_conditions_returns_configured_conditions() {
+        let (env, client, _admin, _om) = setup();
+        env.ledger().set_timestamp(1000);
+
+        let creator = Address::generate(&env);
+        let stake_token = env.register_contract(None, MockToken);
+        client.whitelist_token(&stake_token);
+
+        let mut conditions = soroban_sdk::Vec::new(&env);
+        conditions.push_back(AssetCondition {
+            token_address: Address::generate(&env),
+            pair_id: Bytes::from_slice(&env, b"XLM-USDC"),
+            condition: LeafConditionType::TargetAbove(150_000_000),
+            weight_bps: 5_000,
+        });
+        conditions.push_back(AssetCondition {
+            token_address: Address::generate(&env),
+            pair_id: Bytes::from_slice(&env, b"BTC-USDC"),
+            condition: LeafConditionType::TargetAbove(60000_0000000),
+            weight_bps: 5_000,
+        });
+
+        let call = client.create_call(
+            &creator,
+            &crate::types::CallInitArgs {
+                stake_token,
+                stake_amount: 100_000_000,
+                start_price: TEST_START_PRICE,
+                end_ts: 2000,
+                token_address: Address::generate(&env),
+                pair_id: Bytes::from_slice(&env, b"BASKET"),
+                ipfs_cid: Bytes::from_slice(&env, b"QmBasket"),
+                metadata_hash: BytesN::from_array(&env, &[2u8; 32]),
+                condition: ConditionType::Basket(BasketCall {
+                    conditions: conditions.clone(),
+                    logic: BasketLogic::AllOf,
+                }),
+                outcome_count: 2,
+            },
+        );
+
+        let fetched = client.get_basket_conditions(&call.id);
+        assert_eq!(fetched.len(), 2);
+        assert_eq!(fetched.get(0).unwrap().weight_bps, 5_000);
+        assert_eq!(fetched.get(1).unwrap().weight_bps, 5_000);
     }
 }
 
@@ -3571,6 +3687,4 @@ mod sep10_tests {
         let user = Address::generate(&env);
         assert_eq!(client.get_sep10_home_domain(&user), None);
     }
-
-
 }

--- a/packages/contracts/call_registry/src/types.rs
+++ b/packages/contracts/call_registry/src/types.rs
@@ -1,5 +1,48 @@
 use soroban_sdk::{contracttype, Address, Bytes, BytesN, Map, Vec};
 
+/// Basket aggregation logic used to combine multiple asset conditions.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum BasketLogic {
+    /// Resolves UP only if every condition evaluates to true.
+    AllOf,
+    /// Resolves UP if at least one condition evaluates to true.
+    AnyOf,
+    /// Resolves UP when the sum of true-condition weights is greater than
+    /// `threshold_bps`.
+    Weighted(u32),
+}
+
+/// Non-recursive condition used by each basket leg.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LeafConditionType {
+    TargetAbove(i128),
+    TargetBelow(i128),
+    PercentUp(u32),
+    PercentDown(u32),
+    Range(i128, i128),
+}
+
+/// One asset-specific condition inside a basket.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssetCondition {
+    pub token_address: Address,
+    pub pair_id: Bytes,
+    pub condition: LeafConditionType,
+    /// Weight in basis points used by `BasketLogic::Weighted`.
+    pub weight_bps: u32,
+}
+
+/// Basket call payload containing all conditions and their aggregation logic.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BasketCall {
+    pub conditions: Vec<AssetCondition>,
+    pub logic: BasketLogic,
+}
+
 /// Describes the price-movement condition that determines the winning outcome.
 ///
 /// All price values use 7 decimal places (e.g. `1_0000000` = 1.0).
@@ -21,6 +64,8 @@ pub enum ConditionType {
     /// Resolves UP when the end price falls within `[min, max]` inclusive.
     /// Both `min` and `max` are absolute prices with 7 decimals.
     Range(i128, i128),
+    /// Multi-asset basket; overall outcome is derived from `BasketLogic`.
+    Basket(BasketCall),
 }
 
 /// Arguments for initializing a new Call
@@ -77,6 +122,8 @@ pub struct Call {
     pub settled: bool,
     /// Whether the call has been voided by admin (triggers full refunds)
     pub voided: bool,
+    /// Whether the call became unresolvable due to incomplete oracle basket data.
+    pub unresolvable: bool,
     /// Creation timestamp
     pub created_at: u64,
     /// Whether the call has been cancelled by its creator

--- a/packages/contracts/call_registry/src/withdrawal.rs
+++ b/packages/contracts/call_registry/src/withdrawal.rs
@@ -1,6 +1,8 @@
-use soroban_sdk::{Address, Env, Map};
 use crate::events::{emit_stake_withdrawn, emit_xlm_stake_withdrawn};
-use crate::storage::{get_call, set_call, get_config, get_user_stake, set_user_stake, extend_storage_ttl};
+use crate::storage::{
+    extend_storage_ttl, get_call, get_config, get_user_stake, set_call, set_user_stake,
+};
+use soroban_sdk::{Address, Env, Map};
 
 /// Basis points penalty for early stake withdrawal (default 1000 = 10%).
 pub const DEFAULT_EARLY_EXIT_PENALTY_BPS: u32 = 1000;
@@ -9,12 +11,7 @@ pub const DEFAULT_EARLY_EXIT_PENALTY_BPS: u32 = 1000;
 ///
 /// - `position`: 1..=outcome_count
 /// - Returns `(refunded_amount, penalty)`.
-pub fn execute_withdrawal(
-    env: &Env,
-    staker: Address,
-    call_id: u64,
-    position: u32,
-) -> (i128, i128) {
+pub fn execute_withdrawal(env: &Env, staker: Address, call_id: u64, position: u32) -> (i128, i128) {
     staker.require_auth();
 
     let mut call = get_call(env, call_id).expect("call not found");
@@ -52,10 +49,8 @@ pub fn execute_withdrawal(
     let refund = stake - penalty;
 
     // Remove staker's entry from the position map
-    let mut outcome_stakers: Map<Address, i128> = call
-        .stakes
-        .get(position)
-        .unwrap_or_else(|| Map::new(env));
+    let mut outcome_stakers: Map<Address, i128> =
+        call.stakes.get(position).unwrap_or_else(|| Map::new(env));
     outcome_stakers.remove(staker.clone());
     call.stakes.set(position, outcome_stakers);
 
@@ -71,12 +66,18 @@ pub fn execute_withdrawal(
 
     // Transfer refund from contract to staker
     if crate::is_native_xlm(env, &call.stake_token) {
-        soroban_sdk::token::StellarAssetClient::new(env, &call.stake_token)
-            .transfer(&env.current_contract_address(), &staker, &refund);
+        soroban_sdk::token::StellarAssetClient::new(env, &call.stake_token).transfer(
+            &env.current_contract_address(),
+            &staker,
+            &refund,
+        );
         emit_xlm_stake_withdrawn(env, call_id, &staker, refund, penalty);
     } else {
-        soroban_sdk::token::Client::new(env, &call.stake_token)
-            .transfer(&env.current_contract_address(), &staker, &refund);
+        soroban_sdk::token::Client::new(env, &call.stake_token).transfer(
+            &env.current_contract_address(),
+            &staker,
+            &refund,
+        );
         emit_stake_withdrawn(env, call_id, &staker, refund, penalty);
     }
 

--- a/packages/contracts/call_registry/tests/integration.rs
+++ b/packages/contracts/call_registry/tests/integration.rs
@@ -6,9 +6,9 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, Vec,
 };
 
+use backit_shared::{OUTCOME_DOWN, OUTCOME_UP};
 use call_registry::{CallRegistry, CallRegistryClient};
 use outcome_manager::{OutcomeManager, OutcomeManagerClient};
-use backit_shared::{OUTCOME_UP, OUTCOME_DOWN};
 
 use call_registry::types::{Call, CallInitArgs, ConditionType};
 
@@ -90,12 +90,22 @@ fn test_full_lifecycle_create_stake_submit_claim() {
     assert_eq!(call.outcome_stakes.get(OUTCOME_DOWN).unwrap_or(0), 0);
 
     let up_call = registry_client.stake_on_call(&staker_up, &1u64, &50_000_000_i128, &OUTCOME_UP);
-    assert_eq!(up_call.outcome_stakes.get(OUTCOME_UP).unwrap_or(0), 50_000_000_i128);
+    assert_eq!(
+        up_call.outcome_stakes.get(OUTCOME_UP).unwrap_or(0),
+        50_000_000_i128
+    );
     assert_eq!(up_call.outcome_stakes.get(OUTCOME_DOWN).unwrap_or(0), 0);
 
-    let down_call = registry_client.stake_on_call(&staker_down, &1u64, &30_000_000_i128, &OUTCOME_DOWN);
-    assert_eq!(down_call.outcome_stakes.get(OUTCOME_UP).unwrap_or(0), 50_000_000_i128);
-    assert_eq!(down_call.outcome_stakes.get(OUTCOME_DOWN).unwrap_or(0), 30_000_000_i128);
+    let down_call =
+        registry_client.stake_on_call(&staker_down, &1u64, &30_000_000_i128, &OUTCOME_DOWN);
+    assert_eq!(
+        down_call.outcome_stakes.get(OUTCOME_UP).unwrap_or(0),
+        50_000_000_i128
+    );
+    assert_eq!(
+        down_call.outcome_stakes.get(OUTCOME_DOWN).unwrap_or(0),
+        30_000_000_i128
+    );
 
     env.ledger().set_timestamp(5100);
 
@@ -233,7 +243,10 @@ fn test_error_paths_double_claiming() {
     let call = registry_client.get_call(&1u64);
     assert_eq!(call.outcome, OUTCOME_UP);
     // Verify stake is preserved in outcome_stakes after resolution
-    assert_eq!(call.outcome_stakes.get(OUTCOME_UP).unwrap_or(0), 50_000_000_i128);
+    assert_eq!(
+        call.outcome_stakes.get(OUTCOME_UP).unwrap_or(0),
+        50_000_000_i128
+    );
 }
 
 #[test]
@@ -408,16 +421,31 @@ fn test_three_outcome_market() {
 
     // Three stakers cover all three outcomes
     let call_after_a = registry_client.stake_on_call(&staker_a, &1u64, &20_000_000_i128, &1u32);
-    assert_eq!(call_after_a.outcome_stakes.get(1u32).unwrap_or(0), 20_000_000_i128);
+    assert_eq!(
+        call_after_a.outcome_stakes.get(1u32).unwrap_or(0),
+        20_000_000_i128
+    );
 
     let call_after_b = registry_client.stake_on_call(&staker_b, &1u64, &30_000_000_i128, &2u32);
-    assert_eq!(call_after_b.outcome_stakes.get(2u32).unwrap_or(0), 30_000_000_i128);
+    assert_eq!(
+        call_after_b.outcome_stakes.get(2u32).unwrap_or(0),
+        30_000_000_i128
+    );
 
     let call_after_c = registry_client.stake_on_call(&staker_c, &1u64, &15_000_000_i128, &3u32);
     // All three outcomes accumulate independently
-    assert_eq!(call_after_c.outcome_stakes.get(1u32).unwrap_or(0), 20_000_000_i128);
-    assert_eq!(call_after_c.outcome_stakes.get(2u32).unwrap_or(0), 30_000_000_i128);
-    assert_eq!(call_after_c.outcome_stakes.get(3u32).unwrap_or(0), 15_000_000_i128);
+    assert_eq!(
+        call_after_c.outcome_stakes.get(1u32).unwrap_or(0),
+        20_000_000_i128
+    );
+    assert_eq!(
+        call_after_c.outcome_stakes.get(2u32).unwrap_or(0),
+        30_000_000_i128
+    );
+    assert_eq!(
+        call_after_c.outcome_stakes.get(3u32).unwrap_or(0),
+        15_000_000_i128
+    );
 
     // Resolve to outcome 3
     env.ledger().set_timestamp(5100);
@@ -429,5 +457,8 @@ fn test_three_outcome_market() {
     let settled = registry_client.get_call(&1u64);
     assert!(settled.settled);
     assert_eq!(settled.outcome, 3u32);
-    assert_eq!(settled.outcome_stakes.get(3u32).unwrap_or(0), 15_000_000_i128);
+    assert_eq!(
+        settled.outcome_stakes.get(3u32).unwrap_or(0),
+        15_000_000_i128
+    );
 }

--- a/packages/contracts/charity_markets/src/events.rs
+++ b/packages/contracts/charity_markets/src/events.rs
@@ -22,37 +22,21 @@ pub fn emit_charity_call_created(
     );
 }
 
-pub fn emit_charity_call_resolved(
-    env: &Env,
-    call_id: u64,
-    final_outcome: u32,
-    creator_won: bool,
-) {
+pub fn emit_charity_call_resolved(env: &Env, call_id: u64, final_outcome: u32, creator_won: bool) {
     env.events().publish(
         ("charity_markets", "resolved"),
         (call_id, final_outcome, creator_won),
     );
 }
 
-pub fn emit_charity_donation(
-    env: &Env,
-    donor: &Address,
-    charity: &Address,
-    amount: i128,
-) {
+pub fn emit_charity_donation(env: &Env, donor: &Address, charity: &Address, amount: i128) {
     env.events().publish(
         ("charity_markets", "donation"),
         (donor.clone(), charity.clone(), amount),
     );
 }
 
-pub fn emit_stake_added(
-    env: &Env,
-    call_id: u64,
-    staker: &Address,
-    amount: i128,
-    outcome: u32,
-) {
+pub fn emit_stake_added(env: &Env, call_id: u64, staker: &Address, amount: i128, outcome: u32) {
     env.events().publish(
         ("charity_markets", "stake_added"),
         (call_id, staker.clone(), amount, outcome),

--- a/packages/contracts/charity_markets/src/lib.rs
+++ b/packages/contracts/charity_markets/src/lib.rs
@@ -10,8 +10,7 @@ mod test;
 
 use errors::CharityError;
 use events::{
-    emit_charity_call_created, emit_charity_call_resolved, emit_charity_donation,
-    emit_stake_added,
+    emit_charity_call_created, emit_charity_call_resolved, emit_charity_donation, emit_stake_added,
 };
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Map};
 use storage::*;
@@ -26,12 +25,7 @@ pub struct CharityMarkets;
 
 #[contractimpl]
 impl CharityMarkets {
-    pub fn initialize(
-        env: Env,
-        admin: Address,
-        outcome_manager: Address,
-        stake_token: Address,
-    ) {
+    pub fn initialize(env: Env, admin: Address, outcome_manager: Address, stake_token: Address) {
         if get_admin(&env).is_some() {
             soroban_sdk::panic_with_error!(&env, CharityError::AlreadyInitialized);
         }
@@ -50,10 +44,8 @@ impl CharityMarkets {
         creator.require_auth();
 
         let _admin = get_admin(&env).ok_or(CharityError::NotInitialized)?;
-        let stake_token =
-            get_stake_token(&env).ok_or(CharityError::NotInitialized)?;
-        let outcome_manager =
-            get_outcome_manager(&env).ok_or(CharityError::NotInitialized)?;
+        let stake_token = get_stake_token(&env).ok_or(CharityError::NotInitialized)?;
+        let outcome_manager = get_outcome_manager(&env).ok_or(CharityError::NotInitialized)?;
 
         if charity_split_bps > 10_000 {
             return Err(CharityError::CharitySplitExceedsMax);
@@ -114,7 +106,13 @@ impl CharityMarkets {
         };
 
         set_charity_call(&env, call_id, &charity_call);
-        set_user_stake(&env, call_id, &creator, call_params.creator_outcome, call_params.stake_amount);
+        set_user_stake(
+            &env,
+            call_id,
+            &creator,
+            call_params.creator_outcome,
+            call_params.stake_amount,
+        );
 
         emit_charity_call_created(
             &env,
@@ -137,10 +135,8 @@ impl CharityMarkets {
     ) -> Result<CharityCall, CharityError> {
         staker.require_auth();
 
-        let stake_token =
-            get_stake_token(&env).ok_or(CharityError::NotInitialized)?;
-        let mut call =
-            get_charity_call(&env, call_id).ok_or(CharityError::CallNotFound)?;
+        let stake_token = get_stake_token(&env).ok_or(CharityError::NotInitialized)?;
+        let mut call = get_charity_call(&env, call_id).ok_or(CharityError::CallNotFound)?;
 
         if call.resolved {
             return Err(CharityError::AlreadyResolved);
@@ -163,8 +159,10 @@ impl CharityMarkets {
         let prev_total = call.outcome_stakes.get(outcome).unwrap_or(0);
         call.outcome_stakes.set(outcome, prev_total + amount);
 
-        let mut outcome_stakers: Map<Address, i128> =
-            call.user_stakes.get(outcome).unwrap_or_else(|| Map::new(&env));
+        let mut outcome_stakers: Map<Address, i128> = call
+            .user_stakes
+            .get(outcome)
+            .unwrap_or_else(|| Map::new(&env));
         let prev_staker = outcome_stakers.get(staker.clone()).unwrap_or(0);
         outcome_stakers.set(staker.clone(), prev_staker + amount);
         call.user_stakes.set(outcome, outcome_stakers);
@@ -182,12 +180,10 @@ impl CharityMarkets {
         call_id: u64,
         final_outcome: u32,
     ) -> Result<CharityCall, CharityError> {
-        let outcome_manager =
-            get_outcome_manager(&env).ok_or(CharityError::NotInitialized)?;
+        let outcome_manager = get_outcome_manager(&env).ok_or(CharityError::NotInitialized)?;
         outcome_manager.require_auth();
 
-        let mut call =
-            get_charity_call(&env, call_id).ok_or(CharityError::CallNotFound)?;
+        let mut call = get_charity_call(&env, call_id).ok_or(CharityError::CallNotFound)?;
 
         if call.resolved {
             return Err(CharityError::AlreadyResolved);
@@ -208,8 +204,7 @@ impl CharityMarkets {
             for i in 1..=call.outcome_count {
                 total_pool += call.outcome_stakes.get(i).unwrap_or(0);
             }
-            let winning_total =
-                call.outcome_stakes.get(final_outcome).unwrap_or(0);
+            let winning_total = call.outcome_stakes.get(final_outcome).unwrap_or(0);
 
             if winning_total == 0 {
                 return Err(CharityError::ZeroPool);
@@ -220,8 +215,7 @@ impl CharityMarkets {
             let creator_share_ratio = call.stake_amount * losing_total / winning_total;
             let creator_gross = call.stake_amount + creator_share_ratio;
 
-            let charity_amount =
-                (creator_gross * call.charity_split_bps as i128) / 10_000;
+            let charity_amount = (creator_gross * call.charity_split_bps as i128) / 10_000;
             let creator_payout = creator_gross - charity_amount;
 
             if charity_amount > 0 {
@@ -254,7 +248,9 @@ impl CharityMarkets {
                 if staker == call.creator {
                     continue;
                 }
-                let stake_amt = call.user_stakes.get(final_outcome)
+                let stake_amt = call
+                    .user_stakes
+                    .get(final_outcome)
                     .unwrap_or_else(|| Map::new(&env))
                     .get(staker.clone())
                     .unwrap_or(0);
@@ -271,10 +267,14 @@ impl CharityMarkets {
                 call.stake_amount,
             );
             call.total_donated = call.stake_amount;
-            emit_charity_donation(&env, &call.creator, &call.charity_address, call.stake_amount);
+            emit_charity_donation(
+                &env,
+                &call.creator,
+                &call.charity_address,
+                call.stake_amount,
+            );
 
-            let winning_total =
-                call.outcome_stakes.get(final_outcome).unwrap_or(0);
+            let winning_total = call.outcome_stakes.get(final_outcome).unwrap_or(0);
             if winning_total > 0 {
                 let mut total_pool: i128 = 0;
                 for i in 1..=call.outcome_count {
@@ -294,7 +294,9 @@ impl CharityMarkets {
                     if staker == call.creator {
                         continue;
                     }
-                    let stake_amt = call.user_stakes.get(final_outcome)
+                    let stake_amt = call
+                        .user_stakes
+                        .get(final_outcome)
                         .unwrap_or_else(|| Map::new(&env))
                         .get(staker.clone())
                         .unwrap_or(0);
@@ -316,9 +318,12 @@ impl CharityMarkets {
     }
 
     pub fn get_charity_info(env: Env, call_id: u64) -> Result<(Address, u32, i128), CharityError> {
-        let call =
-            get_charity_call(&env, call_id).ok_or(CharityError::CallNotFound)?;
-        Ok((call.charity_address, call.charity_split_bps, call.total_donated))
+        let call = get_charity_call(&env, call_id).ok_or(CharityError::CallNotFound)?;
+        Ok((
+            call.charity_address,
+            call.charity_split_bps,
+            call.total_donated,
+        ))
     }
 
     pub fn get_charity_call(env: Env, call_id: u64) -> Option<CharityCall> {

--- a/packages/contracts/charity_markets/src/storage.rs
+++ b/packages/contracts/charity_markets/src/storage.rs
@@ -20,9 +20,7 @@ pub fn get_admin(env: &Env) -> Option<Address> {
 }
 
 pub fn set_outcome_manager(env: &Env, mgr: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::OutcomeManager, mgr);
+    env.storage().instance().set(&DataKey::OutcomeManager, mgr);
 }
 
 pub fn get_outcome_manager(env: &Env) -> Option<Address> {
@@ -30,9 +28,7 @@ pub fn get_outcome_manager(env: &Env) -> Option<Address> {
 }
 
 pub fn set_stake_token(env: &Env, token: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::StakeToken, token);
+    env.storage().instance().set(&DataKey::StakeToken, token);
 }
 
 pub fn get_stake_token(env: &Env) -> Option<Address> {
@@ -40,9 +36,7 @@ pub fn get_stake_token(env: &Env) -> Option<Address> {
 }
 
 pub fn set_next_call_id(env: &Env, id: u64) {
-    env.storage()
-        .instance()
-        .set(&DataKey::NextCallId, &id);
+    env.storage().instance().set(&DataKey::NextCallId, &id);
 }
 
 pub fn get_next_call_id(env: &Env) -> u64 {
@@ -59,24 +53,14 @@ pub fn set_charity_call(env: &Env, call_id: u64, call: &CharityCall) {
 }
 
 pub fn get_charity_call(env: &Env, call_id: u64) -> Option<CharityCall> {
-    env.storage()
-        .instance()
-        .get(&DataKey::CharityCall(call_id))
+    env.storage().instance().get(&DataKey::CharityCall(call_id))
 }
 
-pub fn set_user_stake(
-    env: &Env,
-    call_id: u64,
-    staker: &Address,
-    outcome: u32,
-    amount: i128,
-) {
-    env.storage()
-        .instance()
-        .set(
-            &DataKey::UserStake(call_id, staker.clone(), outcome),
-            &amount,
-        );
+pub fn set_user_stake(env: &Env, call_id: u64, staker: &Address, outcome: u32, amount: i128) {
+    env.storage().instance().set(
+        &DataKey::UserStake(call_id, staker.clone(), outcome),
+        &amount,
+    );
 }
 
 #[allow(dead_code)]

--- a/packages/contracts/charity_markets/src/test.rs
+++ b/packages/contracts/charity_markets/src/test.rs
@@ -13,7 +13,13 @@ fn create_token<'a>(env: &'a Env, admin: &Address) -> (Address, StellarAssetClie
 
 fn deploy<'a>(
     env: &'a Env,
-) -> (CharityMarketsClient<'a>, Address, Address, Address, StellarAssetClient<'a>) {
+) -> (
+    CharityMarketsClient<'a>,
+    Address,
+    Address,
+    Address,
+    StellarAssetClient<'a>,
+) {
     let admin = Address::generate(env);
     let outcome_manager = Address::generate(env);
     let (stake_token, sac) = create_token(env, &admin);

--- a/packages/contracts/dutch_auction/src/lib.rs
+++ b/packages/contracts/dutch_auction/src/lib.rs
@@ -125,8 +125,7 @@ impl DutchAuction {
         match info.condition_type {
             1 => Ok(info.start_price * 2 * (duration as i128 - elapsed as i128) / duration as i128),
             2 => {
-                let numerator =
-                    info.start_price * (duration as i128 + 3 * elapsed as i128);
+                let numerator = info.start_price * (duration as i128 + 3 * elapsed as i128);
                 Ok(numerator / (2 * duration as i128))
             }
             _ => Err(DutchAuctionError::UnknownConditionType),
@@ -155,7 +154,12 @@ impl DutchAuction {
         config.oracle_deadline_secs = oracle_deadline_secs;
         config.settler_reward_bps = settler_reward_bps;
         set_config(&env, &config);
-        emit_auth_params_changed(&env, auction_duration_secs, oracle_deadline_secs, settler_reward_bps);
+        emit_auth_params_changed(
+            &env,
+            auction_duration_secs,
+            oracle_deadline_secs,
+            settler_reward_bps,
+        );
         Ok(())
     }
 }

--- a/packages/contracts/gas_station/src/lib.rs
+++ b/packages/contracts/gas_station/src/lib.rs
@@ -352,9 +352,7 @@ impl GasStation {
             .checked_div(MAX_BPS as i128)
             .unwrap_or_else(|| overflow(&env));
 
-        let user_amount = payout
-            .checked_sub(cut)
-            .unwrap_or_else(|| overflow(&env));
+        let user_amount = payout.checked_sub(cut).unwrap_or_else(|| overflow(&env));
 
         if user_amount > 0 {
             transfer_token(&env, &xlm_token, &contract_address, &user, user_amount);

--- a/packages/contracts/gas_station/src/storage.rs
+++ b/packages/contracts/gas_station/src/storage.rs
@@ -37,7 +37,9 @@ pub fn set_sponsorship(env: &Env, user: &Address, info: &SponsorshipInfo) {
 }
 
 pub fn get_sponsorship(env: &Env, user: &Address) -> Option<SponsorshipInfo> {
-    env.storage().instance().get(&DataKey::Sponsorship(user.clone()))
+    env.storage()
+        .instance()
+        .get(&DataKey::Sponsorship(user.clone()))
 }
 
 pub fn get_metrics(env: &Env) -> GasStationMetrics {
@@ -52,7 +54,9 @@ pub fn set_metrics(env: &Env, metrics: &GasStationMetrics) {
 }
 
 pub fn is_call_processed(env: &Env, call_id: u64) -> bool {
-    env.storage().instance().has(&DataKey::CallProcessed(call_id))
+    env.storage()
+        .instance()
+        .has(&DataKey::CallProcessed(call_id))
 }
 
 pub fn mark_call_processed(env: &Env, call_id: u64) {

--- a/packages/contracts/gas_station/src/test.rs
+++ b/packages/contracts/gas_station/src/test.rs
@@ -183,7 +183,9 @@ fn resolve_market(setup: &TestSetup, call_id: u64, outcome: u32, end_ts: u64) {
             end_ts + 1,
         ),
     };
-    setup.outcome_mgr.submit_outcome_for_market(&signed, &end_ts);
+    setup
+        .outcome_mgr
+        .submit_outcome_for_market(&signed, &end_ts);
 }
 
 fn assert_contract_error<T, E>(
@@ -203,7 +205,9 @@ fn sponsor_transaction_registers_user_and_updates_metrics() {
     let setup = setup_full_stack();
     let user = Address::generate(&setup.env);
 
-    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+    setup
+        .gas_station
+        .sponsor_transaction(&user, &50i128, &300u32);
 
     let info = setup.gas_station.get_sponsorship(&user).unwrap();
     assert_eq!(info.max_gas_xlm, 50);
@@ -244,7 +248,9 @@ fn sponsor_transaction_rejects_non_positive_gas() {
 fn revoke_sponsorship_deactivates_without_erasing_history() {
     let setup = setup_full_stack();
     let user = Address::generate(&setup.env);
-    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+    setup
+        .gas_station
+        .sponsor_transaction(&user, &50i128, &300u32);
 
     setup.gas_station.revoke_sponsorship(&user);
 
@@ -256,7 +262,12 @@ fn revoke_sponsorship_deactivates_without_erasing_history() {
 #[test]
 fn compute_effective_stake_matches_formula() {
     let setup = setup_full_stack();
-    assert_eq!(setup.gas_station.compute_effective_stake(&1_000i128, &50i128), 950);
+    assert_eq!(
+        setup
+            .gas_station
+            .compute_effective_stake(&1_000i128, &50i128),
+        950
+    );
 }
 
 #[test]
@@ -286,7 +297,9 @@ fn sponsored_stake_win_gas_station_earns_cut_and_user_gets_remainder() {
     let market = PredictionMarketClient::new(env, &market_addr);
 
     // Sponsor the user for up to 50 stroops of gas at a 3% winning cut.
-    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+    setup
+        .gas_station
+        .sponsor_transaction(&user, &50i128, &300u32);
 
     // The user stakes directly, as themselves (the gas station only ever
     // relays the fee off-chain — see module docs — it never becomes an
@@ -336,7 +349,9 @@ fn claim_sponsored_payout_cannot_be_processed_twice_for_same_call() {
     let (market_addr, call_id) = deploy_market(&setup, end_ts);
     let market = PredictionMarketClient::new(env, &market_addr);
 
-    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+    setup
+        .gas_station
+        .sponsor_transaction(&user, &50i128, &300u32);
     market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_UP);
     market.stake_on_call(&counterparty, &call_id, &3_000i128, &OUTCOME_DOWN);
     resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
@@ -411,7 +426,9 @@ fn sponsored_stake_loss_gas_station_absorbs_cost_no_deduction() {
     let (market_addr, call_id) = deploy_market(&setup, end_ts);
     let market = PredictionMarketClient::new(env, &market_addr);
 
-    setup.gas_station.sponsor_transaction(&user, &50i128, &300u32);
+    setup
+        .gas_station
+        .sponsor_transaction(&user, &50i128, &300u32);
 
     let user_balance_after_stake_before_resolve;
     market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_DOWN);
@@ -438,7 +455,10 @@ fn sponsored_stake_loss_gas_station_absorbs_cost_no_deduction() {
     // they simply don't get their stake back (as normal for prediction
     // markets), and no gas station cut is deducted from a non-existent
     // payout.
-    assert_eq!(token.balance(&user), user_balance_after_stake_before_resolve);
+    assert_eq!(
+        token.balance(&user),
+        user_balance_after_stake_before_resolve
+    );
 
     // The pool's on-chain balance is untouched by the loss — the estimated
     // gas cost was fronted off-chain (see module docs); what the gas
@@ -492,7 +512,9 @@ fn winning_cuts_flow_back_into_the_same_pool_refill_grows() {
     let (market_addr, call_id) = deploy_market(&setup, end_ts);
     let market = PredictionMarketClient::new(env, &market_addr);
 
-    setup.gas_station.sponsor_transaction(&user, &50i128, &1_000u32); // 10%
+    setup
+        .gas_station
+        .sponsor_transaction(&user, &50i128, &1_000u32); // 10%
     market.stake_on_call(&user, &call_id, &1_000i128, &OUTCOME_UP);
     market.stake_on_call(&counterparty, &call_id, &1_000i128, &OUTCOME_DOWN);
     resolve_market(&setup, call_id, OUTCOME_UP, end_ts);
@@ -550,8 +572,6 @@ fn set_admin_transfers_admin_rights() {
 #[test]
 fn initialize_cannot_be_called_twice() {
     let setup = setup_full_stack();
-    let result = setup
-        .gas_station
-        .try_initialize(&setup.admin, &setup.token);
+    let result = setup.gas_station.try_initialize(&setup.admin, &setup.token);
     assert_contract_error(result, GasStationError::AlreadyInitialized);
 }

--- a/packages/contracts/index_fund/src/events.rs
+++ b/packages/contracts/index_fund/src/events.rs
@@ -14,7 +14,12 @@ pub fn emit_index_withdraw(env: &Env, user: &Address, index_amount: i128, usdc_o
     );
 }
 
-pub fn emit_index_rebalanced(env: &Env, keeper: &Address, markets_staked: u32, markets_claimed: u32) {
+pub fn emit_index_rebalanced(
+    env: &Env,
+    keeper: &Address,
+    markets_staked: u32,
+    markets_claimed: u32,
+) {
     env.events().publish(
         ("index_fund", "rebalanced"),
         (keeper.clone(), markets_staked, markets_claimed),
@@ -22,8 +27,6 @@ pub fn emit_index_rebalanced(env: &Env, keeper: &Address, markets_staked: u32, m
 }
 
 pub fn emit_payout_claimed(env: &Env, call_id: u64, amount: i128) {
-    env.events().publish(
-        ("index_fund", "payout_claimed"),
-        (call_id, amount),
-    );
+    env.events()
+        .publish(("index_fund", "payout_claimed"), (call_id, amount));
 }

--- a/packages/contracts/index_fund/src/lib.rs
+++ b/packages/contracts/index_fund/src/lib.rs
@@ -108,7 +108,13 @@ impl IndexFund {
             .ok_or(IndexFundError::InvalidAmount)?;
 
         // Transfer USDC into this contract
-        transfer_token(&env, &config.stake_token, &user, &env.current_contract_address(), usdc_amount);
+        transfer_token(
+            &env,
+            &config.stake_token,
+            &user,
+            &env.current_contract_address(),
+            usdc_amount,
+        );
 
         // Mint INDEX tokens
         let total_supply = get_total_index_supply(&env);

--- a/packages/contracts/index_fund/src/storage.rs
+++ b/packages/contracts/index_fund/src/storage.rs
@@ -29,9 +29,7 @@ pub struct IndexConfig {
 // ─── Initialized flag ────────────────────────────────────────────────────────
 
 pub fn set_initialized(env: &Env) {
-    env.storage()
-        .instance()
-        .set(&DataKey::Initialized, &true);
+    env.storage().instance().set(&DataKey::Initialized, &true);
 }
 
 pub fn is_initialized(env: &Env) -> bool {
@@ -112,9 +110,7 @@ pub fn set_constituents(env: &Env, constituents: &Vec<IndexConstituent>) {
 }
 
 pub fn get_constituent(env: &Env, call_id: u64) -> Option<IndexConstituent> {
-    env.storage()
-        .instance()
-        .get(&DataKey::Constituent(call_id))
+    env.storage().instance().get(&DataKey::Constituent(call_id))
 }
 
 pub fn set_constituent(env: &Env, constituent: &IndexConstituent) {

--- a/packages/contracts/index_fund/src/test.rs
+++ b/packages/contracts/index_fund/src/test.rs
@@ -3,9 +3,7 @@
 extern crate std;
 
 use soroban_sdk::{
-    testutils::Address as _,
-    token::StellarAssetClient as TokenAdminClient,
-    Address, Env,
+    testutils::Address as _, token::StellarAssetClient as TokenAdminClient, Address, Env,
 };
 
 use crate::{IndexFund, IndexFundClient};
@@ -13,12 +11,19 @@ use crate::{IndexFund, IndexFundClient};
 fn create_test_env() -> (Env, Address, Address, Address) {
     let env = Env::default();
     let admin = Address::generate(&env);
-    let stake_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let stake_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let factory = Address::generate(&env);
     (env, admin, stake_token, factory)
 }
 
-fn setup_fund<'a>(env: &'a Env, admin: &'a Address, stake_token: &'a Address, factory: &'a Address) -> IndexFundClient<'a> {
+fn setup_fund<'a>(
+    env: &'a Env,
+    admin: &'a Address,
+    stake_token: &'a Address,
+    factory: &'a Address,
+) -> IndexFundClient<'a> {
     env.mock_all_auths();
     let contract_id = env.register(IndexFund, ());
     let fund = IndexFundClient::new(env, &contract_id);

--- a/packages/contracts/launchpad/src/lib.rs
+++ b/packages/contracts/launchpad/src/lib.rs
@@ -53,7 +53,7 @@ impl LaunchpadContract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{Env, testutils::Address as _};
+    use soroban_sdk::{testutils::Address as _, Env};
 
     #[test]
     fn test_launchpad_estimate() {

--- a/packages/contracts/lending_pool/src/lib.rs
+++ b/packages/contracts/lending_pool/src/lib.rs
@@ -140,9 +140,7 @@ fn other_position(position: u32) -> u32 {
 fn compute_tvl(env: &Env, config: &PoolConfig) -> Result<i128, LendingPoolError> {
     let liquid = token_balance(env, &config.stake_token);
     let locked = get_total_allocated_locked(env);
-    liquid
-        .checked_add(locked)
-        .ok_or(LendingPoolError::Overflow)
+    liquid.checked_add(locked).ok_or(LendingPoolError::Overflow)
 }
 
 /// Appends a yield event and prunes entries older than [`APY_WINDOW_SECS`],
@@ -287,7 +285,13 @@ impl LendingPool {
             return Err(LendingPoolError::InvalidAmount);
         }
 
-        transfer_token(&env, &config.stake_token, &user, &env.current_contract_address(), amount);
+        transfer_token(
+            &env,
+            &config.stake_token,
+            &user,
+            &env.current_contract_address(),
+            amount,
+        );
 
         set_total_lp_shares(
             &env,
@@ -364,7 +368,13 @@ impl LendingPool {
                 .ok_or(LendingPoolError::Overflow)?,
         );
 
-        transfer_token(&env, &config.stake_token, &env.current_contract_address(), &user, amount_out);
+        transfer_token(
+            &env,
+            &config.stake_token,
+            &env.current_contract_address(),
+            &user,
+            amount_out,
+        );
 
         emit_withdrawn(&env, &user, lp_amount, amount_out);
         Ok(amount_out)
@@ -464,7 +474,11 @@ impl LendingPool {
                 results.push_back(AllocationOutcome::SkippedNotBinary);
                 continue;
             }
-            if call.settled || call.cancelled || call.voided || call.outcome != 0 || now >= call.end_ts
+            if call.settled
+                || call.cancelled
+                || call.voided
+                || call.outcome != 0
+                || now >= call.end_ts
             {
                 results.push_back(AllocationOutcome::SkippedMarketUnavailable);
                 continue;
@@ -500,7 +514,11 @@ impl LendingPool {
                 continue;
             }
 
-            let position: u32 = if oracle_bps > market_implied_bps { 1 } else { 2 };
+            let position: u32 = if oracle_bps > market_implied_bps {
+                1
+            } else {
+                2
+            };
 
             let raw_alloc = match tvl
                 .checked_mul(edge_bps as i128)
@@ -524,7 +542,13 @@ impl LendingPool {
                 continue;
             }
 
-            authorize_stake_transfer(&env, &call.stake_token, &contract_address, &market_address, amount);
+            authorize_stake_transfer(
+                &env,
+                &call.stake_token,
+                &contract_address,
+                &market_address,
+                amount,
+            );
             match market.try_stake_on_call(&contract_address, &input.call_id, &amount, &position) {
                 Ok(Ok(_)) => {
                     liquid_remaining = match liquid_remaining.checked_sub(amount) {
@@ -534,7 +558,9 @@ impl LendingPool {
                     let locked = get_total_allocated_locked(&env);
                     set_total_allocated_locked(
                         &env,
-                        locked.checked_add(amount).ok_or(LendingPoolError::Overflow)?,
+                        locked
+                            .checked_add(amount)
+                            .ok_or(LendingPoolError::Overflow)?,
                     );
                     set_allocation(
                         &env,
@@ -569,7 +595,8 @@ impl LendingPool {
     /// recorded for this allocation (can be negative on a loss).
     pub fn harvest_yield(env: Env, call_id: u64) -> Result<i128, LendingPoolError> {
         let config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
-        let mut allocation = get_allocation(&env, call_id).ok_or(LendingPoolError::AllocationNotFound)?;
+        let mut allocation =
+            get_allocation(&env, call_id).ok_or(LendingPoolError::AllocationNotFound)?;
         if allocation.settled {
             return Err(LendingPoolError::AlreadyHarvested);
         }
@@ -635,11 +662,24 @@ impl LendingPool {
                 .ok_or(LendingPoolError::Overflow)?
                 .checked_div(BPS_SCALE)
                 .ok_or(LendingPoolError::Overflow)?;
-            let net = gross_change.checked_sub(fee).ok_or(LendingPoolError::Overflow)?;
+            let net = gross_change
+                .checked_sub(fee)
+                .ok_or(LendingPoolError::Overflow)?;
             if fee > 0 {
-                transfer_token(&env, &config.stake_token, &contract_address, &config.treasury, fee);
+                transfer_token(
+                    &env,
+                    &config.stake_token,
+                    &contract_address,
+                    &config.treasury,
+                    fee,
+                );
                 let total_fees = get_total_fees_paid(&env);
-                set_total_fees_paid(&env, total_fees.checked_add(fee).ok_or(LendingPoolError::Overflow)?);
+                set_total_fees_paid(
+                    &env,
+                    total_fees
+                        .checked_add(fee)
+                        .ok_or(LendingPoolError::Overflow)?,
+                );
             }
             (fee, net)
         } else {
@@ -665,7 +705,9 @@ impl LendingPool {
         let config = get_config(&env).ok_or(LendingPoolError::NotInitialized)?;
         let liquid = token_balance(&env, &config.stake_token);
         let locked = get_total_allocated_locked(&env);
-        let tvl = liquid.checked_add(locked).ok_or(LendingPoolError::Overflow)?;
+        let tvl = liquid
+            .checked_add(locked)
+            .ok_or(LendingPoolError::Overflow)?;
 
         Ok(PoolStats {
             total_deposited: get_total_deposited(&env),

--- a/packages/contracts/lending_pool/src/storage.rs
+++ b/packages/contracts/lending_pool/src/storage.rs
@@ -35,7 +35,9 @@ pub fn get_total_lp_shares(env: &Env) -> i128 {
 }
 
 pub fn set_total_lp_shares(env: &Env, amount: i128) {
-    env.storage().instance().set(&DataKey::TotalLpShares, &amount);
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalLpShares, &amount);
 }
 
 pub fn get_lp_shares(env: &Env, user: &Address) -> i128 {
@@ -61,7 +63,9 @@ pub fn get_total_deposited(env: &Env) -> i128 {
 }
 
 pub fn set_total_deposited(env: &Env, amount: i128) {
-    env.storage().instance().set(&DataKey::TotalDeposited, &amount);
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalDeposited, &amount);
 }
 
 pub fn get_total_yield_earned(env: &Env) -> i128 {
@@ -85,7 +89,9 @@ pub fn get_total_fees_paid(env: &Env) -> i128 {
 }
 
 pub fn set_total_fees_paid(env: &Env, amount: i128) {
-    env.storage().instance().set(&DataKey::TotalFeesPaid, &amount);
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalFeesPaid, &amount);
 }
 
 // ─── Allocated (locked) capital ──────────────────────────────────────────────

--- a/packages/contracts/lending_pool/src/test.rs
+++ b/packages/contracts/lending_pool/src/test.rs
@@ -152,7 +152,7 @@ fn setup_full_stack<'a>() -> TestSetup<'a> {
         &token,
         &factory_id,
         &outcome_id,
-        &100_000i128,      // min_deposit
+        &100_000i128,       // min_deposit
         &1_000_000_000i128, // max_pool_size
         &1_000_000i128,     // min_allocation_pool_size
     );
@@ -192,7 +192,12 @@ fn deploy_market_with_counter_stake(
     let market_addr = setup.factory.deploy_market(&setup.creator, &args);
     let market = PredictionMarketClient::new(env, &market_addr);
     let call_id = market.get_call_id();
-    market.stake_on_call(&setup.counterparty, &call_id, &counter_stake, &counter_position);
+    market.stake_on_call(
+        &setup.counterparty,
+        &call_id,
+        &counter_stake,
+        &counter_position,
+    );
     (market_addr, call_id)
 }
 
@@ -214,7 +219,9 @@ fn resolve_market(setup: &TestSetup, call_id: u64, outcome: u32, end_ts: u64) {
             end_ts + 1,
         ),
     };
-    setup.outcome_mgr.submit_outcome_for_market(&signed, &end_ts);
+    setup
+        .outcome_mgr
+        .submit_outcome_for_market(&signed, &end_ts);
 }
 
 // ─── Deposit / withdraw cycle ────────────────────────────────────────────────
@@ -411,8 +418,7 @@ fn allocate_capital_skips_non_binary_and_small_edge_markets() {
     // A 3-outcome market: this pool's Kelly-edge math only supports binary
     // markets, so it must be skipped rather than mis-handled.
     let end_ts_1 = env.ledger().timestamp() + 3600;
-    let (_market_1, call_1) =
-        deploy_market_with_counter_stake(&setup, end_ts_1, 1_000_000, 1, 3);
+    let (_market_1, call_1) = deploy_market_with_counter_stake(&setup, end_ts_1, 1_000_000, 1, 3);
 
     // A binary market whose implied probability already matches the oracle
     // estimate exactly — zero edge, below the default 100-bps threshold.
@@ -434,7 +440,10 @@ fn allocate_capital_skips_non_binary_and_small_edge_markets() {
     let results = setup.pool.allocate_capital(&markets);
 
     assert_eq!(results.get(0).unwrap(), AllocationOutcome::SkippedNotBinary);
-    assert_eq!(results.get(1).unwrap(), AllocationOutcome::SkippedEdgeTooSmall);
+    assert_eq!(
+        results.get(1).unwrap(),
+        AllocationOutcome::SkippedEdgeTooSmall
+    );
 
     // Nothing was actually staked.
     let stats = setup.pool.get_pool_stats();
@@ -545,7 +554,10 @@ fn pool_apy_and_lp_share_price_grow_after_net_positive_yield() {
     // as the "new depositor".
     let minted = setup.pool.deposit(&setup.counterparty, &1_217_300i128);
     assert_eq!(minted, 1_000_000);
-    assert_eq!(setup.pool.get_user_lp_shares(&setup.counterparty), 1_000_000);
+    assert_eq!(
+        setup.pool.get_user_lp_shares(&setup.counterparty),
+        1_000_000
+    );
     assert_eq!(setup.pool.get_pool_stats().total_lp_shares, 11_000_000);
 }
 

--- a/packages/contracts/lending_pool/src/xcontract.rs
+++ b/packages/contracts/lending_pool/src/xcontract.rs
@@ -135,8 +135,14 @@ pub fn claim_payout_for_market(
         total_losing_stake,
     )
         .into_val(env);
-    let result: Result<Result<(), soroban_sdk::ConversionError>, Result<OutcomeMirrorError, soroban_sdk::InvokeError>> =
-        env.try_invoke_contract(&config.outcome_manager, &Symbol::new(env, "claim_payout_for_market"), args);
+    let result: Result<
+        Result<(), soroban_sdk::ConversionError>,
+        Result<OutcomeMirrorError, soroban_sdk::InvokeError>,
+    > = env.try_invoke_contract(
+        &config.outcome_manager,
+        &Symbol::new(env, "claim_payout_for_market"),
+        args,
+    );
     match result {
         Ok(Ok(())) => Ok(()),
         _ => Err(LendingPoolError::MarketCallFailed),

--- a/packages/contracts/oracle_marketplace/src/lib.rs
+++ b/packages/contracts/oracle_marketplace/src/lib.rs
@@ -11,7 +11,9 @@ mod test;
 pub use types::{MarketplaceConfig, OracleProvider, OracleRating};
 
 use errors::OracleMarketplaceError;
-use events::{emit_oracle_deregistered, emit_oracle_rated, emit_oracle_registered, emit_oracle_selected};
+use events::{
+    emit_oracle_deregistered, emit_oracle_rated, emit_oracle_registered, emit_oracle_selected,
+};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, Vec};
 use storage::*;
 
@@ -124,7 +126,8 @@ impl OracleMarketplace {
         call_id: u64,
         oracle_pubkey: BytesN<32>,
     ) -> Result<(), OracleMarketplaceError> {
-        let oracle = get_oracle(&env, &oracle_pubkey).ok_or(OracleMarketplaceError::OracleNotFound)?;
+        let oracle =
+            get_oracle(&env, &oracle_pubkey).ok_or(OracleMarketplaceError::OracleNotFound)?;
         if !oracle.is_active {
             return Err(OracleMarketplaceError::OracleNotActive);
         }
@@ -145,7 +148,8 @@ impl OracleMarketplace {
         satisfied: bool,
     ) -> Result<(), OracleMarketplaceError> {
         user.require_auth();
-        let _oracle = get_oracle(&env, &oracle_pubkey).ok_or(OracleMarketplaceError::OracleNotFound)?;
+        let _oracle =
+            get_oracle(&env, &oracle_pubkey).ok_or(OracleMarketplaceError::OracleNotFound)?;
 
         let mut ratings = get_oracle_ratings(&env, &oracle_pubkey);
         if ratings.contains_key(user.clone()) {
@@ -163,7 +167,8 @@ impl OracleMarketplace {
         env: Env,
         oracle_pubkey: BytesN<32>,
     ) -> Result<(u64, u64), OracleMarketplaceError> {
-        let oracle = get_oracle(&env, &oracle_pubkey).ok_or(OracleMarketplaceError::OracleNotFound)?;
+        let oracle =
+            get_oracle(&env, &oracle_pubkey).ok_or(OracleMarketplaceError::OracleNotFound)?;
         Ok((oracle.total_resolved, oracle.total_disputes))
     }
 

--- a/packages/contracts/oracle_marketplace/src/storage.rs
+++ b/packages/contracts/oracle_marketplace/src/storage.rs
@@ -19,11 +19,15 @@ pub fn get_config(env: &Env) -> Option<MarketplaceConfig> {
 }
 
 pub fn set_oracle(env: &Env, pubkey: &BytesN<32>, provider: &OracleProvider) {
-    env.storage().instance().set(&DataKey::Oracle(pubkey.clone()), provider);
+    env.storage()
+        .instance()
+        .set(&DataKey::Oracle(pubkey.clone()), provider);
 }
 
 pub fn get_oracle(env: &Env, pubkey: &BytesN<32>) -> Option<OracleProvider> {
-    env.storage().instance().get(&DataKey::Oracle(pubkey.clone()))
+    env.storage()
+        .instance()
+        .get(&DataKey::Oracle(pubkey.clone()))
 }
 
 pub fn set_oracle_list(env: &Env, list: &Vec<BytesN<32>>) {

--- a/packages/contracts/oracle_marketplace/src/test.rs
+++ b/packages/contracts/oracle_marketplace/src/test.rs
@@ -6,10 +6,7 @@ use crate::{
     types::{MarketplaceConfig, OracleProvider},
     OracleMarketplace, OracleMarketplaceClient,
 };
-use soroban_sdk::{
-    testutils::Address as AddressTest,
-    Address, BytesN, Env,
-};
+use soroban_sdk::{testutils::Address as AddressTest, Address, BytesN, Env};
 
 #[test]
 fn initialize_marketplace() {

--- a/packages/contracts/outcome_manager/src/call_types.rs
+++ b/packages/contracts/outcome_manager/src/call_types.rs
@@ -2,7 +2,7 @@
 //! These must stay in sync with `call_registry/src/types.rs` and
 //! `call_registry/src/errors.rs`.
 
-use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Map};
+use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Map, Vec};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -24,6 +24,44 @@ pub enum CallRegistryError {
     FeeTooHigh = 14,
     StakingCutoffActive = 15,
     Sep10TokenExpired = 16,
+    ReentrancyDetected = 17,
+    Overflow = 18,
+    EmptyBasket = 19,
+    InvalidCondition = 20,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum BasketLogic {
+    AllOf,
+    AnyOf,
+    Weighted(u32),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LeafConditionType {
+    TargetAbove(i128),
+    TargetBelow(i128),
+    PercentUp(u32),
+    PercentDown(u32),
+    Range(i128, i128),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssetCondition {
+    pub token_address: Address,
+    pub pair_id: Bytes,
+    pub condition: LeafConditionType,
+    pub weight_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BasketCall {
+    pub conditions: Vec<AssetCondition>,
+    pub logic: BasketLogic,
 }
 
 #[contracttype]
@@ -34,6 +72,7 @@ pub enum ConditionType {
     PercentUp(u32),
     PercentDown(u32),
     Range(i128, i128),
+    Basket(BasketCall),
 }
 
 #[contracttype]
@@ -56,6 +95,7 @@ pub struct Call {
     pub condition: ConditionType,
     pub settled: bool,
     pub voided: bool,
+    pub unresolvable: bool,
     pub created_at: u64,
     pub cancelled: bool,
     pub metadata_version: u32,

--- a/packages/contracts/outcome_manager/src/errors.rs
+++ b/packages/contracts/outcome_manager/src/errors.rs
@@ -72,4 +72,10 @@ pub enum OutcomeError {
     /// The same oracle submitted a second resolution observation for the
     /// same `call_id` via `submit_resolution_observation`.
     DuplicateOracleObservation = 32,
+    /// Basket submission did not include all required condition indices.
+    BasketSubmissionIncomplete = 33,
+    /// A basket submission referenced an out-of-range condition index.
+    InvalidBasketConditionIndex = 34,
+    /// The target call is not a basket call.
+    NotBasketCall = 35,
 }

--- a/packages/contracts/outcome_manager/src/events.rs
+++ b/packages/contracts/outcome_manager/src/events.rs
@@ -146,7 +146,12 @@ pub fn emit_recovery_claimed(
 ) {
     env.events().publish(
         (symbol_short!("recovery"), symbol_short!("claimed")),
-        (recovery_agent.clone(), original_winner.clone(), call_id, amount),
+        (
+            recovery_agent.clone(),
+            original_winner.clone(),
+            call_id,
+            amount,
+        ),
     );
 }
 

--- a/packages/contracts/outcome_manager/src/lib.rs
+++ b/packages/contracts/outcome_manager/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![allow(deprecated)]
+#![allow(clippy::too_many_arguments)]
 
 mod auth;
 mod call_types;
@@ -7,19 +8,19 @@ mod errors;
 mod events;
 #[cfg(test)]
 mod fuzz_tests;
+mod rotation;
 mod storage;
 mod test;
-mod rotation;
 mod verification;
 
-pub use storage::SignedOutcome;
+pub use storage::{SignedBasketCondition, SignedOutcome};
 
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec};
 
 use auth::require_admin;
 use backit_shared::{is_valid_fee_bps, is_valid_outcome};
-use call_types::{Call, CallRegistryError};
+use call_types::{BasketLogic, Call, CallRegistryError, ConditionType, LeafConditionType};
 use errors::OutcomeError;
 use events::{
     emit_admin_params_changed, emit_batch_payout_started, emit_claimable_balance_created,
@@ -79,8 +80,16 @@ fn registry_mark_settled(env: &Env, registry: &Address, call_id: u64) {
     }
 }
 
+fn registry_mark_unresolvable(env: &Env, registry: &Address, call_id: u64) {
+    let args = (call_id,).into_val(env);
+    let result: Result<Call, CallRegistryError> =
+        env.invoke_contract(registry, &Symbol::new(env, "mark_unresolvable"), args);
+    if result.is_err() {
+        soroban_sdk::panic_with_error!(env, OutcomeError::CallNotSettled);
+    }
+}
+
 /// Call `get_call(call_id)` on the CallRegistry and return the decoded Call.
-#[allow(dead_code)]
 fn registry_get_call(env: &Env, registry: &Address, call_id: u64) -> Call {
     let args = (call_id,).into_val(env);
     let result: Result<Call, CallRegistryError> =
@@ -190,6 +199,53 @@ fn require_call_settled(env: &Env, call_id: u64) {
 /// missing timestamp can never be mistaken for an *elapsed* grace period.
 fn get_settled_at(env: &Env, call_id: u64) -> u64 {
     storage::get_settled_at_opt(env, call_id).unwrap_or_else(|| env.ledger().timestamp())
+}
+
+fn build_basket_message(
+    env: &Env,
+    call_id: u64,
+    condition_index: u32,
+    price: i128,
+    timestamp: u64,
+) -> Bytes {
+    let mut msg = Bytes::from_slice(env, b"BACKit:BasketPrice:");
+    msg.append(&Bytes::from_slice(env, &call_id.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(&Bytes::from_slice(env, &condition_index.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(&Bytes::from_slice(env, &price.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(&Bytes::from_slice(env, &timestamp.to_be_bytes()));
+    msg
+}
+
+fn evaluate_leaf_condition(
+    condition: &LeafConditionType,
+    start_price: i128,
+    end_price: i128,
+) -> bool {
+    match condition {
+        LeafConditionType::TargetAbove(target) => end_price > *target,
+        LeafConditionType::TargetBelow(target) => end_price < *target,
+        LeafConditionType::PercentUp(percent) => {
+            if start_price <= 0 {
+                return false;
+            }
+            end_price * 100 >= start_price * (100 + *percent as i128)
+        }
+        LeafConditionType::PercentDown(percent) => {
+            if start_price <= 0 {
+                return false;
+            }
+            end_price * 100 <= start_price * (100 - *percent as i128)
+        }
+        LeafConditionType::Range(min, max) => {
+            if min > max {
+                return false;
+            }
+            end_price >= *min && end_price <= *max
+        }
+    }
 }
 
 fn get_fee_config(env: &Env) -> (u32, Address) {
@@ -509,6 +565,138 @@ impl OutcomeManager {
     pub fn submit_outcome_for_market(env: Env, signed: SignedOutcome, call_end_ts: u64) {
         let registry = Self::resolve_market_address(env.clone(), signed.call_id);
         Self::submit_outcome(env, registry, signed, call_end_ts);
+    }
+
+    /// Submit per-condition oracle price reports for a basket call via factory routing.
+    pub fn submit_basket_outcome_for_market(
+        env: Env,
+        call_id: u64,
+        submissions: Vec<SignedBasketCondition>,
+        call_end_ts: u64,
+    ) {
+        let registry = Self::resolve_market_address(env.clone(), call_id);
+        Self::submit_basket_outcome(env, registry, call_id, submissions, call_end_ts);
+    }
+
+    /// Submit per-condition oracle price reports for a basket call.
+    ///
+    /// Resolves UP when basket logic evaluates to true, otherwise DOWN.
+    /// If submissions are incomplete after the deadline, marks the call unresolvable.
+    pub fn submit_basket_outcome(
+        env: Env,
+        registry: Address,
+        call_id: u64,
+        submissions: Vec<SignedBasketCondition>,
+        call_end_ts: u64,
+    ) {
+        if is_paused(&env) {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::ContractPaused);
+        }
+
+        validate_market_registry(&env, &registry, call_id);
+
+        if env
+            .storage()
+            .instance()
+            .has(&InstanceKey::FinalOutcome(call_id))
+        {
+            soroban_sdk::panic_with_error!(&env, OutcomeError::AlreadySettled);
+        }
+
+        let call = registry_get_call(&env, &registry, call_id);
+        let basket = match call.condition {
+            ConditionType::Basket(basket) => basket,
+            _ => soroban_sdk::panic_with_error!(&env, OutcomeError::NotBasketCall),
+        };
+
+        let expected_len = basket.conditions.len();
+        let now = env.ledger().timestamp();
+        if submissions.len() != expected_len {
+            if now > call_end_ts {
+                registry_mark_unresolvable(&env, &registry, call_id);
+                return;
+            }
+            soroban_sdk::panic_with_error!(&env, OutcomeError::BasketSubmissionIncomplete);
+        }
+
+        let oracles = get_oracles(&env);
+        let mut seen = Map::<u32, bool>::new(&env);
+        let mut total_weight_true: u32 = 0;
+        let mut representative_price: i128 = 0;
+
+        for submission in submissions.iter() {
+            if submission.call_id != call_id {
+                soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidBasketConditionIndex);
+            }
+            if submission.condition_index >= expected_len {
+                soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidBasketConditionIndex);
+            }
+            if seen.get(submission.condition_index).unwrap_or(false) {
+                soroban_sdk::panic_with_error!(&env, OutcomeError::DuplicateSubmission);
+            }
+            if !oracles.contains_key(submission.oracle_pubkey.clone()) {
+                soroban_sdk::panic_with_error!(&env, OutcomeError::UnauthorizedOracle);
+            }
+
+            let message = build_basket_message(
+                &env,
+                submission.call_id,
+                submission.condition_index,
+                submission.price,
+                submission.timestamp,
+            );
+            verify_signature(
+                &env,
+                &submission.oracle_pubkey,
+                &submission.signature,
+                &message,
+            );
+
+            let cond = basket
+                .conditions
+                .get(submission.condition_index)
+                .unwrap_or_else(|| {
+                    soroban_sdk::panic_with_error!(&env, OutcomeError::InvalidBasketConditionIndex)
+                });
+
+            if evaluate_leaf_condition(&cond.condition, call.start_price, submission.price) {
+                total_weight_true = total_weight_true.saturating_add(cond.weight_bps);
+            }
+
+            if submission.condition_index == 0 {
+                representative_price = submission.price;
+            }
+            seen.set(submission.condition_index, true);
+        }
+
+        if seen.keys().len() != expected_len {
+            if now > call_end_ts {
+                registry_mark_unresolvable(&env, &registry, call_id);
+                return;
+            }
+            soroban_sdk::panic_with_error!(&env, OutcomeError::BasketSubmissionIncomplete);
+        }
+
+        let basket_true = match basket.logic {
+            BasketLogic::AllOf => {
+                total_weight_true
+                    == basket
+                        .conditions
+                        .iter()
+                        .fold(0u32, |acc, c| acc.saturating_add(c.weight_bps))
+            }
+            BasketLogic::AnyOf => total_weight_true > 0,
+            BasketLogic::Weighted(threshold_bps) => total_weight_true > threshold_bps,
+        };
+
+        let outcome = if basket_true { 1u32 } else { 2u32 };
+        let finalized = Outcome {
+            call_id,
+            outcome,
+            price: representative_price,
+            timestamp: now,
+        };
+        Self::finalize(&env, &registry, finalized);
     }
 
     /// Claim payout, resolving the market address from the factory.
@@ -1266,7 +1454,9 @@ impl OutcomeManager {
         let (window_secs, min_observations) = get_twap_config(&env);
         match try_compute_twap(&observations, end_ts, window_secs, min_observations) {
             Some(twap) => twap,
-            None => soroban_sdk::panic_with_error!(&env, OutcomeError::InsufficientPriceObservations),
+            None => {
+                soroban_sdk::panic_with_error!(&env, OutcomeError::InsufficientPriceObservations)
+            }
         }
     }
 
@@ -1335,7 +1525,7 @@ impl OutcomeManager {
         env: Env,
         call_id: u64,
         observation: ResolutionObservation,
-        signature: BytesN<64>,
+        _signature: BytesN<64>,
     ) {
         let oracles = get_oracles(&env);
         if !oracles.contains_key(observation.oracle.clone()) {

--- a/packages/contracts/outcome_manager/src/rotation.rs
+++ b/packages/contracts/outcome_manager/src/rotation.rs
@@ -9,9 +9,10 @@ pub fn schedule_oracle_removal(env: &Env, oracle_pubkey: BytesN<32>, effective_l
         "effective_ledger must be in the future"
     );
 
-    env.storage()
-        .persistent()
-        .set(&PersistentKey::PendingOracleRemoval(oracle_pubkey), &effective_ledger);
+    env.storage().persistent().set(
+        &PersistentKey::PendingOracleRemoval(oracle_pubkey),
+        &effective_ledger,
+    );
 }
 
 /// Execute a scheduled oracle removal once the grace period has elapsed.
@@ -38,7 +39,9 @@ pub fn execute_oracle_removal(env: &Env, oracle_pubkey: BytesN<32>) {
         .unwrap_or_else(|| Map::new(env));
 
     oracles.remove(oracle_pubkey.clone());
-    env.storage().instance().set(&InstanceKey::Oracles, &oracles);
+    env.storage()
+        .instance()
+        .set(&InstanceKey::Oracles, &oracles);
 
     // Clean up the dedicated persistent entry
     env.storage().persistent().remove(&key);

--- a/packages/contracts/outcome_manager/src/storage.rs
+++ b/packages/contracts/outcome_manager/src/storage.rs
@@ -28,6 +28,18 @@ pub struct SignedOutcome {
     pub signature: BytesN<64>,
 }
 
+/// A signed price report for one basket condition.
+#[contracttype]
+#[derive(Clone)]
+pub struct SignedBasketCondition {
+    pub call_id: u64,
+    pub condition_index: u32,
+    pub price: i128,
+    pub timestamp: u64,
+    pub oracle_pubkey: BytesN<32>,
+    pub signature: BytesN<64>,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OracleVote {
@@ -257,7 +269,9 @@ pub fn set_settled_at(env: &Env, call_id: u64, ts: u64) {
 
 /// Read the settlement timestamp for `call_id`, if recorded.
 pub fn get_settled_at_opt(env: &Env, call_id: u64) -> Option<u64> {
-    env.storage().instance().get(&InstanceKey::SettledAt(call_id))
+    env.storage()
+        .instance()
+        .get(&InstanceKey::SettledAt(call_id))
 }
 
 pub fn set_recovery_grace_period(env: &Env, secs: u64) {

--- a/packages/contracts/outcome_manager/src/test.rs
+++ b/packages/contracts/outcome_manager/src/test.rs
@@ -4,13 +4,17 @@
 extern crate std;
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, testutils::{Address as _, Ledger as _}, Address, Bytes, BytesN, Env, Map,
-    Vec,
+    contract, contractimpl, contracttype,
+    testutils::{Address as _, Ledger as _},
+    Address, Bytes, BytesN, Env, Map, Vec,
 };
 
-use crate::call_types::{Call, CallRegistryError, ConditionType};
+use crate::call_types::{
+    AssetCondition, BasketCall, BasketLogic, Call, CallRegistryError, ConditionType,
+    LeafConditionType,
+};
 use crate::errors::OutcomeError;
-use crate::storage::{OracleVote, PriceObservation, SignedOutcome};
+use crate::storage::{OracleVote, PriceObservation, SignedBasketCondition, SignedOutcome};
 use crate::{OutcomeManager, OutcomeManagerClient, MAX_ORACLES};
 
 const CLAIM_PAYOUT_BUDGET_CPU: u64 = 10_000_000;
@@ -57,6 +61,7 @@ impl MockRegistry {
             condition: ConditionType::TargetAbove(100),
             settled: false,
             voided: false,
+            unresolvable: false,
             created_at: 0,
             cancelled: false,
             metadata_version: 0,
@@ -103,6 +108,20 @@ impl MockRegistry {
             .instance()
             .set(&MockDataKey::Call(call_id), &call);
         Ok(())
+    }
+
+    pub fn mark_unresolvable(env: Env, call_id: u64) -> Result<Call, CallRegistryError> {
+        let mut call: Call = env
+            .storage()
+            .instance()
+            .get(&MockDataKey::Call(call_id))
+            .unwrap_or_else(|| Self::default_mock_call(&env, call_id));
+        call.unresolvable = true;
+        call.voided = true;
+        env.storage()
+            .instance()
+            .set(&MockDataKey::Call(call_id), &call);
+        Ok(call)
     }
 
     pub fn set_mock_call(env: Env, call_id: u64, call: Call) {
@@ -266,6 +285,7 @@ fn prepare_mock_payout(
         condition: ConditionType::TargetAbove(100),
         settled: true,
         voided: false,
+        unresolvable: false,
         created_at: 500,
         cancelled: false,
         metadata_version: 0,
@@ -322,6 +342,7 @@ fn prepare_mock_batch_payout(
         condition: ConditionType::TargetAbove(100),
         settled: true,
         voided: false,
+        unresolvable: false,
         created_at: 500,
         cancelled: false,
         metadata_version: 0,
@@ -1288,7 +1309,11 @@ fn test_twap_overflow_prevention_large_window() {
     let huge_price = i128::MAX / 2;
     let call_end_ts = 3000u64;
     client.set_twap_config(&2000u64, &3u32);
-    for (price, ts) in [(huge_price, 1_000u64), (huge_price, 2_000), (huge_price, 3_000)] {
+    for (price, ts) in [
+        (huge_price, 1_000u64),
+        (huge_price, 2_000),
+        (huge_price, 3_000),
+    ] {
         let sig = sign_observation(&env, &oracle_secret, call_id, price, ts);
         client.submit_price_observation(
             &call_id,
@@ -1469,7 +1494,9 @@ fn test_is_oracle_active_false_after_effective_ledger() {
     client.schedule_oracle_removal(&oracle_pubkey, &10u32);
 
     // Advance past the effective ledger
-    env.ledger().with_mut(|li| { li.sequence_number = 10; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 10;
+    });
 
     assert!(!client.is_oracle_active(&oracle_pubkey));
 }
@@ -1481,7 +1508,9 @@ fn test_execute_oracle_removal_succeeds_after_grace_period() {
 
     client.schedule_oracle_removal(&oracle_pubkey, &10u32);
 
-    env.ledger().with_mut(|li| { li.sequence_number = 10; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 10;
+    });
     client.execute_oracle_removal(&oracle_pubkey);
 
     // Oracle must be gone from the active oracle set
@@ -1509,16 +1538,25 @@ fn test_rotation_keys_do_not_collide_with_admin_or_quorum() {
 
     client.schedule_oracle_removal(&oracle_pubkey, &10u32);
 
-    env.ledger().with_mut(|li| { li.sequence_number = 10; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 10;
+    });
     client.execute_oracle_removal(&oracle_pubkey);
 
     // Quorum must be unchanged after rotation
-    assert_eq!(client.get_quorum(), quorum_before, "quorum collided with rotation storage");
+    assert_eq!(
+        client.get_quorum(),
+        quorum_before,
+        "quorum collided with rotation storage"
+    );
 
     // Admin functions must still work, proving Admin key is intact
     let (_, extra_pubkey) = gen_keypair(&env);
     client.add_oracle(&extra_pubkey);
-    assert!(client.is_oracle(&extra_pubkey), "admin key corrupted by rotation");
+    assert!(
+        client.is_oracle(&extra_pubkey),
+        "admin key corrupted by rotation"
+    );
 }
 
 // ─── Social Recovery Tests ──────────────────────────────────────────────────
@@ -1759,3 +1797,283 @@ fn test_claim_on_behalf_fails_when_paused() {
     assert_contract_error(result, OutcomeError::ContractPaused);
 }
 
+// ── Basket outcome tests ──────────────────────────────────────────────────────
+
+fn sign_basket_condition(
+    env: &Env,
+    secret: &BytesN<32>,
+    call_id: u64,
+    condition_index: u32,
+    price: i128,
+    timestamp: u64,
+) -> BytesN<64> {
+    use ed25519_dalek::{Signer, SigningKey};
+
+    let mut msg = Bytes::from_slice(env, b"BACKit:BasketPrice:");
+    msg.append(&Bytes::from_slice(env, &call_id.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(&Bytes::from_slice(env, &condition_index.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(&Bytes::from_slice(env, &price.to_be_bytes()));
+    msg.append(&Bytes::from_slice(env, b":"));
+    msg.append(&Bytes::from_slice(env, &timestamp.to_be_bytes()));
+
+    let msg_len = msg.len() as usize;
+    let mut buf = [0u8; 128];
+    msg.copy_into_slice(&mut buf[..msg_len]);
+
+    let signing_key = SigningKey::from_bytes(&secret.to_array());
+    BytesN::from_array(env, &signing_key.sign(&buf[..msg_len]).to_bytes())
+}
+
+fn make_basket_condition(env: &Env, target: i128, weight_bps: u32) -> AssetCondition {
+    AssetCondition {
+        token_address: Address::generate(env),
+        pair_id: Bytes::from_slice(env, b"PAIR"),
+        condition: LeafConditionType::TargetAbove(target),
+        weight_bps,
+    }
+}
+
+fn set_mock_basket_call(
+    env: &Env,
+    registry_id: &Address,
+    call_id: u64,
+    logic: BasketLogic,
+    conditions: Vec<AssetCondition>,
+) {
+    let mock_client = MockRegistryClient::new(env, registry_id);
+    let mut outcome_stakes = Map::new(env);
+    outcome_stakes.set(1, 0);
+    outcome_stakes.set(2, 0);
+    let mut stakes = Map::new(env);
+    stakes.set(1, Map::new(env));
+    stakes.set(2, Map::new(env));
+
+    let call = Call {
+        id: call_id,
+        creator: Address::generate(env),
+        stake_token: Address::generate(env),
+        stake_amount: 1,
+        end_ts: 900,
+        token_address: Address::generate(env),
+        pair_id: Bytes::from_slice(env, b"basket"),
+        metadata_hash: BytesN::from_array(env, &[0u8; 32]),
+        outcome_count: 2,
+        outcome_stakes,
+        stakes,
+        outcome: 0,
+        start_price: 100,
+        end_price: 0,
+        condition: ConditionType::Basket(BasketCall { conditions, logic }),
+        settled: false,
+        voided: false,
+        unresolvable: false,
+        created_at: 0,
+        cancelled: false,
+        metadata_version: 0,
+        share_tokens: Map::new(env),
+    };
+    mock_client.set_mock_call(&call_id, &call);
+}
+
+#[test]
+fn test_basket_allof_all_winning() {
+    let env = Env::default();
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 42u64;
+
+    let mut conditions = Vec::new(&env);
+    conditions.push_back(make_basket_condition(&env, 110, 5_000));
+    conditions.push_back(make_basket_condition(&env, 120, 5_000));
+    set_mock_basket_call(&env, &registry_id, call_id, BasketLogic::AllOf, conditions);
+
+    let mut submissions = Vec::new(&env);
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 0,
+        price: 130,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 0, 130, 1000),
+    });
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 1,
+        price: 140,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 1, 140, 1000),
+    });
+
+    client.submit_basket_outcome(&registry_id, &call_id, &submissions, &900u64);
+    assert_eq!(client.get_outcome(&call_id).outcome, 1);
+}
+
+#[test]
+fn test_basket_allof_one_losing() {
+    let env = Env::default();
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 43u64;
+
+    let mut conditions = Vec::new(&env);
+    conditions.push_back(make_basket_condition(&env, 110, 5_000));
+    conditions.push_back(make_basket_condition(&env, 120, 5_000));
+    set_mock_basket_call(&env, &registry_id, call_id, BasketLogic::AllOf, conditions);
+
+    let mut submissions = Vec::new(&env);
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 0,
+        price: 130,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 0, 130, 1000),
+    });
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 1,
+        price: 100,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 1, 100, 1000),
+    });
+
+    client.submit_basket_outcome(&registry_id, &call_id, &submissions, &900u64);
+    assert_eq!(client.get_outcome(&call_id).outcome, 2);
+}
+
+#[test]
+fn test_basket_anyof_all_winning() {
+    let env = Env::default();
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 44u64;
+
+    let mut conditions = Vec::new(&env);
+    conditions.push_back(make_basket_condition(&env, 110, 5_000));
+    conditions.push_back(make_basket_condition(&env, 120, 5_000));
+    set_mock_basket_call(&env, &registry_id, call_id, BasketLogic::AnyOf, conditions);
+
+    let mut submissions = Vec::new(&env);
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 0,
+        price: 130,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 0, 130, 1000),
+    });
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 1,
+        price: 140,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 1, 140, 1000),
+    });
+
+    client.submit_basket_outcome(&registry_id, &call_id, &submissions, &900u64);
+    assert_eq!(client.get_outcome(&call_id).outcome, 1);
+}
+
+#[test]
+fn test_basket_anyof_one_winning() {
+    let env = Env::default();
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 45u64;
+
+    let mut conditions = Vec::new(&env);
+    conditions.push_back(make_basket_condition(&env, 110, 5_000));
+    conditions.push_back(make_basket_condition(&env, 120, 5_000));
+    set_mock_basket_call(&env, &registry_id, call_id, BasketLogic::AnyOf, conditions);
+
+    let mut submissions = Vec::new(&env);
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 0,
+        price: 100,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 0, 100, 1000),
+    });
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 1,
+        price: 130,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 1, 130, 1000),
+    });
+
+    client.submit_basket_outcome(&registry_id, &call_id, &submissions, &900u64);
+    assert_eq!(client.get_outcome(&call_id).outcome, 1);
+}
+
+#[test]
+fn test_basket_weighted_resolution() {
+    let env = Env::default();
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 46u64;
+
+    let mut conditions = Vec::new(&env);
+    conditions.push_back(make_basket_condition(&env, 110, 6_000));
+    conditions.push_back(make_basket_condition(&env, 120, 4_000));
+    set_mock_basket_call(
+        &env,
+        &registry_id,
+        call_id,
+        BasketLogic::Weighted(5_000),
+        conditions,
+    );
+
+    let mut submissions = Vec::new(&env);
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 0,
+        price: 130,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 0, 130, 1000),
+    });
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 1,
+        price: 100,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 1, 100, 1000),
+    });
+
+    client.submit_basket_outcome(&registry_id, &call_id, &submissions, &900u64);
+    assert_eq!(client.get_outcome(&call_id).outcome, 1);
+}
+
+#[test]
+fn test_basket_incomplete_after_deadline_marks_unresolvable() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_admin, registry_id, oracle_secret, oracle_pubkey, client) = setup_single_oracle(&env);
+    let call_id = 47u64;
+
+    let mut conditions = Vec::new(&env);
+    conditions.push_back(make_basket_condition(&env, 110, 5_000));
+    conditions.push_back(make_basket_condition(&env, 120, 5_000));
+    set_mock_basket_call(&env, &registry_id, call_id, BasketLogic::AllOf, conditions);
+
+    let mut submissions = Vec::new(&env);
+    submissions.push_back(SignedBasketCondition {
+        call_id,
+        condition_index: 0,
+        price: 130,
+        timestamp: 1000,
+        oracle_pubkey: oracle_pubkey.clone(),
+        signature: sign_basket_condition(&env, &oracle_secret, call_id, 0, 130, 1000),
+    });
+
+    client.submit_basket_outcome(&registry_id, &call_id, &submissions, &900u64);
+
+    let mock = MockRegistryClient::new(&env, &registry_id);
+    let updated = mock.get_call(&call_id);
+    assert!(updated.unresolvable);
+    assert!(updated.voided);
+}

--- a/packages/contracts/parlay_betting/src/lib.rs
+++ b/packages/contracts/parlay_betting/src/lib.rs
@@ -82,7 +82,11 @@ pub struct ParlayBetting;
 
 #[contractimpl]
 impl ParlayBetting {
-    pub fn initialize(env: Env, admin: Address, outcome_manager: Address) -> Result<(), ParlayError> {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        outcome_manager: Address,
+    ) -> Result<(), ParlayError> {
         if get_config(&env).is_some() {
             return Err(ParlayError::AlreadyInitialized);
         }

--- a/packages/contracts/parlay_betting/src/test.rs
+++ b/packages/contracts/parlay_betting/src/test.rs
@@ -289,17 +289,11 @@ fn three_leg_parlay_all_win() {
 
     resolve_market(&setup, call_1, OUTCOME_UP, end_ts_1);
     setup.parlay.advance_parlay(&parlay_id);
-    assert_eq!(
-        setup.parlay.get_parlay(&parlay_id).active_leg_index,
-        1
-    );
+    assert_eq!(setup.parlay.get_parlay(&parlay_id).active_leg_index, 1);
 
     resolve_market(&setup, call_2, OUTCOME_UP, end_ts_2);
     setup.parlay.advance_parlay(&parlay_id);
-    assert_eq!(
-        setup.parlay.get_parlay(&parlay_id).active_leg_index,
-        2
-    );
+    assert_eq!(setup.parlay.get_parlay(&parlay_id).active_leg_index, 2);
 
     resolve_market(&setup, call_3, OUTCOME_UP, end_ts_3);
     setup.parlay.advance_parlay(&parlay_id);
@@ -343,10 +337,7 @@ fn parlay_loses_on_leg_1() {
     assert_eq!(final_parlay.status, ParlayStatus::Lost);
     assert_eq!(final_parlay.total_escrowed, 0);
     // The initial stake was lost to the pool — no refund.
-    assert_eq!(
-        token.balance(&setup.user),
-        user_balance_before - 1_000_000
-    );
+    assert_eq!(token.balance(&setup.user), user_balance_before - 1_000_000);
 }
 
 #[test]

--- a/packages/contracts/prediction_market/src/events.rs
+++ b/packages/contracts/prediction_market/src/events.rs
@@ -80,12 +80,7 @@ pub fn emit_reserve_discrepancy(env: &Env, call_id: u64, discrepancy: i128) {
     );
 }
 
-pub fn emit_early_staker_bonus(
-    env: &Env,
-    call_id: u64,
-    staker: &Address,
-    bonus: i128,
-) {
+pub fn emit_early_staker_bonus(env: &Env, call_id: u64, staker: &Address, bonus: i128) {
     env.events().publish(
         ("prediction_market", "early_staker_bonus"),
         (call_id, staker.clone(), bonus),
@@ -131,7 +126,14 @@ pub fn emit_limit_order_filled(
 ) {
     env.events().publish(
         ("prediction_market", "limit_order_filled"),
-        (order_id, call_id, user.clone(), outcome, amount, filled_price),
+        (
+            order_id,
+            call_id,
+            user.clone(),
+            outcome,
+            amount,
+            filled_price,
+        ),
     );
 }
 

--- a/packages/contracts/prediction_market/src/lib.rs
+++ b/packages/contracts/prediction_market/src/lib.rs
@@ -106,7 +106,11 @@ fn with_lock<T>(env: &Env, f: impl FnOnce() -> Result<T, MarketError>) -> Result
 /// #465: Shared checked-arithmetic helper: adds `amount` to `current` and,
 /// if `config.max_stake_per_user` is set, rejects the result if it would
 /// exceed the cap. Returns the updated total on success.
-fn check_max_stake(config: &MarketConfig, current: i128, amount: i128) -> Result<i128, MarketError> {
+fn check_max_stake(
+    config: &MarketConfig,
+    current: i128,
+    amount: i128,
+) -> Result<i128, MarketError> {
     let updated = current.checked_add(amount).ok_or(MarketError::Overflow)?;
     if config.max_stake_per_user > 0 && updated > config.max_stake_per_user {
         return Err(MarketError::InvalidStakeAmount);
@@ -139,7 +143,9 @@ fn apply_stake(
     let updated_staker_stake = check_max_stake(config, current_staker_stake, amount)?;
 
     let current_total = call.outcome_stakes.get(position).unwrap_or(0);
-    let updated_total = current_total.checked_add(amount).ok_or(MarketError::Overflow)?;
+    let updated_total = current_total
+        .checked_add(amount)
+        .ok_or(MarketError::Overflow)?;
 
     call.outcome_stakes.set(position, updated_total);
     outcome_stakers.set(staker.clone(), updated_staker_stake);
@@ -398,6 +404,7 @@ impl PredictionMarket {
             condition,
             settled: false,
             voided: false,
+            unresolvable: false,
             created_at: current_timestamp,
             cancelled: false,
             metadata_version: 0,
@@ -670,7 +677,11 @@ impl PredictionMarket {
     /// caller receives `config.expired_order_refund_bps` of the escrowed
     /// amount as a small reward for the cleanup, and the remainder goes back
     /// to the order's original owner.
-    pub fn refund_expired_order(env: Env, caller: Address, order_id: u64) -> Result<(), MarketError> {
+    pub fn refund_expired_order(
+        env: Env,
+        caller: Address,
+        order_id: u64,
+    ) -> Result<(), MarketError> {
         caller.require_auth();
         with_lock(&env, || {
             let order = get_limit_order(&env, order_id).ok_or(MarketError::OrderNotFound)?;
@@ -688,7 +699,10 @@ impl PredictionMarket {
                 .ok_or(MarketError::Overflow)?
                 .checked_div(10_000)
                 .ok_or(MarketError::Overflow)?;
-            let refund_to_user = order.amount.checked_sub(reward).ok_or(MarketError::Overflow)?;
+            let refund_to_user = order
+                .amount
+                .checked_sub(reward)
+                .ok_or(MarketError::Overflow)?;
 
             if reward > 0 {
                 transfer_token(
@@ -934,9 +948,7 @@ impl PredictionMarket {
     }
 
     /// #497: Get current reserve status (view function).
-    pub fn get_reserve_status(
-        env: Env,
-    ) -> Result<ReserveVerification, MarketError> {
+    pub fn get_reserve_status(env: Env) -> Result<ReserveVerification, MarketError> {
         let _config = get_config(&env).ok_or(MarketError::NotInitialized)?;
         let call = get_call(&env).ok_or(MarketError::CallNotFound)?;
 

--- a/packages/contracts/prediction_market/src/storage.rs
+++ b/packages/contracts/prediction_market/src/storage.rs
@@ -83,9 +83,10 @@ pub fn get_user_stake_timestamp(env: &Env, staker: &Address, position: u32) -> u
 }
 
 pub fn set_user_has_withdrawn(env: &Env, staker: &Address, position: u32, withdrawn: bool) {
-    env.storage()
-        .instance()
-        .set(&DataKey::UserHasWithdrawn(staker.clone(), position), &withdrawn);
+    env.storage().instance().set(
+        &DataKey::UserHasWithdrawn(staker.clone(), position),
+        &withdrawn,
+    );
 }
 
 pub fn get_user_has_withdrawn(env: &Env, staker: &Address, position: u32) -> bool {
@@ -103,7 +104,9 @@ pub fn get_early_staker_count(env: &Env) -> u64 {
 }
 
 pub fn set_early_staker_count(env: &Env, count: u64) {
-    env.storage().instance().set(&DataKey::EarlyStakerCount, &count);
+    env.storage()
+        .instance()
+        .set(&DataKey::EarlyStakerCount, &count);
 }
 
 pub fn get_total_early_staker_bonus_paid(env: &Env) -> i128 {
@@ -123,9 +126,15 @@ pub fn set_total_early_staker_bonus_paid(env: &Env, total: i128) {
 
 /// Allocate the next limit order id (monotonically increasing, starts at 1).
 pub fn next_order_id(env: &Env) -> u64 {
-    let counter: u64 = env.storage().instance().get(&DataKey::NextOrderId).unwrap_or(0);
+    let counter: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::NextOrderId)
+        .unwrap_or(0);
     let next_id = counter + 1;
-    env.storage().instance().set(&DataKey::NextOrderId, &next_id);
+    env.storage()
+        .instance()
+        .set(&DataKey::NextOrderId, &next_id);
     next_id
 }
 
@@ -156,7 +165,9 @@ pub fn get_limit_order(env: &Env, order_id: u64) -> Option<LimitOrder> {
 
 /// Remove a limit order's persistent storage entry (fill / cancel / refund).
 pub fn remove_limit_order(env: &Env, order_id: u64) {
-    env.storage().persistent().remove(&DataKey::LimitOrder(order_id));
+    env.storage()
+        .persistent()
+        .remove(&DataKey::LimitOrder(order_id));
 }
 
 /// Retrieve the list of open order ids for a call, refreshing TTL if non-empty.

--- a/packages/contracts/prediction_market/src/test.rs
+++ b/packages/contracts/prediction_market/src/test.rs
@@ -168,14 +168,25 @@ fn limit_order_created_escrows_tokens_and_is_listed() {
     let orderer = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 0, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        0,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     let token_client = TokenClient::new(&env, &token);
 
     token_client.transfer(&admin, &orderer, &5_000);
     assert_eq!(token_client.balance(&orderer), 5_000);
 
-    let order_id = market.create_limit_order(&orderer, &1u64, &1u32, &2_000i128, &3_000u32, &3600u64);
+    let order_id =
+        market.create_limit_order(&orderer, &1u64, &1u32, &2_000i128, &3_000u32, &3600u64);
     assert_eq!(order_id, 1);
 
     // Escrow transferred out of the orderer's wallet into the contract.
@@ -209,16 +220,28 @@ fn limit_order_rejects_invalid_target_and_ttl() {
     let orderer = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 0, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        0,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     TokenClient::new(&env, &token).transfer(&admin, &orderer, &10_000);
 
     // target_implied_probability_bps > 10_000 is invalid.
-    let result = market.try_create_limit_order(&orderer, &1u64, &1u32, &1_000i128, &10_001u32, &3600u64);
+    let result =
+        market.try_create_limit_order(&orderer, &1u64, &1u32, &1_000i128, &10_001u32, &3600u64);
     assert_eq!(result, Err(Ok(MarketError::InvalidTargetProbability)));
 
     // ttl_secs == 0 is invalid.
-    let result = market.try_create_limit_order(&orderer, &1u64, &1u32, &1_000i128, &3_000u32, &0u64);
+    let result =
+        market.try_create_limit_order(&orderer, &1u64, &1u32, &1_000i128, &3_000u32, &0u64);
     assert_eq!(result, Err(Ok(MarketError::InvalidOrderTTL)));
 
     // ttl_secs beyond MAX_ORDER_TTL_SECS (7 days) is invalid.
@@ -260,7 +283,17 @@ fn limit_order_fills_when_target_probability_reached() {
     let orderer = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 0, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        0,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -273,7 +306,8 @@ fn limit_order_fills_when_target_probability_reached() {
 
     // Pool is 3_000 / 7_000 (30% on outcome 1). Order wants <= 20% — must not
     // fill immediately, and creation only escrows, it never matches itself.
-    let order_id = market.create_limit_order(&orderer, &1u64, &1u32, &1_000i128, &2_000u32, &3600u64);
+    let order_id =
+        market.create_limit_order(&orderer, &1u64, &1u32, &1_000i128, &2_000u32, &3600u64);
     assert_eq!(market.get_staker_stake(&1u64, &orderer, &1u32), 0);
     assert_eq!(market.get_open_orders(&1u64).len(), 1);
 
@@ -311,12 +345,23 @@ fn limit_order_cancelled_before_fill_refunds_escrow() {
     let stranger = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 0, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        0,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     let token_client = TokenClient::new(&env, &token);
     token_client.transfer(&admin, &orderer, &10_000);
 
-    let order_id = market.create_limit_order(&orderer, &1u64, &1u32, &4_000i128, &3_000u32, &3600u64);
+    let order_id =
+        market.create_limit_order(&orderer, &1u64, &1u32, &4_000i128, &3_000u32, &3600u64);
     assert_eq!(token_client.balance(&orderer), 6_000);
 
     // Only the owner may cancel.
@@ -351,7 +396,17 @@ fn limit_order_expired_is_not_matched_and_is_refundable_with_reward() {
     let staker = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 0, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        0,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     let token_client = TokenClient::new(&env, &token);
     token_client.transfer(&admin, &orderer, &10_000);
@@ -361,7 +416,8 @@ fn limit_order_expired_is_not_matched_and_is_refundable_with_reward() {
     // Target of 10_000 bps (100%) always matches once any stake exists, so
     // if this order is NOT filled after expiry, that proves the matching
     // loop correctly skips expired orders rather than filling them.
-    let order_id = market.create_limit_order(&orderer, &1u64, &1u32, &4_000i128, &10_000u32, &100u64);
+    let order_id =
+        market.create_limit_order(&orderer, &1u64, &1u32, &4_000i128, &10_000u32, &100u64);
 
     // Refunding before expiry must fail.
     let result = market.try_refund_expired_order(&refunder, &order_id);
@@ -406,7 +462,17 @@ fn limit_order_multiple_orders_fill_in_sequence() {
     let order_c = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 0, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        0,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     let token_client = TokenClient::new(&env, &token);
     for a in [&seed_staker, &pusher, &order_a, &order_b, &order_c] {
@@ -473,7 +539,17 @@ fn limit_order_matching_cap_leaves_excess_orders_open_for_next_stake() {
     let trigger_staker = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 0, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        0,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     let token_client = TokenClient::new(&env, &token);
     token_client.transfer(&admin, &seed_staker, &1_000_000);
@@ -548,7 +624,17 @@ fn limit_order_over_cap_is_skipped_without_aborting_triggering_stake() {
     let trigger_staker = Address::generate(&env);
     let token = setup_token(&env, &admin);
 
-    let market_id = setup_market(&env, &creator, &outcome_manager, &factory, &token, 1, 1, 500, 2);
+    let market_id = setup_market(
+        &env,
+        &creator,
+        &outcome_manager,
+        &factory,
+        &token,
+        1,
+        1,
+        500,
+        2,
+    );
     let market = PredictionMarketClient::new(&env, &market_id);
     let token_client = TokenClient::new(&env, &token);
     token_client.transfer(&admin, &capped_orderer, &10_000);
@@ -556,8 +642,16 @@ fn limit_order_over_cap_is_skipped_without_aborting_triggering_stake() {
 
     market.stake_on_call(&capped_orderer, &1u64, &400i128, &1u32);
 
-    let order1 = market.create_limit_order(&capped_orderer, &1u64, &1u32, &50i128, &10_000u32, &3600u64);
-    let order2 = market.create_limit_order(&capped_orderer, &1u64, &1u32, &100i128, &10_000u32, &3600u64);
+    let order1 =
+        market.create_limit_order(&capped_orderer, &1u64, &1u32, &50i128, &10_000u32, &3600u64);
+    let order2 = market.create_limit_order(
+        &capped_orderer,
+        &1u64,
+        &1u32,
+        &100i128,
+        &10_000u32,
+        &3600u64,
+    );
     assert_eq!(market.get_open_orders(&1u64).len(), 2);
 
     // Trigger matching. trigger_staker is unrelated to capped_orderer's cap.

--- a/packages/contracts/prediction_market/src/types.rs
+++ b/packages/contracts/prediction_market/src/types.rs
@@ -47,6 +47,8 @@ pub struct Call {
     pub condition: ConditionType,
     pub settled: bool,
     pub voided: bool,
+    /// Whether the call became unresolvable due to incomplete oracle basket data.
+    pub unresolvable: bool,
     pub created_at: u64,
     pub cancelled: bool,
     pub metadata_version: u32,

--- a/packages/contracts/prediction_market_factory/src/lib.rs
+++ b/packages/contracts/prediction_market_factory/src/lib.rs
@@ -15,7 +15,10 @@ mod test;
 
 use conditional_staking::{ConditionalStrategy, StrategyAction, StrategyTrigger};
 use errors::FactoryError;
-use events::{emit_factory_initialized, emit_market_deployed, emit_strategy_cancelled, emit_strategy_created, emit_strategy_executed};
+use events::{
+    emit_factory_initialized, emit_market_deployed, emit_strategy_cancelled, emit_strategy_created,
+    emit_strategy_executed,
+};
 use prediction_market::MarketInitArgs;
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, Map, String, Vec};
 use storage::*;
@@ -271,10 +274,7 @@ impl PredictionMarketFactory {
     }
 
     /// #499: Execute a conditional strategy (keeper pattern).
-    pub fn execute_strategy(
-        env: Env,
-        strategy_id: u64,
-    ) -> Result<(), FactoryError> {
+    pub fn execute_strategy(env: Env, strategy_id: u64) -> Result<(), FactoryError> {
         let strategy = get_strategy(&env, strategy_id).ok_or(FactoryError::StrategyNotFound)?;
 
         if strategy.executed {
@@ -301,11 +301,7 @@ impl PredictionMarketFactory {
     }
 
     /// #499: Cancel a conditional strategy before it executes.
-    pub fn cancel_strategy(
-        env: Env,
-        user: Address,
-        strategy_id: u64,
-    ) -> Result<(), FactoryError> {
+    pub fn cancel_strategy(env: Env, user: Address, strategy_id: u64) -> Result<(), FactoryError> {
         user.require_auth();
 
         let strategy = get_strategy(&env, strategy_id).ok_or(FactoryError::StrategyNotFound)?;
@@ -326,10 +322,7 @@ impl PredictionMarketFactory {
     }
 
     /// #499: Get all strategies for a user.
-    pub fn get_user_strategies(
-        env: Env,
-        user: Address,
-    ) -> Vec<ConditionalStrategy> {
+    pub fn get_user_strategies(env: Env, user: Address) -> Vec<ConditionalStrategy> {
         let ids = storage::get_user_strategies(&env, &user);
         let mut result = Vec::new(&env);
         for i in 0..ids.len() {
@@ -361,11 +354,7 @@ impl PredictionMarketFactory {
     }
 
     /// #471: Batch stake across multiple prediction markets.
-    pub fn batch_stake(
-        env: Env,
-        user: Address,
-        stakes_count: u32,
-    ) -> Result<u32, FactoryError> {
+    pub fn batch_stake(env: Env, user: Address, stakes_count: u32) -> Result<u32, FactoryError> {
         user.require_auth();
         if stakes_count > 10 {
             return Err(FactoryError::InvalidStakeAmount);

--- a/packages/contracts/prediction_market_factory/src/storage.rs
+++ b/packages/contracts/prediction_market_factory/src/storage.rs
@@ -85,7 +85,9 @@ pub fn next_strategy_id(env: &Env) -> u64 {
 }
 
 pub fn set_strategy(env: &Env, id: u64, strategy: &ConditionalStrategy) {
-    env.storage().instance().set(&DataKey::Strategy(id), strategy);
+    env.storage()
+        .instance()
+        .set(&DataKey::Strategy(id), strategy);
 }
 
 pub fn get_strategy(env: &Env, id: u64) -> Option<ConditionalStrategy> {

--- a/packages/contracts/schelling_oracle/src/events.rs
+++ b/packages/contracts/schelling_oracle/src/events.rs
@@ -38,7 +38,12 @@ pub fn emit_vote_committed(
 ) {
     env.events().publish(
         ("schelling_oracle", "vote_committed"),
-        (dispute_id, voter.clone(), commitment_hash.clone(), stake_amount),
+        (
+            dispute_id,
+            voter.clone(),
+            commitment_hash.clone(),
+            stake_amount,
+        ),
     );
 }
 

--- a/packages/contracts/schelling_oracle/src/lib.rs
+++ b/packages/contracts/schelling_oracle/src/lib.rs
@@ -70,9 +70,7 @@ mod types;
 mod test;
 
 use errors::OracleError;
-use events::{
-    emit_dispute_opened, emit_dispute_resolved, emit_vote_committed, emit_vote_revealed,
-};
+use events::{emit_dispute_opened, emit_dispute_resolved, emit_vote_committed, emit_vote_revealed};
 use soroban_sdk::{contract, contractimpl, token, Address, Bytes, BytesN, Env};
 use storage::*;
 use types::{Dispute, DisputeConfig, DisputeResult, VoteCommitment};
@@ -139,7 +137,10 @@ fn checked_sub(a: i128, b: i128) -> Result<i128, OracleError> {
 }
 
 fn compute_min_bond(total_pool_amount: i128, bond_bps: u32) -> Result<i128, OracleError> {
-    checked_div(checked_mul(total_pool_amount, bond_bps as i128)?, BPS_DENOMINATOR)
+    checked_div(
+        checked_mul(total_pool_amount, bond_bps as i128)?,
+        BPS_DENOMINATOR,
+    )
 }
 
 #[contract]
@@ -244,7 +245,13 @@ impl SchellingOracle {
         }
 
         let contract_address = env.current_contract_address();
-        transfer_token(&env, &stake_token, &disputer, &contract_address, bond_amount);
+        transfer_token(
+            &env,
+            &stake_token,
+            &disputer,
+            &contract_address,
+            bond_amount,
+        );
 
         let now = env.ledger().timestamp();
         let commit_deadline = now
@@ -385,7 +392,13 @@ impl SchellingOracle {
         commitment.revealed_outcome = vote_outcome;
         set_commitment(&env, dispute_id, &voter, &commitment);
 
-        emit_vote_revealed(&env, dispute_id, &voter, vote_outcome, commitment.stake_amount);
+        emit_vote_revealed(
+            &env,
+            dispute_id,
+            &voter,
+            vote_outcome,
+            commitment.stake_amount,
+        );
         Ok(())
     }
 
@@ -465,8 +478,8 @@ impl SchellingOracle {
         let mut disputed_total: i128 = 0;
         let mut unrevealed_total: i128 = 0;
         for voter in voters.iter() {
-            let commitment = get_commitment(&env, dispute_id, &voter)
-                .ok_or(OracleError::NoCommitmentFound)?;
+            let commitment =
+                get_commitment(&env, dispute_id, &voter).ok_or(OracleError::NoCommitmentFound)?;
             if !commitment.revealed {
                 unrevealed_total = checked_add(unrevealed_total, commitment.stake_amount)?;
             } else if commitment.revealed_outcome == dispute.original_outcome {
@@ -528,7 +541,8 @@ impl SchellingOracle {
                 for voter in voters.iter() {
                     let commitment = get_commitment(&env, dispute_id, &voter)
                         .ok_or(OracleError::NoCommitmentFound)?;
-                    if commitment.revealed && commitment.revealed_outcome == dispute.original_outcome
+                    if commitment.revealed
+                        && commitment.revealed_outcome == dispute.original_outcome
                     {
                         let share = checked_div(
                             checked_mul(commitment.stake_amount, reward_pool)?,

--- a/packages/contracts/schelling_oracle/src/test.rs
+++ b/packages/contracts/schelling_oracle/src/test.rs
@@ -178,7 +178,13 @@ fn vote_on_dispute_rejects_after_commit_deadline() {
     fund(&h.env, &h.token, &h.admin, &voter, 1_000_000);
 
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
 
     advance(&h.env, 1_001);
@@ -199,15 +205,20 @@ fn reveal_vote_rejects_before_commit_deadline() {
     fund(&h.env, &h.token, &h.admin, &voter, 1_000_000);
 
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let s = salt(&h.env, 1);
     let hash = commit_hash(&h.env, ORIGINAL, &s);
-    h.client.vote_on_dispute(&voter, &dispute_id, &hash, &10_000i128);
+    h.client
+        .vote_on_dispute(&voter, &dispute_id, &hash, &10_000i128);
 
-    let result = h
-        .client
-        .try_reveal_vote(&voter, &dispute_id, &ORIGINAL, &s);
+    let result = h.client.try_reveal_vote(&voter, &dispute_id, &ORIGINAL, &s);
     assert_contract_error(result, OracleError::RevealPeriodNotStarted);
 }
 
@@ -220,16 +231,21 @@ fn reveal_vote_rejects_after_reveal_deadline() {
     fund(&h.env, &h.token, &h.admin, &voter, 1_000_000);
 
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let s = salt(&h.env, 1);
     let hash = commit_hash(&h.env, ORIGINAL, &s);
-    h.client.vote_on_dispute(&voter, &dispute_id, &hash, &10_000i128);
+    h.client
+        .vote_on_dispute(&voter, &dispute_id, &hash, &10_000i128);
 
     advance(&h.env, 2_001);
-    let result = h
-        .client
-        .try_reveal_vote(&voter, &dispute_id, &ORIGINAL, &s);
+    let result = h.client.try_reveal_vote(&voter, &dispute_id, &ORIGINAL, &s);
     assert_contract_error(result, OracleError::RevealPeriodEnded);
 }
 
@@ -242,17 +258,22 @@ fn reveal_vote_rejects_hash_mismatch() {
     fund(&h.env, &h.token, &h.admin, &voter, 1_000_000);
 
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let s = salt(&h.env, 1);
     let hash = commit_hash(&h.env, ORIGINAL, &s);
-    h.client.vote_on_dispute(&voter, &dispute_id, &hash, &10_000i128);
+    h.client
+        .vote_on_dispute(&voter, &dispute_id, &hash, &10_000i128);
 
     advance(&h.env, 1_001);
     // Reveal with a different outcome than committed -> hash mismatch.
-    let result = h
-        .client
-        .try_reveal_vote(&voter, &dispute_id, &DISPUTED, &s);
+    let result = h.client.try_reveal_vote(&voter, &dispute_id, &DISPUTED, &s);
     assert_contract_error(result, OracleError::CommitmentMismatch);
 
     // Also try the correct outcome but a wrong salt.
@@ -269,7 +290,13 @@ fn resolve_dispute_rejects_before_reveal_deadline() {
     let disputer = Address::generate(&h.env);
     fund(&h.env, &h.token, &h.admin, &disputer, 1_000_000);
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let result = h.client.try_resolve_dispute(&dispute_id);
     assert_contract_error(result, OracleError::RevealPeriodNotEnded);
@@ -295,15 +322,36 @@ fn honest_majority_wins_disputer_loses_bond() {
 
     let bond = 50_000i128; // 5% of 1_000_000
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &bond,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &bond,
     );
 
     let s1 = salt(&h.env, 1);
     let s2 = salt(&h.env, 2);
     let s3 = salt(&h.env, 3);
-    h.client.vote_on_dispute(&v1, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s1), &30_000);
-    h.client.vote_on_dispute(&v2, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s2), &70_000);
-    h.client.vote_on_dispute(&v3, &dispute_id, &commit_hash(&h.env, DISPUTED, &s3), &20_000);
+    h.client.vote_on_dispute(
+        &v1,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s1),
+        &30_000,
+    );
+    h.client.vote_on_dispute(
+        &v2,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s2),
+        &70_000,
+    );
+    h.client.vote_on_dispute(
+        &v3,
+        &dispute_id,
+        &commit_hash(&h.env, DISPUTED, &s3),
+        &20_000,
+    );
 
     advance(&h.env, 1_001);
     h.client.reveal_vote(&v1, &dispute_id, &ORIGINAL, &s1);
@@ -359,13 +407,29 @@ fn dishonest_majority_disputer_wins() {
 
     let bond = 50_000i128;
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &bond,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &bond,
     );
 
     let s1 = salt(&h.env, 1);
     let s2 = salt(&h.env, 2);
-    h.client.vote_on_dispute(&v1, &dispute_id, &commit_hash(&h.env, DISPUTED, &s1), &80_000);
-    h.client.vote_on_dispute(&v2, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s2), &40_000);
+    h.client.vote_on_dispute(
+        &v1,
+        &dispute_id,
+        &commit_hash(&h.env, DISPUTED, &s1),
+        &80_000,
+    );
+    h.client.vote_on_dispute(
+        &v2,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s2),
+        &40_000,
+    );
 
     advance(&h.env, 1_001);
     h.client.reveal_vote(&v1, &dispute_id, &DISPUTED, &s1);
@@ -380,7 +444,8 @@ fn dishonest_majority_disputer_wins() {
 
     // Disputer gets bond back (50_000) + the losing voters' forfeited stake
     // (v2's 40_000) = 90_000.
-    let disputer_payout = TokenClient::new(&h.env, &h.token).balance(&disputer) - disputer_balance_before;
+    let disputer_payout =
+        TokenClient::new(&h.env, &h.token).balance(&disputer) - disputer_balance_before;
     assert_eq!(disputer_payout, 90_000);
 
     // v1 (correct, sided with disputer) just gets their own stake back.
@@ -412,13 +477,29 @@ fn unrevealed_votes_are_forfeited() {
 
     let bond = 50_000i128;
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &bond,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &bond,
     );
 
     let s1 = salt(&h.env, 1);
     let s2 = salt(&h.env, 2);
-    h.client.vote_on_dispute(&v1, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s1), &50_000);
-    h.client.vote_on_dispute(&v2, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s2), &30_000);
+    h.client.vote_on_dispute(
+        &v1,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s1),
+        &50_000,
+    );
+    h.client.vote_on_dispute(
+        &v2,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s2),
+        &30_000,
+    );
 
     advance(&h.env, 1_001);
     h.client.reveal_vote(&v1, &dispute_id, &ORIGINAL, &s1);
@@ -459,7 +540,13 @@ fn no_voters_resolves_void_and_refunds_bond() {
 
     let bond = 50_000i128;
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &bond,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &bond,
     );
 
     advance(&h.env, 2_001);
@@ -487,10 +574,21 @@ fn all_unrevealed_routes_pool_to_admin() {
 
     let bond = 50_000i128;
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &bond,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &bond,
     );
     let s1 = salt(&h.env, 1);
-    h.client.vote_on_dispute(&v1, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s1), &40_000);
+    h.client.vote_on_dispute(
+        &v1,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s1),
+        &40_000,
+    );
 
     advance(&h.env, 2_001); // skip straight past the reveal deadline, no reveal happens
 
@@ -521,20 +619,42 @@ fn multiple_concurrent_disputes_do_not_interfere() {
 
     // Dispute A: disputer wins.
     let dispute_a = h.client.dispute_outcome(
-        &disputer_a, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer_a,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     // Dispute B: disputer loses.
     let dispute_b = h.client.dispute_outcome(
-        &disputer_b, &2u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer_b,
+        &2u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     assert_ne!(dispute_a, dispute_b);
 
     let sa = salt(&h.env, 10);
     let sb = salt(&h.env, 20);
     // voter_a votes DISPUTED on dispute A (helps disputer_a win).
-    h.client.vote_on_dispute(&voter_a, &dispute_a, &commit_hash(&h.env, DISPUTED, &sa), &100_000);
+    h.client.vote_on_dispute(
+        &voter_a,
+        &dispute_a,
+        &commit_hash(&h.env, DISPUTED, &sa),
+        &100_000,
+    );
     // voter_b votes ORIGINAL on dispute B (helps disputer_b lose).
-    h.client.vote_on_dispute(&voter_b, &dispute_b, &commit_hash(&h.env, ORIGINAL, &sb), &100_000);
+    h.client.vote_on_dispute(
+        &voter_b,
+        &dispute_b,
+        &commit_hash(&h.env, ORIGINAL, &sb),
+        &100_000,
+    );
 
     advance(&h.env, 1_001);
     h.client.reveal_vote(&voter_a, &dispute_a, &DISPUTED, &sa);
@@ -562,7 +682,13 @@ fn double_resolve_rejected() {
     let disputer = Address::generate(&h.env);
     fund(&h.env, &h.token, &h.admin, &disputer, 1_000_000);
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     advance(&h.env, 2_001);
     h.client.resolve_dispute(&dispute_id);
@@ -578,10 +704,21 @@ fn double_commit_rejected() {
     fund(&h.env, &h.token, &h.admin, &disputer, 1_000_000);
     fund(&h.env, &h.token, &h.admin, &voter, 1_000_000);
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let s = salt(&h.env, 1);
-    h.client.vote_on_dispute(&voter, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s), &10_000);
+    h.client.vote_on_dispute(
+        &voter,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s),
+        &10_000,
+    );
     let result = h.client.try_vote_on_dispute(
         &voter,
         &dispute_id,
@@ -599,10 +736,21 @@ fn double_reveal_rejected() {
     fund(&h.env, &h.token, &h.admin, &disputer, 1_000_000);
     fund(&h.env, &h.token, &h.admin, &voter, 1_000_000);
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let s = salt(&h.env, 1);
-    h.client.vote_on_dispute(&voter, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s), &10_000);
+    h.client.vote_on_dispute(
+        &voter,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s),
+        &10_000,
+    );
     advance(&h.env, 1_001);
     h.client.reveal_vote(&voter, &dispute_id, &ORIGINAL, &s);
     let result = h.client.try_reveal_vote(&voter, &dispute_id, &ORIGINAL, &s);
@@ -617,11 +765,18 @@ fn reveal_vote_rejects_invalid_outcome() {
     fund(&h.env, &h.token, &h.admin, &disputer, 1_000_000);
     fund(&h.env, &h.token, &h.admin, &voter, 1_000_000);
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let s = salt(&h.env, 1);
     // Commit to some third outcome value entirely.
-    h.client.vote_on_dispute(&voter, &dispute_id, &commit_hash(&h.env, 99, &s), &10_000);
+    h.client
+        .vote_on_dispute(&voter, &dispute_id, &commit_hash(&h.env, 99, &s), &10_000);
     advance(&h.env, 1_001);
     let result = h.client.try_reveal_vote(&voter, &dispute_id, &99u32, &s);
     assert_contract_error(result, OracleError::InvalidVoteOutcome);
@@ -639,12 +794,28 @@ fn tie_defaults_to_disputer_losing() {
     fund(&h.env, &h.token, &h.admin, &v2, 1_000_000);
 
     let dispute_id = h.client.dispute_outcome(
-        &disputer, &1u64, &ORIGINAL, &DISPUTED, &1_000_000i128, &h.token, &50_000i128,
+        &disputer,
+        &1u64,
+        &ORIGINAL,
+        &DISPUTED,
+        &1_000_000i128,
+        &h.token,
+        &50_000i128,
     );
     let s1 = salt(&h.env, 1);
     let s2 = salt(&h.env, 2);
-    h.client.vote_on_dispute(&v1, &dispute_id, &commit_hash(&h.env, ORIGINAL, &s1), &50_000);
-    h.client.vote_on_dispute(&v2, &dispute_id, &commit_hash(&h.env, DISPUTED, &s2), &50_000);
+    h.client.vote_on_dispute(
+        &v1,
+        &dispute_id,
+        &commit_hash(&h.env, ORIGINAL, &s1),
+        &50_000,
+    );
+    h.client.vote_on_dispute(
+        &v2,
+        &dispute_id,
+        &commit_hash(&h.env, DISPUTED, &s2),
+        &50_000,
+    );
     advance(&h.env, 1_001);
     h.client.reveal_vote(&v1, &dispute_id, &ORIGINAL, &s1);
     h.client.reveal_vote(&v2, &dispute_id, &DISPUTED, &s2);

--- a/packages/contracts/tournament/src/events.rs
+++ b/packages/contracts/tournament/src/events.rs
@@ -24,12 +24,7 @@ pub fn emit_tournament_created(
     );
 }
 
-pub fn emit_market_entered(
-    env: &Env,
-    tournament_id: u64,
-    creator: &Address,
-    call_id: u64,
-) {
+pub fn emit_market_entered(env: &Env, tournament_id: u64, creator: &Address, call_id: u64) {
     env.events().publish(
         ("tournament", "market_entered"),
         (tournament_id, creator.clone(), call_id),

--- a/packages/contracts/tournament/src/lib.rs
+++ b/packages/contracts/tournament/src/lib.rs
@@ -5,9 +5,7 @@ mod events;
 mod storage;
 mod types;
 
-pub use types::{
-    MarketEntry, ScoringWeights, Tournament, TournamentStanding, TournamentStatus,
-};
+pub use types::{MarketEntry, ScoringWeights, Tournament, TournamentStanding, TournamentStatus};
 
 #[cfg(test)]
 mod test;
@@ -16,9 +14,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env, Map, String, Vec};
 use storage::*;
 
 use errors::TournamentError;
-use events::{
-    emit_market_entered, emit_tournament_created, emit_tournament_finalized,
-};
+use events::{emit_market_entered, emit_tournament_created, emit_tournament_finalized};
 
 const MAX_SCORE: i128 = 10_000;
 const BPS_DENOMINATOR: u32 = 10_000;
@@ -111,12 +107,7 @@ impl TournamentContract {
         tournament_id
     }
 
-    pub fn enter_market(
-        env: Env,
-        tournament_id: u64,
-        creator: Address,
-        call_id: u64,
-    ) {
+    pub fn enter_market(env: Env, tournament_id: u64, creator: Address, call_id: u64) {
         let factory = get_factory(&env)
             .ok_or(TournamentError::NotInitialized)
             .unwrap_or_else(|e| soroban_sdk::panic_with_error!(&env, e));
@@ -190,11 +181,7 @@ impl TournamentContract {
         set_market_entries(&env, tournament_id, &entries);
     }
 
-    pub fn calculate_score(
-        env: Env,
-        tournament_id: u64,
-        participant: Address,
-    ) -> i128 {
+    pub fn calculate_score(env: Env, tournament_id: u64, participant: Address) -> i128 {
         let tournament = get_tournament(&env, tournament_id)
             .ok_or(TournamentError::TournamentNotFound)
             .unwrap_or_else(|e| soroban_sdk::panic_with_error!(&env, e));
@@ -231,7 +218,8 @@ impl TournamentContract {
         };
 
         let accuracy_score = if entry.resolved_total > 0 {
-            let ratio = (entry.resolved_correct as i128) * MAX_SCORE / (entry.resolved_total as i128);
+            let ratio =
+                (entry.resolved_correct as i128) * MAX_SCORE / (entry.resolved_total as i128);
             ratio
         } else {
             0

--- a/packages/contracts/tournament/src/storage.rs
+++ b/packages/contracts/tournament/src/storage.rs
@@ -74,26 +74,15 @@ pub fn get_market_entries(env: &Env, tournament_id: u64) -> Option<Map<Address, 
         .get(&PersistentKey::MarketEntries(tournament_id))
 }
 
-pub fn set_participant_score(
-    env: &Env,
-    tournament_id: u64,
-    participant: &Address,
-    score: i128,
-) {
-    env.storage()
-        .persistent()
-        .set(
-            &PersistentKey::ParticipantScores(tournament_id, participant.clone()),
-            &score,
-        );
+pub fn set_participant_score(env: &Env, tournament_id: u64, participant: &Address, score: i128) {
+    env.storage().persistent().set(
+        &PersistentKey::ParticipantScores(tournament_id, participant.clone()),
+        &score,
+    );
 }
 
 #[allow(dead_code)]
-pub fn get_participant_score(
-    env: &Env,
-    tournament_id: u64,
-    participant: &Address,
-) -> Option<i128> {
+pub fn get_participant_score(env: &Env, tournament_id: u64, participant: &Address) -> Option<i128> {
     env.storage()
         .persistent()
         .get(&PersistentKey::ParticipantScores(
@@ -103,12 +92,10 @@ pub fn get_participant_score(
 }
 
 pub fn set_standings(env: &Env, tournament_id: u64, standings: &Vec<TournamentStanding>) {
-    env.storage()
-        .persistent()
-        .set(
-            &PersistentKey::TournamentStandings(tournament_id),
-            standings,
-        );
+    env.storage().persistent().set(
+        &PersistentKey::TournamentStandings(tournament_id),
+        standings,
+    );
 }
 
 pub fn get_standings(env: &Env, tournament_id: u64) -> Option<Vec<TournamentStanding>> {

--- a/packages/contracts/tournament/src/test.rs
+++ b/packages/contracts/tournament/src/test.rs
@@ -109,10 +109,7 @@ impl TestEnv {
         });
     }
 
-    fn get_tournament(
-        &self,
-        tournament_id: u64,
-    ) -> Option<crate::types::Tournament> {
+    fn get_tournament(&self, tournament_id: u64) -> Option<crate::types::Tournament> {
         self.env.as_contract(&self.contract_id, || {
             TournamentContract::get_tournament(self.env.clone(), tournament_id)
         })
@@ -180,7 +177,14 @@ fn test_create_tournament() {
 fn test_create_tournament_invalid_time() {
     let te = TestEnv::new();
     let now = te.env.ledger().timestamp();
-    te.create_tournament("Bad", now + 1000, now + 500, 1_000_000, &default_weights(), 3);
+    te.create_tournament(
+        "Bad",
+        now + 1000,
+        now + 500,
+        1_000_000,
+        &default_weights(),
+        3,
+    );
 }
 
 #[test]
@@ -194,7 +198,14 @@ fn test_create_tournament_invalid_weights() {
         uniqueness_weight_bps: 1000,
         accuracy_weight_bps: 1000,
     };
-    te.create_tournament("Bad Weights", now + 100, now + 1000, 1_000_000, &bad_weights, 3);
+    te.create_tournament(
+        "Bad Weights",
+        now + 100,
+        now + 1000,
+        1_000_000,
+        &bad_weights,
+        3,
+    );
 }
 
 #[test]
@@ -332,10 +343,24 @@ fn test_get_tournament_count() {
 
     assert_eq!(te.get_tournament_count(), 0);
 
-    te.create_tournament("T1", now + 100, now + 1000, 1_000_000, &default_weights(), 3);
+    te.create_tournament(
+        "T1",
+        now + 100,
+        now + 1000,
+        1_000_000,
+        &default_weights(),
+        3,
+    );
     assert_eq!(te.get_tournament_count(), 1);
 
-    te.create_tournament("T2", now + 200, now + 2000, 2_000_000, &default_weights(), 5);
+    te.create_tournament(
+        "T2",
+        now + 200,
+        now + 2000,
+        2_000_000,
+        &default_weights(),
+        5,
+    );
     assert_eq!(te.get_tournament_count(), 2);
 }
 


### PR DESCRIPTION
## Summary
Closes #474 
Adds multi-asset **basket prediction calls** to Soroban contracts so users can stake on multiple assets in one market (e.g. XLM AND BTC AND ETH), with configurable aggregation logic and incomplete-oracle refunds.

- Extends `ConditionType` with `Basket(BasketCall)` while keeping single-asset calls as a backward-compatible special case
- Introduces `AssetCondition`, `BasketCall`, and `BasketLogic` (`AllOf` / `AnyOf` / `Weighted`)
- Adds oracle basket resolution in `outcome_manager` and marks incomplete baskets unresolvable for full stake refunds

## Changes

### `call_registry`
- `BasketLogic`, `LeafConditionType`, `AssetCondition`, `BasketCall` types
- `create_call` accepts basket conditions; rejects empty baskets (`EmptyBasket`)
- `Call.unresolvable` flag + `mark_unresolvable` (outcome manager only) to void and refund
- `get_basket_conditions(call_id)` view (legacy single-asset → synthetic 1-condition basket)

### `outcome_manager`
- `submit_basket_outcome` / `submit_basket_outcome_for_market`
- Per-condition signed price submissions (ed25519)
- Evaluates `AllOf` / `AnyOf` / `Weighted(threshold_bps)` to resolve UP/DOWN
- After deadline, incomplete submissions → `mark_unresolvable` + refund path

## Tests
- [x] AllOf — all conditions winning → UP
- [x] AllOf — one losing → DOWN
- [x] AnyOf — all winning → UP
- [x] AnyOf — one winning → UP
- [x] Weighted basket resolution
- [x] Incomplete basket after deadline → unresolvable
- [x] Empty basket rejected on create
- [x] `get_basket_conditions` returns configured legs

## Test plan
- [ ] `cargo test -p call-registry --lib basket`
- [ ] `cargo test -p outcome-manager --lib basket`
- [ ] `cargo test -p call-registry -p outcome-manager`
- [ ] Confirm single-asset create/resolve/claim still works (backward compatibility)
- [ ] Confirm empty basket create returns `EmptyBasket`
- [ ] Confirm incomplete basket after `call_end_ts` marks call unresolvable and refunds stakes

<img width="694" height="575" alt="image" src="https://github.com/user-attachments/assets/dff62391-61af-4791-9566-887cadbf138a" />
